### PR TITLE
Improve user feedback on auth screens

### DIFF
--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers.dart';
 import 'registration_page.dart';
+import 'package:dio/dio.dart';
 
 class LoginPage extends ConsumerWidget {
   const LoginPage({super.key});
@@ -23,10 +24,24 @@ class LoginPage extends ConsumerWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () async {
-                await ref
-                    .read(authNotifierProvider.notifier)
-                    .login(emailCtrl.text, passCtrl.text);
-                if (context.mounted) Navigator.of(context).pop();
+                try {
+                  await ref
+                      .read(authNotifierProvider.notifier)
+                      .login(emailCtrl.text, passCtrl.text);
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Logged in')),
+                    );
+                    Navigator.of(context).pop();
+                  }
+                } on DioException catch (e) {
+                  if (context.mounted) {
+                    final msg = e.response?.data.toString() ?? e.message;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Login failed: ' + msg)),
+                    );
+                  }
+                }
               },
               child: const Text('Login'),
             ),

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers.dart';
 import 'registration_page.dart';
 import 'package:dio/dio.dart';
+import '../utils/snackbar.dart';
 
 class LoginPage extends ConsumerWidget {
   const LoginPage({super.key});
@@ -28,15 +29,22 @@ class LoginPage extends ConsumerWidget {
                   await ref
                       .read(authNotifierProvider.notifier)
                       .login(emailCtrl.text, passCtrl.text);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Logged in')),
-                  );
-                  Navigator.of(context).pop();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Logged in')),
+                    );
+                    Navigator.of(context).pop();
+                  }
                 } on DioException catch (e) {
-                  final msg = e.response?.data.toString() ?? e.message;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Login failed: $msg')),
-                  );
+                  if (context.mounted) {
+                    showApiError(context, e, 'Login');
+                  }
+                } catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Login failed: $e')),
+                    );
+                  }
                 }
               },
               child: const Text('Login'),

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -28,19 +28,15 @@ class LoginPage extends ConsumerWidget {
                   await ref
                       .read(authNotifierProvider.notifier)
                       .login(emailCtrl.text, passCtrl.text);
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Logged in')),
-                    );
-                    Navigator.of(context).pop();
-                  }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Logged in')),
+                  );
+                  Navigator.of(context).pop();
                 } on DioException catch (e) {
-                  if (context.mounted) {
-                    final msg = e.response?.data.toString() ?? e.message;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Login failed: ' + msg)),
-                    );
-                  }
+                  final msg = e.response?.data.toString() ?? e.message;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Login failed: $msg')),
+                  );
                 }
               },
               child: const Text('Login'),

--- a/lib/screens/registration_page.dart
+++ b/lib/screens/registration_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers.dart';
 import 'package:dio/dio.dart';
+import '../utils/snackbar.dart';
 
 class RegistrationPage extends ConsumerWidget {
   const RegistrationPage({super.key});
@@ -29,15 +30,22 @@ class RegistrationPage extends ConsumerWidget {
                   await ref
                       .read(authNotifierProvider.notifier)
                       .register(emailCtrl.text, passCtrl.text, pass2Ctrl.text);
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    const SnackBar(content: Text('Registration successful')),
-                  );
-                  Navigator.of(context).pop();
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Registration successful')),
+                    );
+                    Navigator.of(context).pop();
+                  }
                 } on DioException catch (e) {
-                  final msg = e.response?.data.toString() ?? e.message;
-                  ScaffoldMessenger.of(context).showSnackBar(
-                    SnackBar(content: Text('Registration failed: $msg')),
-                  );
+                  if (context.mounted) {
+                    showApiError(context, e, 'Registration');
+                  }
+                } catch (e) {
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Registration failed: $e')),
+                    );
+                  }
                 }
               },
               child: const Text('Create account'),

--- a/lib/screens/registration_page.dart
+++ b/lib/screens/registration_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers.dart';
+import 'package:dio/dio.dart';
 
 class RegistrationPage extends ConsumerWidget {
   const RegistrationPage({super.key});
@@ -24,10 +25,24 @@ class RegistrationPage extends ConsumerWidget {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () async {
-                await ref
-                    .read(authNotifierProvider.notifier)
-                    .register(emailCtrl.text, passCtrl.text, pass2Ctrl.text);
-                if (context.mounted) Navigator.of(context).pop();
+                try {
+                  await ref
+                      .read(authNotifierProvider.notifier)
+                      .register(emailCtrl.text, passCtrl.text, pass2Ctrl.text);
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Registration successful')),
+                    );
+                    Navigator.of(context).pop();
+                  }
+                } on DioException catch (e) {
+                  if (context.mounted) {
+                    final msg = e.response?.data.toString() ?? e.message;
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      SnackBar(content: Text('Registration failed: ' + msg)),
+                    );
+                  }
+                }
               },
               child: const Text('Create account'),
             ),

--- a/lib/screens/registration_page.dart
+++ b/lib/screens/registration_page.dart
@@ -29,19 +29,15 @@ class RegistrationPage extends ConsumerWidget {
                   await ref
                       .read(authNotifierProvider.notifier)
                       .register(emailCtrl.text, passCtrl.text, pass2Ctrl.text);
-                  if (context.mounted) {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Registration successful')),
-                    );
-                    Navigator.of(context).pop();
-                  }
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    const SnackBar(content: Text('Registration successful')),
+                  );
+                  Navigator.of(context).pop();
                 } on DioException catch (e) {
-                  if (context.mounted) {
-                    final msg = e.response?.data.toString() ?? e.message;
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      SnackBar(content: Text('Registration failed: ' + msg)),
-                    );
-                  }
+                  final msg = e.response?.data.toString() ?? e.message;
+                  ScaffoldMessenger.of(context).showSnackBar(
+                    SnackBar(content: Text('Registration failed: $msg')),
+                  );
                 }
               },
               child: const Text('Create account'),

--- a/lib/utils/snackbar.dart
+++ b/lib/utils/snackbar.dart
@@ -1,0 +1,19 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+void showApiError(BuildContext context, DioException e, String action) {
+  final status = e.response?.statusCode;
+  String message;
+  final data = e.response?.data;
+  if (data is Map && data['detail'] != null) {
+    message = data['detail'].toString();
+  } else if (data is String && data.isNotEmpty) {
+    message = data;
+  } else {
+    message = e.message ?? '';
+  }
+  final prefix = action.isNotEmpty ? '$action failed' : 'Error';
+  final text = status != null ? '$prefix (HTTP $status): $message' : '$prefix: $message';
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
+}
+

--- a/lib/widgets/auth_sheet.dart
+++ b/lib/widgets/auth_sheet.dart
@@ -14,13 +14,21 @@ class AuthSheet extends StatelessWidget {
         mainAxisSize: MainAxisSize.min,
         children: [
           ElevatedButton.icon(
-            onPressed: () {},
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Google sign-in not implemented')),
+              );
+            },
             icon: const Icon(Icons.g_mobiledata),
             label: const Text('Continue with Google'),
           ),
           const SizedBox(height: 12),
           ElevatedButton.icon(
-            onPressed: () {},
+            onPressed: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Facebook sign-in not implemented')),
+              );
+            },
             icon: const Icon(Icons.facebook),
             label: const Text('Continue with Facebook'),
             style: ElevatedButton.styleFrom(backgroundColor: Colors.white, foregroundColor: Colors.black),


### PR DESCRIPTION
## Summary
- show error/success SnackBars on login and registration
- notify when social login buttons are tapped

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6873d51275188326a8597a1fc84a5867