### PR TITLE
Fix login refresh token handling

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -189,6 +189,8 @@ SIMPLE_JWT = {
 REST_AUTH = {
     "USE_JWT": True,
     "SESSION_LOGIN": False,
+    # return refresh token in response body instead of HttpOnly cookie
+    "JWT_AUTH_HTTPONLY": False,
 }
 # dj-rest-auth expects REST_USE_JWT to be set globally so that login and
 # registration endpoints return JWTs instead of session cookies.
@@ -199,5 +201,6 @@ SESSION_COOKIE_SECURE = False
 ACCOUNT_AUTHENTICATION_METHOD = "email"
 ACCOUNT_EMAIL_REQUIRED = True
 ACCOUNT_USERNAME_REQUIRED = False
-ACCOUNT_EMAIL_VERIFICATION = "none"  # disable SMTP during tests
+ACCOUNT_EMAIL_VERIFICATION = "optional"  # send verification emails
+ACCOUNT_CONFIRM_EMAIL_ON_GET = True
 EMAIL_BACKEND = "django.core.mail.backends.locmem.EmailBackend"

--- a/backend/PlayNexus/urls.py
+++ b/backend/PlayNexus/urls.py
@@ -22,6 +22,7 @@ from rest_framework_simplejwt.views import (
     TokenRefreshView,
 )
 from dj_rest_auth.registration.views import RegisterView
+from django.http import HttpResponse
 
 urlpatterns = [
     path("healthz", lambda r: JsonResponse({"status": "ok"})),
@@ -47,5 +48,10 @@ urlpatterns = [
     path(
         "api/auth/token/refresh/",
         TokenRefreshView.as_view(),
+    ),
+    path(
+        "password-reset-confirm/<uidb64>/<token>/",
+        lambda r, uidb64, token: HttpResponse(""),
+        name="password_reset_confirm",
     ),
 ]

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -129,3 +129,31 @@ def test_google_login(client, monkeypatch):
     from allauth.socialaccount.models import SocialAccount
 
     assert SocialAccount.objects.filter(user=user, provider="google").exists()
+
+
+def test_registration_sends_email():
+    from django.core import mail
+    client = APIClient()
+    client.post(
+        "/api/auth/registration/",
+        {
+            "email": "verify@example.com",
+            "password1": "StrongPass123",
+            "password2": "StrongPass123",
+        },
+        format="json",
+    )
+    assert len(mail.outbox) == 1
+
+
+def test_password_reset_sends_email():
+    from django.core import mail
+    User.objects.create_user("u1", email="u1@example.com", password="pass12345")
+    client = APIClient()
+    resp = client.post(
+        "/api/auth/password/reset/",
+        {"email": "u1@example.com"},
+        format="json",
+    )
+    assert resp.status_code == 200
+    assert len(mail.outbox) == 1

--- a/lib/screens/login_page.dart
+++ b/lib/screens/login_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers.dart';
 import 'registration_page.dart';
+import 'profile_page.dart';
+import 'reset_password_page.dart';
 import 'package:dio/dio.dart';
 import '../utils/snackbar.dart';
 
@@ -52,7 +54,9 @@ class LoginPage extends ConsumerWidget {
                     ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Logged in')),
                     );
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(builder: (_) => const ProfilePage()),
+                    );
                   }
                 } on DioException catch (e) {
                   if (context.mounted) {
@@ -76,6 +80,15 @@ class LoginPage extends ConsumerWidget {
                 );
               },
               child: const Text('Create an account'),
+            ),
+            TextButton(
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const ResetPasswordPage()),
+                );
+              },
+              child: const Text('Forgot password?'),
             ),
           ],
         ),

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -4,6 +4,8 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/profile.dart';
 import '../services/profile_service.dart';
 import '../services/auth_service.dart';
+import '../services/booking_service.dart';
+import '../models/booking.dart';
 import '../widgets/auth_sheet.dart';
 
 class ProfilePage extends ConsumerWidget {
@@ -31,21 +33,28 @@ class _ProfileBody extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     return Scaffold(
       appBar: AppBar(title: const Text('Profile')),
-      body: FutureBuilder<Profile>(
-        future: profileService.fetch(),
+      body: FutureBuilder<List<Object>>(
+        future: Future.wait([
+          profileService.fetch(),
+          bookingService.fetchMine(),
+        ]),
         builder: (context, snapshot) {
           if (!snapshot.hasData) {
             return const Center(child: CircularProgressIndicator());
           }
-          final p = snapshot.data!;
+          final profile = snapshot.data![0] as Profile;
+          final bookings = snapshot.data![1] as List<Booking>;
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Column(
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
-                Text('Email: ${p.email}'),
-                Text('Company: ${p.companyName}'),
-                Text('Phone: ${p.phone}'),
+                Text('Email: \${profile.email}'),
+                Text('Company: \${profile.companyName}'),
+                Text('Phone: \${profile.phone}'),
+                const SizedBox(height: 20),
+                Text('My bookings:', style: Theme.of(context).textTheme.titleMedium),
+                ...bookings.map((b) => Text(b.slot.title)),
               ],
             ),
           );

--- a/lib/screens/registration_page.dart
+++ b/lib/screens/registration_page.dart
@@ -2,17 +2,57 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
 import '../providers.dart';
+import 'profile_page.dart';
 import 'package:dio/dio.dart';
 import '../utils/snackbar.dart';
 
-class RegistrationPage extends ConsumerWidget {
+class RegistrationPage extends ConsumerStatefulWidget {
   const RegistrationPage({super.key});
 
   @override
+  ConsumerState<RegistrationPage> createState() => _RegistrationPageState();
+}
+
+class _RegistrationPageState extends ConsumerState<RegistrationPage> {
+  final emailCtrl = TextEditingController();
+  final passCtrl = TextEditingController();
+  final pass2Ctrl = TextEditingController();
+  String strength = '';
+
+  @override
+  void initState() {
+    super.initState();
+    passCtrl.addListener(_updateStrength);
+  }
+
+  void _updateStrength() {
+    final p = passCtrl.text;
+    int score = 0;
+    if (p.length >= 8) score++;
+    if (RegExp(r'[A-Z]').hasMatch(p)) score++;
+    if (RegExp(r'[0-9]').hasMatch(p)) score++;
+    if (RegExp(r'[^A-Za-z0-9]').hasMatch(p)) score++;
+    setState(() {
+      if (score >= 4) {
+        strength = 'Strong';
+      } else if (score >= 3) {
+        strength = 'Medium';
+      } else {
+        strength = 'Weak';
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    emailCtrl.dispose();
+    passCtrl.dispose();
+    pass2Ctrl.dispose();
+    super.dispose();
+  }
+
+  @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final emailCtrl = TextEditingController();
-    final passCtrl = TextEditingController();
-    final pass2Ctrl = TextEditingController();
 
     return Scaffold(
       appBar: AppBar(title: const Text('Register')),
@@ -22,6 +62,10 @@ class RegistrationPage extends ConsumerWidget {
           children: [
             TextField(controller: emailCtrl, decoration: const InputDecoration(labelText: 'Email')),
             TextField(controller: passCtrl, decoration: const InputDecoration(labelText: 'Password'), obscureText: true),
+            Align(
+              alignment: Alignment.centerLeft,
+              child: Text('Strength: \$strength'),
+            ),
             TextField(controller: pass2Ctrl, decoration: const InputDecoration(labelText: 'Confirm Password'), obscureText: true),
             const SizedBox(height: 20),
             ElevatedButton(
@@ -32,9 +76,11 @@ class RegistrationPage extends ConsumerWidget {
                       .register(emailCtrl.text, passCtrl.text, pass2Ctrl.text);
                   if (context.mounted) {
                     ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('Registration successful')),
+                      const SnackBar(content: Text('Registration successful. Check your email to verify your account.')),
                     );
-                    Navigator.of(context).pop();
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(builder: (_) => const ProfilePage()),
+                    );
                   }
                 } on DioException catch (e) {
                   if (context.mounted) {

--- a/lib/screens/reset_password_page.dart
+++ b/lib/screens/reset_password_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:dio/dio.dart';
+import '../services/auth_service.dart';
+import '../utils/snackbar.dart';
+
+class ResetPasswordPage extends StatelessWidget {
+  const ResetPasswordPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final emailCtrl = TextEditingController();
+
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reset Password')),
+      body: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          children: [
+            TextField(
+              controller: emailCtrl,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 20),
+            ElevatedButton(
+              onPressed: () async {
+                try {
+                  await authService.requestPasswordReset(emailCtrl.text);
+                  if (context.mounted) {
+                    ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Reset email sent')),
+                    );
+                    Navigator.pop(context);
+                  }
+                } on DioException catch (e) {
+                  if (context.mounted) {
+                    showApiError(context, e, 'Reset password');
+                  }
+                }
+              },
+              child: const Text('Send reset email'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -62,6 +62,10 @@ class AuthService {
     }
   }
 
+  Future<void> requestPasswordReset(String email) async {
+    await apiClient.post('/auth/password/reset/', data: {'email': email});
+  }
+
   Future<void> refresh() async {
     final refresh = await _storage.read(key: 'refresh');
     if (refresh == null) return;

--- a/lib/utils/snackbar.dart
+++ b/lib/utils/snackbar.dart
@@ -5,8 +5,19 @@ void showApiError(BuildContext context, DioException e, String action) {
   final status = e.response?.statusCode;
   String message;
   final data = e.response?.data;
-  if (data is Map && data['detail'] != null) {
-    message = data['detail'].toString();
+  if (data is Map) {
+    if (data['detail'] != null) {
+      message = data['detail'].toString();
+    } else if (data.isNotEmpty) {
+      final first = data.values.first;
+      if (first is List && first.isNotEmpty) {
+        message = first.first.toString();
+      } else {
+        message = first.toString();
+      }
+    } else {
+      message = e.message ?? '';
+    }
   } else if (data is String && data.isNotEmpty) {
     message = data;
   } else {


### PR DESCRIPTION
## Summary
- return refresh token in login response
- navigate to Profile page after login or registration
- improve API error messages in Flutter
- enable email verification and password reset flows
- show password strength during registration
- add personal bookings list to profile page
- add backend tests for password reset and email verification

## Testing
- `pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_68756fb346f0832690d89e95490ceba4