### PR TITLE
Add logout button in profile page

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,5 @@ If testing on the Android emulator, ensure `ALLOWED_HOSTS` in `.env` includes
 `10.0.2.2` so Django accepts requests from the emulator.
 The backend exposes a simple auth API supporting email/password and Google login.
 After signing up or using Google the app stores JWT tokens securely and the
-profile page shows your account email.
+profile page shows your account email. Use the **Logout** button on that page to
+clear the stored token and log in with a different account.

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -6,6 +6,9 @@ class VendorProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     company_name = models.CharField(max_length=100, blank=True)
 
+    class Meta:
+        app_label = "accounts"
+
     def __str__(self) -> str:
         return self.company_name or self.user.username
 
@@ -13,6 +16,9 @@ class VendorProfile(models.Model):
 class CustomerProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     phone = models.CharField(max_length=20, blank=True)
+
+    class Meta:
+        app_label = "accounts"
 
     def __str__(self) -> str:
         return self.user.username

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -4,7 +4,7 @@ from rest_framework.test import APIClient
 import jwt
 from rest_framework_simplejwt.token_blacklist.models import BlacklistedToken
 from django.contrib.auth.models import User
-from backend.accounts.models import VendorProfile, CustomerProfile
+from accounts.models import VendorProfile, CustomerProfile
 
 django.setup()
 pytestmark = pytest.mark.django_db

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -7,6 +7,7 @@ import '../services/auth_service.dart';
 import '../services/booking_service.dart';
 import '../models/booking.dart';
 import '../widgets/auth_sheet.dart';
+import 'home_page.dart';
 
 class ProfilePage extends ConsumerWidget {
   const ProfilePage({super.key});
@@ -55,6 +56,19 @@ class _ProfileBody extends ConsumerWidget {
                 const SizedBox(height: 20),
                 Text('My bookings:', style: Theme.of(context).textTheme.titleMedium),
                 ...bookings.map((b) => Text(b.slot.title)),
+                const Spacer(),
+                ElevatedButton(
+                  onPressed: () async {
+                    await ref.read(authNotifierProvider.notifier).logout();
+                    if (context.mounted) {
+                      Navigator.of(context).pushAndRemoveUntil(
+                        MaterialPageRoute(builder: (_) => const HomePage()),
+                        (route) => false,
+                      );
+                    }
+                  },
+                  child: const Text('Logout'),
+                ),
               ],
             ),
           );


### PR DESCRIPTION
## Summary
- allow sign-out by adding a Logout button on the profile page
- explain logout option in README
- fix Django tests by importing models from correct package

## Testing
- `PYTHONPATH=/workspace/sports_booking_app:/workspace/sports_booking_app/backend DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend -q`

------
https://chatgpt.com/codex/tasks/task_e_68779ac11b148326a31780385787ed07