### PR TITLE
Add provider facility management UI

### DIFF
--- a/lib/providers/facility_provider.dart
+++ b/lib/providers/facility_provider.dart
@@ -17,3 +17,7 @@ final facilitiesProvider = FutureProvider<List<Facility>>((ref) async {
     position.longitude,
   );
 });
+
+final myFacilitiesProvider = FutureProvider<List<Facility>>((ref) async {
+  return facilityService.fetchMine();
+});

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -1,0 +1,198 @@
+import 'package:flutter/material.dart';
+import 'package:dio/dio.dart';
+import '../models/facility.dart';
+import '../models/category.dart';
+import '../services/facility_service.dart';
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class AddFacilityPage extends StatefulWidget {
+  final Facility? facility;
+  const AddFacilityPage({super.key, this.facility});
+
+  @override
+  State<AddFacilityPage> createState() => _AddFacilityPageState();
+}
+
+class _AddFacilityPageState extends State<AddFacilityPage> {
+  final _formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  final latCtrl = TextEditingController();
+  final lngCtrl = TextEditingController();
+  final radiusCtrl = TextEditingController(text: '1000');
+  List<String> selectedCats = [];
+  List<Category> categories = [];
+  bool _submitting = false;
+  late Future<void> _loadFuture;
+
+  @override
+  void initState() {
+    super.initState();
+    final f = widget.facility;
+    if (f != null) {
+      nameCtrl.text = f.name;
+      latCtrl.text = f.lat.toString();
+      lngCtrl.text = f.lng.toString();
+      radiusCtrl.text = f.radius.toStringAsFixed(0);
+      selectedCats = List<String>.from(f.categories);
+    }
+    _loadFuture = _loadData();
+  }
+
+  Future<void> _loadData() async {
+    categories = await sportsService.fetchCategories();
+  }
+
+  @override
+  void dispose() {
+    nameCtrl.dispose();
+    latCtrl.dispose();
+    lngCtrl.dispose();
+    radiusCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final isEditing = widget.facility != null;
+    return Scaffold(
+      appBar: AppBar(title: Text(isEditing ? 'Edit Facility' : 'Create Facility')),
+      body: FutureBuilder(
+        future: _loadFuture,
+        builder: (context, snap) {
+          if (snap.connectionState != ConnectionState.done) {
+            return const Center(child: CircularProgressIndicator());
+          }
+          return Padding(
+            padding: const EdgeInsets.all(16),
+            child: Form(
+              key: _formKey,
+              child: ListView(
+                children: [
+                  TextFormField(
+                    controller: nameCtrl,
+                    decoration: const InputDecoration(labelText: 'Name'),
+                    validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                  ),
+                  TextFormField(
+                    controller: latCtrl,
+                    decoration: const InputDecoration(labelText: 'Latitude'),
+                    keyboardType: TextInputType.number,
+                    validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
+                  ),
+                  TextFormField(
+                    controller: lngCtrl,
+                    decoration: const InputDecoration(labelText: 'Longitude'),
+                    keyboardType: TextInputType.number,
+                    validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
+                  ),
+                  TextFormField(
+                    controller: radiusCtrl,
+                    decoration: const InputDecoration(labelText: 'Radius (m)'),
+                    keyboardType: TextInputType.number,
+                    validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
+                  ),
+                  const SizedBox(height: 12),
+                  Wrap(
+                    spacing: 8,
+                    children: [
+                      for (final c in categories)
+                        FilterChip(
+                          label: Text(c.name),
+                          selected: selectedCats.contains(c.id.toString()),
+                          onSelected: (sel) {
+                            setState(() {
+                              if (sel) {
+                                selectedCats.add(c.id.toString());
+                              } else {
+                                selectedCats.remove(c.id.toString());
+                              }
+                            });
+                          },
+                        ),
+                    ],
+                  ),
+                  const SizedBox(height: 20),
+                  ElevatedButton(
+                    onPressed: _submitting
+                        ? null
+                        : () async {
+                            if (!_formKey.currentState!.validate()) return;
+                            setState(() => _submitting = true);
+                            try {
+                              if (isEditing) {
+                                await facilityService.updateFacility(
+                                  widget.facility!.id,
+                                  nameCtrl.text,
+                                  double.parse(latCtrl.text),
+                                  double.parse(lngCtrl.text),
+                                  double.parse(radiusCtrl.text),
+                                  selectedCats,
+                                );
+                              } else {
+                                await facilityService.createFacility(
+                                  nameCtrl.text,
+                                  double.parse(latCtrl.text),
+                                  double.parse(lngCtrl.text),
+                                  double.parse(radiusCtrl.text),
+                                  selectedCats,
+                                );
+                              }
+                              if (context.mounted) Navigator.pop(context, true);
+                            } on DioException catch (e) {
+                              if (context.mounted) {
+                                showApiError(context, e, 'Save facility');
+                              }
+                            } finally {
+                              if (mounted) setState(() => _submitting = false);
+                            }
+                          },
+                    child: _submitting
+                        ? const SizedBox(height: 20, width: 20, child: CircularProgressIndicator(strokeWidth: 2))
+                        : Text(isEditing ? 'Save' : 'Create'),
+                  ),
+                  if (isEditing)
+                    TextButton(
+                      onPressed: _submitting
+                          ? null
+                          : () async {
+                              final confirmed = await showDialog<bool>(
+                                context: context,
+                                builder: (_) => AlertDialog(
+                                  title: const Text('Delete facility'),
+                                  content: const Text('Are you sure?'),
+                                  actions: [
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(context, false),
+                                      child: const Text('Cancel'),
+                                    ),
+                                    TextButton(
+                                      onPressed: () => Navigator.pop(context, true),
+                                      child: const Text('Delete'),
+                                    ),
+                                  ],
+                                ),
+                              );
+                              if (confirmed == true) {
+                                setState(() => _submitting = true);
+                                try {
+                                  await facilityService.deleteFacility(widget.facility!.id);
+                                  if (context.mounted) Navigator.pop(context, true);
+                                } on DioException catch (e) {
+                                  if (context.mounted) showApiError(context, e, 'Delete facility');
+                                } finally {
+                                  if (mounted) setState(() => _submitting = false);
+                                }
+                              }
+                            },
+                      child: const Text('Delete', style: TextStyle(color: Colors.red)),
+                    ),
+                ],
+              ),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -9,6 +9,7 @@ import '../services/booking_service.dart';
 import '../models/booking.dart';
 import '../widgets/auth_sheet.dart';
 import 'provider_dashboard_page.dart';
+import 'provider_facilities_page.dart';
 import 'home_page.dart';
 
 class ProfilePage extends ConsumerWidget {
@@ -66,6 +67,17 @@ class _ProfileBody extends ConsumerWidget {
                       );
                     },
                     child: const Text('Provider Dashboard'),
+                  ),
+                  const SizedBox(height: 12),
+                  ElevatedButton(
+                    onPressed: () {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                            builder: (_) => const ProviderFacilitiesPage()),
+                      );
+                    },
+                    child: const Text('My Facilities'),
                   ),
                 ],
                 const SizedBox(height: 20),

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/activity_provider.dart';
 import 'add_activity_page.dart';
+import 'provider_facilities_page.dart';
 
 class ProviderDashboardPage extends ConsumerWidget {
   const ProviderDashboardPage({super.key});
@@ -10,7 +11,21 @@ class ProviderDashboardPage extends ConsumerWidget {
   Widget build(BuildContext context, WidgetRef ref) {
     final asyncActivities = ref.watch(activitiesProvider);
     return Scaffold(
-      appBar: AppBar(title: const Text('Provider Dashboard')),
+      appBar: AppBar(
+        title: const Text('Provider Dashboard'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.store),
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                    builder: (_) => const ProviderFacilitiesPage()),
+              );
+            },
+          ),
+        ],
+      ),
       body: asyncActivities.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('Error: $e')),

--- a/lib/screens/provider_facilities_page.dart
+++ b/lib/screens/provider_facilities_page.dart
@@ -1,0 +1,44 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/facility_provider.dart';
+import 'add_facility_page.dart';
+
+class ProviderFacilitiesPage extends ConsumerWidget {
+  const ProviderFacilitiesPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncFacilities = ref.watch(myFacilitiesProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('My Facilities')),
+      body: asyncFacilities.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Error: $e')),
+        data: (list) => ListView.builder(
+          itemCount: list.length,
+          itemBuilder: (_, i) => ListTile(
+            title: Text(list[i].name),
+            subtitle: Text('${list[i].lat.toStringAsFixed(2)}, ${list[i].lng.toStringAsFixed(2)}'),
+            onTap: () async {
+              final updated = await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (_) => AddFacilityPage(facility: list[i])),
+              );
+              if (updated == true) ref.invalidate(myFacilitiesProvider);
+            },
+          ),
+        ),
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final created = await Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const AddFacilityPage()),
+          );
+          if (created == true) ref.invalidate(myFacilitiesProvider);
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -38,6 +38,25 @@ class FacilityService {
       'categories': categories,
     });
   }
+
+  Future<List<Facility>> fetchMine() async {
+    return fetchFacilities([], 0, 0, 0, mine: true);
+  }
+
+  Future<void> updateFacility(int id, String name, double lat, double lng,
+      double radius, List<String> categories) async {
+    await apiClient.patch('/facilities/$id/', data: {
+      'name': name,
+      'lat': lat,
+      'lng': lng,
+      'radius': radius,
+      'categories': categories,
+    });
+  }
+
+  Future<void> deleteFacility(int id) async {
+    await apiClient.delete('/facilities/$id/');
+  }
 }
 
 final facilityService = FacilityService();


### PR DESCRIPTION
## Summary
- add helper methods to facility service
- provide myFacilitiesProvider for listing vendor-owned facilities
- add pages to create/update facilities
- open facilities from dashboard and profile

## Testing
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_687cc8fa1764832696d0512a8965d572