### PR TITLE
Add image upload and nearby flag

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -20,7 +20,7 @@ lint:
   image: python:3.11
   before_script:
     - python -m pip install --upgrade pip
-    - pip install flake8
+    - pip install flake8 Pillow
   script: flake8 backend
   tags: []          # 如果学校要求 runner tag，就写在这里
   except:
@@ -41,7 +41,7 @@ test:
         POSTGRES_PASSWORD: $DB_PASS
   before_script:
     - python -m pip install --upgrade pip
-    - pip install -r requirements.txt
+    - pip install -r requirements.txt Pillow
     - python backend/manage.py migrate --noinput
     - python backend/manage.py seed_facilities
   script: pytest

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ provider profile which can be updated via `/api/provider/profile/`.
 - JWT authentication with email or Google
 - Flutter client using Riverpod state management
 
+## Image Upload Setup
+
+Install Pillow and mount the `media/` directory when running the app:
+
+```bash
+pip install Pillow
+docker compose up -d
+```
+Uploaded files will appear under `media/` and are served at `/media/` in development.
+
 ## Running tests
 
 Install system requirements such as `gdal` and `spatialite` then run:

--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -162,7 +162,7 @@ USE_TZ = True
 STATIC_URL = "static/"
 STATIC_ROOT = BASE_DIR / "staticfiles"
 STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
-MEDIA_URL = "media/"
+MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"

--- a/backend/sports/admin.py
+++ b/backend/sports/admin.py
@@ -28,8 +28,15 @@ class SlotAdmin(admin.ModelAdmin):
 
 @admin.register(Category)
 class CategoryAdmin(admin.ModelAdmin):
-    list_display = ("name", "icon")
+    list_display = ("name", "image_preview")
     search_fields = ("name",)
+    readonly_fields = ("image_preview",)
+
+    def image_preview(self, obj):
+        if obj.image:
+            from django.utils.html import format_html
+            return format_html('<img src="{}" style="height:50px"/>', obj.image.url)
+        return "-"
 
 
 @admin.register(SportCategory)
@@ -60,9 +67,16 @@ class VariantAdmin(admin.ModelAdmin):
 
 @admin.register(Activity)
 class ActivityAdmin(admin.ModelAdmin):
-    list_display = ("title", "sport", "discipline", "variant")
-    list_filter = ("sport", "discipline")
+    list_display = ("title", "sport", "is_nearby")
+    list_filter = ("sport", "is_nearby")
     search_fields = ("title",)
+    readonly_fields = ("image_preview",)
+
+    def image_preview(self, obj):
+        if obj.image:
+            from django.utils.html import format_html
+            return format_html('<img src="{}" style="height:60px"/>', obj.image.url)
+        return "-"
 
 
 @admin.register(FeaturedCategory)

--- a/backend/sports/migrations/0009_image_fields_and_is_nearby.py
+++ b/backend/sports/migrations/0009_image_fields_and_is_nearby.py
@@ -1,0 +1,46 @@
+from django.db import migrations, models
+
+
+def copy_image_fields(apps, schema_editor):
+    Category = apps.get_model('sports', 'Category')
+    Activity = apps.get_model('sports', 'Activity')
+    for c in Category.objects.all():
+        val = getattr(c, 'image')
+        if isinstance(val, str) and val.startswith(('http', 'https')):
+            c.image = val
+            c.save(update_fields=['image'])
+    for a in Activity.objects.all():
+        val = getattr(a, 'image')
+        if isinstance(val, str) and val.startswith(('http', 'https')):
+            a.image = val
+            a.save(update_fields=['image'])
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('sports', '0008_featured'),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name='category',
+            old_name='icon',
+            new_name='image',
+        ),
+        migrations.AlterField(
+            model_name='category',
+            name='image',
+            field=models.ImageField(blank=True, upload_to='category/'),
+        ),
+        migrations.AlterField(
+            model_name='activity',
+            name='image',
+            field=models.ImageField(blank=True, upload_to='activity/'),
+        ),
+        migrations.AddField(
+            model_name='activity',
+            name='is_nearby',
+            field=models.BooleanField(default=False),
+        ),
+        migrations.RunPython(copy_image_fields, migrations.RunPython.noop),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -57,7 +57,11 @@ class SportCategory(models.Model):
 # ───────────────────────────────── Category ───────────────────────────────
 class Category(models.Model):
     name = models.CharField(max_length=30, unique=True)
-    icon = models.ImageField(upload_to="category_icons/", blank=True)
+    image = models.ImageField(upload_to="category/", blank=True)
+
+    @property
+    def icon(self) -> str:
+        return self.image.name if self.image else ""
 
     class Meta:
         ordering = ("name",)
@@ -112,7 +116,8 @@ class Activity(models.Model):
         default=0,
         validators=[MinValueValidator(0)],
     )
-    image = models.URLField(blank=True)
+    image = models.ImageField(upload_to="activity/", blank=True)
+    is_nearby = models.BooleanField(default=False)
     owner = models.ForeignKey(
         "auth.User",
         on_delete=models.CASCADE,

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -36,9 +36,19 @@ class SlotSerializer(serializers.ModelSerializer):
 
 
 class CategorySerializer(serializers.ModelSerializer):
+    image_url = serializers.SerializerMethodField()
+
     class Meta:
         model = Category
-        fields = ("id", "name", "icon")
+        fields = ("id", "name", "icon", "image_url")
+        read_only_fields = ("icon",)
+
+    def get_image_url(self, obj):
+        if obj.image:
+            request = self.context.get("request")
+            url = obj.image.url
+            return request.build_absolute_uri(url) if request else url
+        return ""
 
 
 class SportCategorySerializer(serializers.ModelSerializer):
@@ -56,6 +66,8 @@ class VariantSerializer(serializers.ModelSerializer):
 
 
 class ActivitySerializer(serializers.ModelSerializer):
+    image_url = serializers.SerializerMethodField()
+
     class Meta:
         model = Activity
         fields = (
@@ -64,14 +76,23 @@ class ActivitySerializer(serializers.ModelSerializer):
             "discipline",
             "variant",
             "image",
+            "image_url",
             "owner",
             "title",
             "description",
             "difficulty",
             "duration",
             "base_price",
+            "is_nearby",
         )
-        read_only_fields = ("id", "owner")
+        read_only_fields = ("id", "owner", "image")
+
+    def get_image_url(self, obj):
+        if obj.image:
+            request = self.context.get("request")
+            url = obj.image.url
+            return request.build_absolute_uri(url) if request else url
+        return ""
 
     def validate_base_price(self, value):
         if value < 0:

--- a/backend/tests/test_image_upload.py
+++ b/backend/tests/test_image_upload.py
@@ -1,0 +1,25 @@
+import io
+from PIL import Image
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from sports.models import Category, Activity, Sport, Slot
+
+pytestmark = pytest.mark.django_db
+
+def dummy_image(name='test.png'):
+    buf = io.BytesIO()
+    Image.new('RGB', (10, 10), 'red').save(buf, format='PNG')
+    buf.seek(0)
+    return SimpleUploadedFile(name, buf.read(), content_type='image/png')
+
+def test_category_upload():
+    c = Category.objects.create(name='Yoga')
+    c.image.save('up.png', dummy_image(), save=True)
+    assert c.image.name.startswith('category/')
+
+def test_is_nearby_filter():
+    sport = Sport.objects.create(name='Run')
+    cat = Category.objects.create(name='Road')
+    act1 = Activity.objects.create(sport=sport, discipline=cat, title='A', is_nearby=True)
+    Activity.objects.create(sport=sport, discipline=cat, title='B', is_nearby=False)
+    assert Activity.objects.filter(is_nearby=True).count() == 1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,8 +13,7 @@ networks:
 
 volumes:
   dbdata:          # PostgreSQL 持久化
-  # 如果以后想把用户上传图片持久化，可加：
-  # media:
+  media:
   # static:
 
 ###############################################################################
@@ -70,7 +69,7 @@ services:
       API_BASE_URL: http://0.0.0.0:8000/api
     volumes:
       - .:/app                # 代码热更新；生产可改成只挂 static/media
-      # - media:/app/media
+      - ./media:/app/media
       # - static:/app/static
     ports: ["8000:8000"]
     networks: [app-net]

--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -5,6 +5,7 @@ class Activity {
     required this.discipline,
     required this.variant,
     required this.image,
+    this.imageUrl,
     required this.title,
     required this.description,
     required this.difficulty,
@@ -17,6 +18,7 @@ class Activity {
   final int discipline;
   final int? variant;
   final String image;
+  final String? imageUrl;
   final String title;
   final String description;
   final int difficulty;
@@ -29,6 +31,7 @@ class Activity {
         discipline: j['discipline'] as int,
         variant: j['variant'] as int?,
         image: j['image'] as String? ?? '',
+        imageUrl: j['image_url'] as String?,
         title: j['title'] as String,
         description: j['description'] as String? ?? '',
         difficulty: j['difficulty'] as int? ?? 1,

--- a/lib/models/category.dart
+++ b/lib/models/category.dart
@@ -1,13 +1,20 @@
 class Category {
-  Category({required this.id, required this.name, required this.icon});
+  Category({
+    required this.id,
+    required this.name,
+    required this.icon,
+    this.imageUrl,
+  });
 
   final int id;
   final String name;
   final String icon;
+  final String? imageUrl;
 
   factory Category.fromJson(Map<String, dynamic> j) => Category(
         id: j['id'] as int,
         name: j['name'] as String,
         icon: j['icon'] as String? ?? '',
+        imageUrl: j['image_url'] as String?,
       );
 }

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -43,9 +43,11 @@ class ProviderDashboardPage extends ConsumerWidget {
         data: (list) => ListView.builder(
           itemCount: list.length,
           itemBuilder: (_, i) => ListTile(
-            leading: list[i].image.isNotEmpty
-                ? Image.network(list[i].image, width: 50, fit: BoxFit.cover)
-                : null,
+            leading: (list[i].imageUrl != null && list[i].imageUrl!.isNotEmpty)
+                ? Image.network(list[i].imageUrl!, width: 50, fit: BoxFit.cover)
+                : list[i].image.isNotEmpty
+                    ? Image.network(list[i].image, width: 50, fit: BoxFit.cover)
+                    : null,
             title: Text(list[i].title),
             onTap: () async {
               final updated = await Navigator.push(


### PR DESCRIPTION
## Summary
- support uploaded images for categories and activities
- serve media files in dev and mount media volume
- show thumbnails and filtering in Django admin
- expose `image_url` in API serializers
- add Flutter model fields and display logic
- document image upload setup

## Testing
- `flake8 backend`
- `pytest backend/tests/test_image_upload.py -q` *(fails: SpatiaLite requires SQLite to allow extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_687d26eca2808326a58e6dd99c953540