### PR TITLE
Dynamic hero content on home page

### DIFF
--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -14,6 +14,7 @@ import 'categories_page.dart';
 import '../providers.dart';                                   // ← new (sportsProvider)
 import '../providers/category_provider.dart';
 import '../providers/activity_provider.dart';
+import '../providers/home_provider.dart';
 import 'add_activity_page.dart';
 import 'login_page.dart';                                     // for login navigation
 import 'profile_page.dart';
@@ -40,6 +41,8 @@ class _HomePageState extends ConsumerState<HomePage> {
     // ========== 监听 Provider ==========
     final categoriesAsync = ref.watch(categoriesProvider);
     final nearbyActsAsync = ref.watch(nearbyActivitiesProvider);
+    final featuredCatsAsync = ref.watch(featuredCategoriesProvider);
+    final featuredActsAsync = ref.watch(featuredActivitiesProvider);
 
     final Widget body = _navIndex == 2
         ? const BookingsPage()
@@ -61,8 +64,38 @@ class _HomePageState extends ConsumerState<HomePage> {
                     PageView(
                       physics: const BouncingScrollPhysics(),
                       children: [
-                        Image.asset('assets/images/stadium.jpg', fit: BoxFit.cover),
-                        Image.asset('assets/images/mountain.jpg', fit: BoxFit.cover),
+                        if (featuredCatsAsync.hasValue)
+                          ...featuredCatsAsync.value!.map(
+                            (f) => GestureDetector(
+                              onTap: () => Navigator.push(
+                                context,
+                                MaterialPageRoute(
+                                  builder: (_) => const CategoriesPage(),
+                                ),
+                              ),
+                              child: Image.network(f.image, fit: BoxFit.cover),
+                            ),
+                          ),
+                        if (featuredActsAsync.hasValue)
+                          ...featuredActsAsync.value!.map(
+                            (f) => GestureDetector(
+                              onTap: () async {
+                                final act = await activityService.fetchById(f.activity);
+                                if (!context.mounted) return;
+                                Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => ActivityDetailPage(activity: act),
+                                  ),
+                                );
+                              },
+                              child: Image.network(f.image, fit: BoxFit.cover),
+                            ),
+                          ),
+                        if (!featuredCatsAsync.hasValue && !featuredActsAsync.hasValue) ...[
+                          Image.asset('assets/images/stadium.jpg', fit: BoxFit.cover),
+                          Image.asset('assets/images/mountain.jpg', fit: BoxFit.cover),
+                        ],
                       ],
                     ),
                     const DecoratedBox(

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -19,6 +19,11 @@ class ActivityService {
         .toList();
   }
 
+  Future<Activity> fetchById(int id) async {
+    final Response res = await apiClient.get('/activities/$id/');
+    return Activity.fromJson(res.data as Map<String, dynamic>);
+  }
+
   Future<void> createActivity(
     int sport,
     int discipline,

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -13,7 +13,7 @@ import 'package:sports_booking_app/main.dart';
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {
     // Build our app and trigger a frame.
-    await tester.pumpWidget(const MyApp());
+    await tester.pumpWidget(const SportsBookingApp());
 
     // Verify that our counter starts at 0.
     expect(find.text('0'), findsOneWidget);


### PR DESCRIPTION
## Summary
- fetch featured categories and activities on the home page
- display provider data as hero carousel cards
- load activity details when tapping a featured activity
- fix widget test to use `SportsBookingApp`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e57093c9c83268f5265f84b1a64b8