### PR TITLE
Add local test setup script and update CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -41,10 +41,11 @@ test:
         POSTGRES_PASSWORD: $DB_PASS
   before_script:
     - python -m pip install --upgrade pip
-    - pip install -r requirements.txt Pillow
+    - python -m pip install -r requirements.txt
     - python backend/manage.py migrate --noinput
     - python backend/manage.py seed_facilities
-  script: pytest
+  script:
+    - pytest
   tags: []          # 如需要 runner tag
   artifacts:
     when: always

--- a/README.md
+++ b/README.md
@@ -122,12 +122,22 @@ Uploaded files will appear under `media/` and are served at `/media/` in develop
 
 ## Running tests
 
-Install system requirements such as `gdal` and `spatialite` then run:
+To run the backend tests locally install a few system packages first (package
+names may vary by distribution):
+
+- `gdal` / `libgdal-dev`
+- `spatialite` / `libspatialite-dev`
+
+After installing the system dependencies, create a Python virtual environment
+and install the project requirements:
 
 ```bash
-pip install -r requirements.txt
+python -m venv .venv
+source .venv/bin/activate
+python -m pip install -r requirements.txt
 DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend -q
 ```
 
-Some tests require SpatiaLite which may not work on every platform. Docker is the
-recommended environment for running the full test suite.
+A helper script `scripts/run_backend_tests.sh` automates the above commands.
+Some tests require SpatiaLite which may not work on every platform. Docker is
+the recommended environment for running the full test suite.

--- a/scripts/run_backend_tests.sh
+++ b/scripts/run_backend_tests.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Create and activate Python virtual environment
+python -m venv .venv
+source .venv/bin/activate
+
+# Install dependencies
+python -m pip install -r requirements.txt
+
+# Run the Django test suite
+DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend "$@"


### PR DESCRIPTION
## Summary
- script for setting up a virtualenv and running backend tests
- document system packages and the new script in README
- adjust GitLab CI to use `python -m pip install -r requirements.txt` and run `pytest`

## Testing
- `bash scripts/run_backend_tests.sh --maxfail=1 -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_687e570247b48326a8fadd6dc928c28e