### PR TITLE
Add configurable CORS origins

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ DB_PORT=5432
 ALLOWED_HOSTS=localhost,127.0.0.1,10.0.2.2
 STRIPE_API_KEY=sk_test_xxx
 API_BASE_URL=http://10.0.2.2:8000/api
+CORS_ALLOWED_ORIGINS=http://localhost:5173

--- a/README.md
+++ b/README.md
@@ -41,6 +41,22 @@ backend is. When testing on the Android emulator the correct value is
 `initApiClient` automatically appends a trailing slash so either form
 (`http://10.0.2.2:8000/api` or `http://10.0.2.2:8000/api/`) works.
 
+Set `CORS_ALLOWED_ORIGINS` if the API will be accessed from a different
+origin, for example when running the Flutter web client:
+
+```bash
+CORS_ALLOWED_ORIGINS=http://localhost:5173
+```
+
+Create a `docker-compose.override.yml` to pass the value to the container:
+
+```yaml
+services:
+  web:
+    environment:
+      CORS_ALLOWED_ORIGINS: http://localhost:5173
+```
+
 If running the backend without Docker, install dependencies with
 `pip install -r requirements.txt` and apply migrations using `python manage.py migrate`.
 GeoDjango requires the GDAL library. On most systems it is easiest to use the

--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -168,9 +168,13 @@ MEDIA_ROOT = BASE_DIR / "media"
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # ──────────────────────────────
-# CORS (allow everything in dev)
+# CORS
 # ──────────────────────────────
-CORS_ALLOW_ALL_ORIGINS = True      # ⚠ tighten in production
+cors_env = os.getenv("CORS_ALLOWED_ORIGINS")
+if cors_env:
+    CORS_ALLOWED_ORIGINS = [origin.strip() for origin in cors_env.split(",") if origin.strip()]
+else:
+    CORS_ALLOWED_ORIGINS = []
 
 # ──────────────────────────────
 # Django REST framework + JWT

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,5 @@
+version: "3.9"
+services:
+  web:
+    environment:
+      CORS_ALLOWED_ORIGINS: http://localhost:5173


### PR DESCRIPTION
## Summary
- allow setting allowed origins through `CORS_ALLOWED_ORIGINS`
- load the variable in Django settings
- document CORS setup
- provide compose override example

## Testing
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest -q` *(fails: SpatiaLite requires SQLite to allow extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_687e570f76dc8326b468c19ed5867c3c