### PR TITLE
Fix booking flow for authenticated users

### DIFF
--- a/lib/models/booking.dart
+++ b/lib/models/booking.dart
@@ -8,19 +8,19 @@ class Booking {
   Booking({
     required this.id,
     required this.slot,
-    required this.created,
-    required this.status,
+    required this.bookedAt,
+    required this.pax,
   });
 
-  final int        id;
-  final Slot       slot;
-  final DateTime   created;
-  final String     status;   // P / C / X
+  final int      id;
+  final Slot     slot;
+  final DateTime bookedAt;
+  final int      pax;
 
   factory Booking.fromJson(Map<String, dynamic> j) => Booking(
-    id:      j['id']     as int,
-    slot:    Slot.fromJson(j['slot'] as Map<String, dynamic>),
-    created: DateTime.parse(j['created'] as String),
-    status:  j['status'] as String,
-  );
+        id: j['id'] as int,
+        slot: Slot.fromJson(j['slot'] as Map<String, dynamic>),
+        bookedAt: DateTime.parse(j['booked_at'] as String),
+        pax: j['pax'] as int? ?? 1,
+      );
 }

--- a/lib/screens/activity_detail_page.dart
+++ b/lib/screens/activity_detail_page.dart
@@ -83,6 +83,11 @@ class _ActivityDetailPageState extends ConsumerState<ActivityDetailPage> {
             const SizedBox(height: 20),
             ElevatedButton(
               onPressed: () {
+                final status = ref.read(authNotifierProvider);
+                if (status != AuthStatus.authenticated) {
+                  showAuthSheet(context);
+                  return;
+                }
                 Navigator.push(
                   context,
                   MaterialPageRoute(

--- a/lib/screens/bookings_page.dart
+++ b/lib/screens/bookings_page.dart
@@ -27,7 +27,11 @@ class BookingsPage extends ConsumerWidget {
               return ListTile(
                 title: Text(b.slot.title),
                 subtitle: Text(
-                  '${b.slot.beginsAt.toLocal()}'.split(' ')[0],
+                  '${b.slot.beginsAt.toLocal()} • pax ${b.pax}',
+                ),
+                trailing: Text(
+                  '${b.bookedAt.toLocal()}'.split(' ')[0],
+                  style: const TextStyle(fontSize: 12),
                 ),
               );
             },

--- a/lib/screens/payment_page.dart
+++ b/lib/screens/payment_page.dart
@@ -1,18 +1,20 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/slot.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 import '../services/payment_service.dart';
+import '../providers.dart';
 import 'booking_confirmation_page.dart';
 
-class PaymentPage extends StatefulWidget {
+class PaymentPage extends ConsumerStatefulWidget {
   const PaymentPage({super.key, required this.slot});
   final Slot slot;
 
   @override
-  State<PaymentPage> createState() => _PaymentPageState();
+  ConsumerState<PaymentPage> createState() => _PaymentPageState();
 }
 
-class _PaymentPageState extends State<PaymentPage> {
+class _PaymentPageState extends ConsumerState<PaymentPage> {
   bool loading = false;
 
   @override
@@ -55,6 +57,7 @@ class _PaymentPageState extends State<PaymentPage> {
       await Stripe.instance.presentPaymentSheet();
 
       final booking = await paymentService.confirmSession(intentId);
+      ref.invalidate(bookingsProvider);
       if (!mounted) return;
       Navigator.pushReplacement(
         context,

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -13,10 +13,10 @@ class BookingService {
         .toList(growable: false);
   }
 
-  Future<Booking> create(int slotId) async {
+  Future<Booking> create(int slotId, {int pax = 1}) async {
     final res = await apiClient.post(
       '/bookings/',
-      data: {'slot': slotId},
+      data: {'slot_id': slotId, 'pax': pax},
       options: Options(contentType: Headers.formUrlEncodedContentType),
     );
     return Booking.fromJson(res.data as Map<String, dynamic>);


### PR DESCRIPTION
## Summary
- ensure login is required before booking
- refresh bookings after payment
- align booking API with backend fields
- show booking details in bookings page

## Testing
- `./scripts/run_backend_tests.sh` *(fails: SpatiaLite requires SQLite extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_687f5ef6503083269fe5d8452dc82c26