### PR TITLE
Fix slot creation missing sport

### DIFF
--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -53,6 +53,14 @@ class SlotCreateSerializer(serializers.ModelSerializer):
     def get_seats_left(self, obj):
         return obj.seats_left
 
+    def create(self, validated_data):
+        """Populate sport from the related activity when creating a Slot."""
+        activity = validated_data["activity"]
+        return Slot.objects.create(
+            **validated_data,
+            sport=activity.sport,
+        )
+
 
 class CategorySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()


### PR DESCRIPTION
## Summary
- ensure SlotCreateSerializer populates `sport` from the related Activity

## Testing
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend -q` *(fails: SpatiaLite requires SQLite extension support)*

------
https://chatgpt.com/codex/tasks/task_e_687fbd73abd88326b4df1eec2086c313