### PR TITLE
Fix slot sync and add payment flow

### DIFF
--- a/backend/payments/views.py
+++ b/backend/payments/views.py
@@ -45,6 +45,12 @@ class StripeCheckoutView(APIView):
         except Slot.DoesNotExist:
             return Response({'detail': 'invalid slot'}, status=400)
 
-        booking, _ = Booking.objects.get_or_create(slot=slot, user=request.user)
+        booking, _ = Booking.objects.get_or_create(
+            slot=slot, user=request.user, defaults={"activity": slot.activity}
+        )
+        booking.paid = True
+        booking.status = "confirmed"
+        booking.activity = slot.activity
+        booking.save(update_fields=["paid", "status", "activity"])
         ser = BookingSerializer(booking)
         return Response(ser.data, status=status.HTTP_201_CREATED)

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -174,13 +174,16 @@ class SlotViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.AllowAny]
 
     def get_queryset(self):
-        qs = Slot.objects.select_related("facility", "sport")
+        qs = Slot.objects.select_related("facility", "sport", "activity")
         facility_id = self.request.query_params.get("facility_id")
         if facility_id:
             qs = qs.filter(facility_id=facility_id)
         sport_id = self.request.query_params.get("sport")
         if sport_id:
             qs = qs.filter(sport_id=sport_id)
+        activity_id = self.request.query_params.get("activity")
+        if activity_id:
+            qs = qs.filter(activity_id=activity_id)
         date_str = self.request.query_params.get("date")
         if date_str:
             try:

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -23,14 +23,14 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
 });
 
 class SlotsByDateParams {
-  const SlotsByDateParams({required this.sportId, required this.date});
-  final int sportId;
+  const SlotsByDateParams({required this.activityId, required this.date});
+  final int activityId;
   final String date;
 }
 
 final slotsByDateProvider =
     FutureProvider.family<List<Slot>, SlotsByDateParams>((ref, params) {
-  return slotService.fetchBySportDate(params.sportId, params.date);
+  return slotService.fetchByActivityDate(params.activityId, params.date);
 });
 
 

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -56,7 +56,7 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
         '${selectedDate!.month.toString().padLeft(2, '0')}-'
         '${selectedDate!.day.toString().padLeft(2, '0')}';
     final asyncSlots =
-        ref.watch(slotsByDateProvider(SlotsByDateParams(sportId: widget.activity.sport, date: dateStr)));
+        ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
     return asyncSlots.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, __) => Center(child: Text('Error: $e')),

--- a/lib/screens/payment_page.dart
+++ b/lib/screens/payment_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/slot.dart';
 import '../services/booking_service.dart';
+import '../services/payment_service.dart';
 import '../providers.dart';
 import 'booking_confirmation_page.dart';
 
@@ -42,7 +43,8 @@ class _PaymentPageState extends ConsumerState<PaymentPage> {
   Future<void> _pay() async {
     setState(() => loading = true);
     try {
-      final booking = await bookingService.create(widget.slot.id);
+      final intent = await paymentService.createIntent(widget.slot.id);
+      final booking = await paymentService.confirmIntent(intent['intent_id'] as String);
       ref.invalidate(bookingsProvider);
       if (!mounted) return;
       Navigator.pushReplacement(

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import '../models/booking.dart';
+import 'api_client.dart';
+
+class PaymentService {
+  Future<Map<String, dynamic>> createIntent(int slotId) async {
+    final res = await apiClient.post('/payments/checkout/', data: {'slot': slotId});
+    return res.data as Map<String, dynamic>;
+  }
+
+  Future<Booking> confirmIntent(String intentId) async {
+    final res = await apiClient.get('/payments/checkout/', queryParameters: {'intent_id': intentId});
+    return Booking.fromJson(res.data as Map<String, dynamic>);
+  }
+}
+
+final paymentService = PaymentService();

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -38,6 +38,21 @@ class SlotService {
         .toList(growable: false);
   }
 
+  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+    final Response res = await apiClient.get(
+      '/slots/',
+      queryParameters: {'activity': activityId, 'date': date},
+    );
+
+    final dynamic payload = res.data;
+    final List data = payload is Map ? payload['results'] as List : payload as List;
+
+    return data
+        .cast<dynamic>()
+        .map((e) => Slot.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   Future<void> createSlot(
       int activityId,
       DateTime start,


### PR DESCRIPTION
## Summary
- filter slots by `activity` in API
- mark bookings paid when confirming Stripe payment
- provide Flutter service for Stripe payments and fetch slots per activity
- update providers and pages to use new filtering
- test slot filtering by activity

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest tests/test_api.py::test_slots_filter_by_activity -q` *(fails: SpatiaLite requires SQLite to allow extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_687fc28b54b08326923ea6b3c2f9fbcf