### PR TITLE
Ensure slots linked to activities and Stripe webhook confirms bookings

### DIFF
--- a/backend/payments/urls.py
+++ b/backend/payments/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
-from .views import StripeCheckoutView
+from .views import StripeCheckoutView, StripeWebhookView
 
 urlpatterns = [
     path('payments/checkout/', StripeCheckoutView.as_view()),
+    path('payments/webhook/', StripeWebhookView.as_view()),
 ]

--- a/backend/sports/admin.py
+++ b/backend/sports/admin.py
@@ -10,6 +10,7 @@ from .models import (
     SportCategory,
     FeaturedCategory,
     FeaturedActivity,
+    UserActivityHistory,
 )
 
 
@@ -22,15 +23,15 @@ class SportAdmin(admin.ModelAdmin):
 @admin.register(Slot)
 class SlotAdmin(admin.ModelAdmin):
     list_display = (
-        "title",
-        "facility",
+        "activity",
         "begins_at",
         "capacity",
         "current_participants",
         "price",
     )
-    list_filter = ("facility", "begins_at")
-    search_fields = ("title", "location")
+    list_filter = ("activity", "begins_at")
+    search_fields = ("activity__title", "location")
+    autocomplete_fields = ("activity",)
 
 
 @admin.register(Category)
@@ -96,3 +97,9 @@ class FeaturedCategoryAdmin(admin.ModelAdmin):
 class FeaturedActivityAdmin(admin.ModelAdmin):
     list_display = ("activity", "order")
     list_editable = ("order",)
+
+
+@admin.register(UserActivityHistory)
+class UserActivityHistoryAdmin(admin.ModelAdmin):
+    list_display = ("user", "activity", "action", "timestamp")
+    list_filter = ("action",)

--- a/backend/sports/migrations/0012_user_activity_history.py
+++ b/backend/sports/migrations/0012_user_activity_history.py
@@ -1,0 +1,25 @@
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0011_booking_slot_updates'),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='UserActivityHistory',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('action', models.CharField(choices=[('view', 'View'), ('favorite', 'Favorite'), ('book', 'Book')], max_length=10)),
+                ('timestamp', models.DateTimeField(default=django.utils.timezone.now)),
+                ('activity', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='user_history', to='sports.activity')),
+                ('user', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='activity_history', to=settings.AUTH_USER_MODEL)),
+            ],
+            options={'ordering': ('-timestamp',)},
+        ),
+    ]

--- a/backend/sports/migrations/0013_slot_activity_required.py
+++ b/backend/sports/migrations/0013_slot_activity_required.py
@@ -1,0 +1,44 @@
+from django.db import migrations, models
+import csv
+
+def forwards(apps, schema_editor):
+    Slot = apps.get_model('sports', 'Slot')
+    Activity = apps.get_model('sports', 'Activity')
+    orphans = []
+    for slot in Slot.objects.filter(activity__isnull=True):
+        act = Activity.objects.filter(sport=slot.sport).first()
+        if act:
+            slot.activity_id = act.id
+            slot.save(update_fields=['activity'])
+        else:
+            orphans.append(slot.id)
+    if orphans:
+        path = schema_editor.connection.alias if hasattr(schema_editor, 'connection') else 'default'
+        with open('orphan_slots.csv', 'w', newline='') as f:
+            writer = csv.writer(f)
+            writer.writerow(['slot_id'])
+            for sid in orphans:
+                writer.writerow([sid])
+
+def backwards(apps, schema_editor):
+    # no-op
+    pass
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0012_user_activity_history'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+        migrations.AlterField(
+            model_name='slot',
+            name='activity',
+            field=models.ForeignKey(on_delete=models.deletion.CASCADE, related_name='slots', to='sports.activity'),
+        ),
+        migrations.AlterUniqueTogether(
+            name='slot',
+            unique_together={('activity', 'begins_at')},
+        ),
+    ]
+

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -173,6 +173,7 @@ class Slot(models.Model):
         on_delete=models.CASCADE,
         null=True,
         blank=True,
+        editable=False,
     )
     title = models.CharField(max_length=60)
     location = models.CharField(max_length=80)
@@ -193,14 +194,12 @@ class Slot(models.Model):
         "Activity",
         related_name="slots",
         on_delete=models.CASCADE,
-        null=True,
-        blank=True,
     )
     current_participants = models.PositiveIntegerField(default=0)
 
     class Meta:
         ordering = ("begins_at",)
-        unique_together = ("facility", "begins_at")
+        unique_together = ("activity", "begins_at")
 
     @property
     def seats_left(self) -> int:
@@ -287,3 +286,34 @@ class Review(models.Model):
 
     def __str__(self) -> str:  # pragma: no cover
         return f"{self.user} → {self.activity} ({self.rating})"
+
+
+class UserActivityHistory(models.Model):
+    """Store user interactions with activities."""
+
+    ACTION_VIEW = "view"
+    ACTION_FAVORITE = "favorite"
+    ACTION_BOOK = "book"
+
+    ACTION_CHOICES = [
+        (ACTION_VIEW, "View"),
+        (ACTION_FAVORITE, "Favorite"),
+        (ACTION_BOOK, "Book"),
+    ]
+
+    user = models.ForeignKey(
+        "auth.User",
+        on_delete=models.CASCADE,
+        related_name="activity_history",
+    )
+    activity = models.ForeignKey(
+        Activity,
+        on_delete=models.CASCADE,
+        related_name="user_history",
+    )
+    action = models.CharField(max_length=10, choices=ACTION_CHOICES)
+    timestamp = models.DateTimeField(default=timezone.now)
+
+    class Meta:
+        ordering = ("-timestamp",)
+

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -144,6 +144,21 @@ class ActivitySerializer(serializers.ModelSerializer):
         return attrs
 
 
+class ActivitySimpleSerializer(serializers.ModelSerializer):
+    image_url = serializers.SerializerMethodField()
+
+    class Meta:
+        model = Activity
+        fields = ("id", "title", "image_url", "base_price")
+
+    def get_image_url(self, obj):
+        if obj.image:
+            request = self.context.get("request")
+            url = obj.image.url
+            return request.build_absolute_uri(url) if request else url
+        return ""
+
+
 class FeaturedCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = FeaturedCategory

--- a/backend/sports/urls.py
+++ b/backend/sports/urls.py
@@ -13,6 +13,7 @@ from .views import (
     FeaturedCategoryViewSet,
     FeaturedActivityViewSet,
     ActivityReviewList,
+    ContinuePlanningView,
     BulkSlotCreateView,
     MerchantSlotCreateView,
     MerchantBookingList,
@@ -34,4 +35,5 @@ urlpatterns = router.urls + [
     path("merchant/slots/", MerchantSlotCreateView.as_view()),
     path("merchant/bookings/", MerchantBookingList.as_view()),
     path("activities/<int:activity_id>/reviews/", ActivityReviewList.as_view(), name="activity-reviews"),
+    path("home/continue-planning/", ContinuePlanningView.as_view()),
 ]

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -5,9 +5,10 @@ Run:  pytest backend
 import pytest
 import django
 from rest_framework.test import APIClient
-from sports.models import Sport, Slot, Booking
+from sports.models import Sport, Slot, Booking, Category, Activity, UserActivityHistory
 from django.contrib.auth.models import User
 from django.utils import timezone
+import json
 from django.db import models
 
 django.setup()
@@ -38,6 +39,21 @@ def test_slots_filter():
     client = APIClient()
     response = client.get("/api/slots/", {"sport": sport.id})
     assert response.status_code == 200
+
+
+def test_slot_requires_activity():
+    sport = Sport.objects.create(name="Hoops")
+    with pytest.raises(Exception):
+        Slot.objects.create(
+            sport=sport,
+            title="M",
+            location="L",
+            begins_at=timezone.now(),
+            ends_at=timezone.now() + timezone.timedelta(hours=1),
+            capacity=1,
+            price=0,
+            rating=0,
+        )
     for slot in response.data:
         assert slot["sport"] == sport.id
 
@@ -92,4 +108,103 @@ def test_concurrent_booking_capacity(db):
     t1.start(); t2.start(); t1.join(); t2.join()
 
     assert results.count(201) == 1
-    assert Booking.objects.filter(slot=slot).aggregate(models.Sum("pax"))["pax__sum"] <= slot.capacity
+    assert (
+        Booking.objects.filter(slot=slot).aggregate(models.Sum("pax"))["pax__sum"]
+        <= slot.capacity
+    )
+
+
+def test_slots_filter_by_activity():
+    sport = Sport.objects.create(name="Yoga")
+    disc = Category.objects.create(name="Flow")
+    activity = Activity.objects.create(
+        sport=sport,
+        discipline=disc,
+        title="Morning Flow",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    )
+    slot = Slot.objects.create(
+        sport=sport,
+        activity=activity,
+        title="Morning",
+        location="Room",
+        begins_at=timezone.now(),
+        ends_at=timezone.now() + timezone.timedelta(hours=1),
+        capacity=5,
+        price=0,
+        rating=0,
+    )
+    client = APIClient()
+    resp = client.get("/api/slots/", {"activity": activity.id})
+    assert resp.status_code == 200
+    assert len(resp.data) == 1
+    assert resp.data[0]["id"] == slot.id
+
+
+def test_continue_planning_endpoint():
+    user = User.objects.create_user("planu")
+    sport = Sport.objects.create(name="Run")
+    cat = Category.objects.create(name="Aerobic")
+    act = Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title="Morning Run",
+        description="",
+        difficulty=1,
+        duration=30,
+        base_price=5,
+    )
+    UserActivityHistory.objects.create(
+        user=user, activity=act, action="view"
+    )
+
+    client = APIClient()
+    client.force_authenticate(user)
+    resp = client.get("/api/home/continue-planning/")
+    assert resp.status_code == 200
+    assert len(resp.data) == 1
+    assert resp.data[0]["title"] == "Morning Run"
+
+
+def test_webhook_updates_booking(client=None):
+    sport = Sport.objects.create(name="Foot")
+    cat = Category.objects.create(name="Play")
+    act = Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title="Match",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=10,
+    )
+    slot = Slot.objects.create(
+        sport=sport,
+        activity=act,
+        title="M",
+        location="L",
+        begins_at=timezone.now(),
+        ends_at=timezone.now() + timezone.timedelta(hours=1),
+        capacity=5,
+        price=10,
+        rating=0,
+    )
+    user = User.objects.create_user("web")
+    booking = Booking.objects.create(slot=slot, activity=act, user=user)
+    client = APIClient()
+    event = {
+        "type": "payment_intent.succeeded",
+        "data": {"object": {"metadata": {"slot_id": slot.id, "user_id": user.id}}},
+    }
+    res = client.post(
+        "/api/payments/webhook/",
+        data=json.dumps(event),
+        content_type="application/json",
+    )
+    assert res.status_code == 200
+    booking.refresh_from_db()
+    assert booking.paid
+    assert booking.status == "confirmed"

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -22,10 +22,16 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
   return slotService.fetchBySport(sportId);
 });
 
+/// Upcoming slots for an activity, used to limit available dates.
+final activitySlotsProvider =
+    FutureProvider.family<List<Slot>, int>((ref, activityId) {
+  return slotService.fetchByActivity(activityId);
+});
+
 class SlotsByDateParams {
   const SlotsByDateParams({required this.activityId, required this.date});
   final int activityId;
-  final String date;
+  final DateTime date;
 }
 
 final slotsByDateProvider =

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -23,14 +23,14 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
 });
 
 class SlotsByDateParams {
-  const SlotsByDateParams({required this.sportId, required this.date});
-  final int sportId;
+  const SlotsByDateParams({required this.activityId, required this.date});
+  final int activityId;
   final String date;
 }
 
 final slotsByDateProvider =
     FutureProvider.family<List<Slot>, SlotsByDateParams>((ref, params) {
-  return slotService.fetchBySportDate(params.sportId, params.date);
+  return slotService.fetchByActivityDate(params.activityId, params.date);
 });
 
 

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -25,7 +25,7 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
 class SlotsByDateParams {
   const SlotsByDateParams({required this.activityId, required this.date});
   final int activityId;
-  final String date;
+  final DateTime date;
 }
 
 final slotsByDateProvider =

--- a/lib/providers/home_provider.dart
+++ b/lib/providers/home_provider.dart
@@ -1,6 +1,7 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/featured_category.dart';
 import '../models/featured_activity.dart';
+import '../models/activity.dart';
 import '../services/home_service.dart';
 
 final featuredCategoriesProvider =
@@ -11,4 +12,8 @@ final featuredCategoriesProvider =
 final featuredActivitiesProvider =
     FutureProvider<List<FeaturedActivity>>((ref) async {
   return homeService.fetchFeaturedActivities();
+});
+
+final continuePlanningProvider = FutureProvider<List<Activity>>((ref) async {
+  return homeService.fetchContinuePlanning();
 });

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -52,9 +52,7 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
   }
 
   Widget _buildSlots() {
-    final dateStr = '${selectedDate!.year.toString().padLeft(4, '0')}-'
-        '${selectedDate!.month.toString().padLeft(2, '0')}-'
-        '${selectedDate!.day.toString().padLeft(2, '0')}';
+    final dateStr = selectedDate!.toUtc().toIso8601String();
     final asyncSlots =
         ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
     return asyncSlots.when(

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -56,7 +56,7 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
         '${selectedDate!.month.toString().padLeft(2, '0')}-'
         '${selectedDate!.day.toString().padLeft(2, '0')}';
     final asyncSlots =
-        ref.watch(slotsByDateProvider(SlotsByDateParams(sportId: widget.activity.sport, date: dateStr)));
+        ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
     return asyncSlots.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, __) => Center(child: Text('Error: $e')),

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -52,9 +52,14 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
   }
 
   Widget _buildSlots() {
-    final dateStr = selectedDate!.toUtc().toIso8601String();
-    final asyncSlots =
-        ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
+    final asyncSlots = ref.watch(
+      slotsByDateProvider(
+        SlotsByDateParams(
+          activityId: widget.activity.id,
+          date: selectedDate!,
+        ),
+      ),
+    );
     return asyncSlots.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, __) => Center(child: Text('Error: $e')),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -43,6 +43,7 @@ class _HomePageState extends ConsumerState<HomePage> {
     final nearbyActsAsync = ref.watch(nearbyActivitiesProvider);
     final featuredCatsAsync = ref.watch(featuredCategoriesProvider);
     final featuredActsAsync = ref.watch(featuredActivitiesProvider);
+    final continuePlanningAsync = ref.watch(continuePlanningProvider);
 
     final Widget body = _navIndex == 2
         ? const BookingsPage()
@@ -340,7 +341,7 @@ class _HomePageState extends ConsumerState<HomePage> {
           ),
 
 
-          // ================= Continue planning（保持不变） =================
+          // ================= Continue planning =================
           SliverPadding(
             padding: const EdgeInsets.fromLTRB(16, 32, 0, 0),
             sliver: SliverToBoxAdapter(
@@ -348,27 +349,59 @@ class _HomePageState extends ConsumerState<HomePage> {
                   style: Theme.of(context).textTheme.titleLarge),
             ),
           ),
-          SliverToBoxAdapter(
-            child: SizedBox(
-              height: 240,
-              child: ListView(
-                padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
-                scrollDirection: Axis.horizontal,
-                children: [
-                  ProjectCard(
-                    title: 'Sunset Sailing Tour',
-                    imageUrl: 'assets/images/sailing.jpg',
-                    onTap: () {},
-                  ),
-                  const SizedBox(width: 20),
-                  ProjectCard(
-                    title: 'Dolphin Watching',
-                    imageUrl: 'assets/images/dolphin.jpg',
-                    onTap: () {},
-                  ),
-                ],
+          continuePlanningAsync.when(
+            loading: () => const SliverToBoxAdapter(
+              child: SizedBox(
+                height: 240,
+                child: Center(child: CircularProgressIndicator()),
               ),
             ),
+            error: (e, __) => SliverToBoxAdapter(
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Text('Error: \$e',
+                    style: Theme.of(context)
+                        .textTheme
+                        .bodyMedium
+                        ?.copyWith(color: Colors.red)),
+              ),
+            ),
+            data: (acts) {
+              if (acts.isEmpty) {
+                return SliverToBoxAdapter(
+                  child: Padding(
+                    padding: const EdgeInsets.all(16),
+                    child: Text('No suggestions yet',
+                        style: Theme.of(context).textTheme.bodyMedium),
+                  ),
+                );
+              }
+              return SliverToBoxAdapter(
+                child: SizedBox(
+                  height: 240,
+                  child: ListView.separated(
+                    scrollDirection: Axis.horizontal,
+                    padding: const EdgeInsets.fromLTRB(16, 12, 16, 32),
+                    itemCount: acts.length,
+                    separatorBuilder: (_, __) => const SizedBox(width: 20),
+                    itemBuilder: (_, i) {
+                      final act = acts[i];
+                      return ProjectCard(
+                        title: act.title,
+                        imageUrl: act.imageUrl ?? act.image,
+                        price: act.basePrice,
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(builder: (_) => ActivityDetailPage(activity: act)),
+                          );
+                        },
+                      );
+                    },
+                  ),
+                ),
+              );
+            },
           ),
         ],
       );

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -21,6 +21,11 @@ class BookingService {
     );
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
+
+  Future<Booking> fetchById(int id) async {
+    final res = await apiClient.get('/bookings/' + id.toString() + '/');
+    return Booking.fromJson(res.data as Map<String, dynamic>);
+  }
 }
 
 final bookingService = BookingService();

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -1,5 +1,6 @@
 import '../models/featured_category.dart';
 import '../models/featured_activity.dart';
+import '../models/activity.dart';
 import 'api_client.dart';
 
 class HomeService {
@@ -16,6 +17,14 @@ class HomeService {
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(FeaturedActivity.fromJson)
+        .toList(growable: false);
+  }
+
+  Future<List<Activity>> fetchContinuePlanning() async {
+    final res = await apiClient.get('/home/continue-planning/');
+    return (res.data as List)
+        .cast<Map<String, dynamic>>()
+        .map(Activity.fromJson)
         .toList(growable: false);
   }
 }

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+import '../models/booking.dart';
+import 'api_client.dart';
+
+class PaymentService {
+  Future<Map<String, dynamic>> createIntent(int slotId) async {
+    final res = await apiClient.post('/payments/checkout/', data: {'slot': slotId});
+    return res.data as Map<String, dynamic>;
+  }
+
+  Future<Booking> fetchBooking(int bookingId) async {
+    final res = await apiClient.get('/bookings/' + bookingId.toString() + '/');
+    return Booking.fromJson(res.data as Map<String, dynamic>);
+  }
+}
+
+final paymentService = PaymentService();

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -23,6 +23,26 @@ class SlotService {
         .toList(growable: false);
   }
 
+  /// All upcoming slots for an activity. Uses `after` filter to
+  /// only return slots from now onwards.
+  Future<List<Slot>> fetchByActivity(int activityId) async {
+    final Response res = await apiClient.get(
+      '/slots/',
+      queryParameters: {
+        'activity': activityId,
+        'after': DateTime.now().toIso8601String(),
+      },
+    );
+
+    final dynamic payload = res.data;
+    final List data = payload is Map ? payload['results'] as List : payload as List;
+
+    return data
+        .cast<dynamic>()
+        .map((e) => Slot.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   Future<List<Slot>> fetchBySportDate(int sportId, String date) async {
     final Response res = await apiClient.get(
       '/slots/',
@@ -38,10 +58,16 @@ class SlotService {
         .toList(growable: false);
   }
 
-  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+  Future<List<Slot>> fetchByActivityDate(int activityId, DateTime date) async {
+    final start = DateTime(date.year, date.month, date.day);
+    final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
       '/slots/',
-      queryParameters: {'activity': activityId, 'after': date},
+      queryParameters: {
+        'activity': activityId,
+        'after': start.toIso8601String(),
+        'before': end.toIso8601String(),
+      },
     );
 
     final dynamic payload = res.data;

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -26,7 +26,22 @@ class SlotService {
   Future<List<Slot>> fetchBySportDate(int sportId, String date) async {
     final Response res = await apiClient.get(
       '/slots/',
-      queryParameters: {'sport': sportId, 'date': date},
+      queryParameters: {'sport': sportId, 'after': date},
+    );
+
+    final dynamic payload = res.data;
+    final List data = payload is Map ? payload['results'] as List : payload as List;
+
+    return data
+        .cast<dynamic>()
+        .map((e) => Slot.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
+  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+    final Response res = await apiClient.get(
+      '/slots/',
+      queryParameters: {'activity': activityId, 'after': date},
     );
 
     final dynamic payload = res.data;

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -38,10 +38,16 @@ class SlotService {
         .toList(growable: false);
   }
 
-  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+  Future<List<Slot>> fetchByActivityDate(int activityId, DateTime date) async {
+    final start = DateTime(date.year, date.month, date.day);
+    final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
       '/slots/',
-      queryParameters: {'activity': activityId, 'after': date},
+      queryParameters: {
+        'activity': activityId,
+        'after': start.toIso8601String(),
+        'before': end.toIso8601String(),
+      },
     );
 
     final dynamic payload = res.data;

--- a/lib/widgets/project_card.dart
+++ b/lib/widgets/project_card.dart
@@ -4,10 +4,27 @@ import 'package:flutter/material.dart';
 class ProjectCard extends StatelessWidget {
   final String title;
   final String imageUrl;
+  final double price;
   final VoidCallback onTap;
 
-  const ProjectCard(
-      {super.key, required this.title, required this.imageUrl, required this.onTap});
+  const ProjectCard({
+    super.key,
+    required this.title,
+    required this.imageUrl,
+    required this.price,
+    required this.onTap,
+  });
+
+  Widget _buildImage() {
+    if (imageUrl.startsWith('http')) {
+      return Image.network(
+        imageUrl,
+        fit: BoxFit.cover,
+        errorBuilder: (_, __, ___) => const ColoredBox(color: Colors.black12),
+      );
+    }
+    return Image.asset(imageUrl, fit: BoxFit.cover);
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -21,7 +38,7 @@ class ProjectCard extends StatelessWidget {
           Expanded(
             child: ClipRRect(
               borderRadius: BorderRadius.circular(16),
-              child: Image.asset(imageUrl, fit: BoxFit.cover),
+              child: _buildImage(),
             ),
           ),
           const SizedBox(height: 18),
@@ -29,6 +46,9 @@ class ProjectCard extends StatelessWidget {
               maxLines: 2,
               overflow: TextOverflow.ellipsis,
               style: Theme.of(context).textTheme.bodyLarge),
+          const SizedBox(height: 4),
+          Text('\$${price.toStringAsFixed(0)}',
+              style: Theme.of(context).textTheme.bodyMedium),
           ],
         ),
       ),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -24,6 +24,7 @@ dependencies:
   flutter_secure_storage: ^9.0.0  # secure token storage
   google_sign_in: ^6.1.5
   qr_flutter: ^4.1.0
+  flutter_stripe: ^10.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- make Slot.activity required and unique together with start time
- migrate existing slots and log orphans
- filter Slot API by time range and activity
- create bookings during checkout and confirm via webhook
- integrate Flutter Stripe payment sheet
- fetch slots with `after` query and update payment services
- add tests for slot activity constraint and webhook

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend/tests/test_api.py::test_slots_filter_by_activity -q` *(fails: Could not find the GDAL library)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc28b54b08326923ea6b3c2f9fbcf