### PR TITLE
Fix slot search date

### DIFF
--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -52,9 +52,7 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
   }
 
   Widget _buildSlots() {
-    final dateStr = '${selectedDate!.year.toString().padLeft(4, '0')}-'
-        '${selectedDate!.month.toString().padLeft(2, '0')}-'
-        '${selectedDate!.day.toString().padLeft(2, '0')}';
+    final dateStr = selectedDate!.toUtc().toIso8601String();
     final asyncSlots =
         ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
     return asyncSlots.when(


### PR DESCRIPTION
## Summary
- ensure selected date uses UTC for filtering slots

## Testing
- `pip install -r requirements.txt` *(fails: Could not find GDAL library)*
- `pytest -q` *(fails due to missing GDAL)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880cca9a578832694472a22183ad2b8