### PR TITLE
Fix date filtering for activity slots

### DIFF
--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -25,7 +25,7 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
 class SlotsByDateParams {
   const SlotsByDateParams({required this.activityId, required this.date});
   final int activityId;
-  final String date;
+  final DateTime date;
 }
 
 final slotsByDateProvider =

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -52,9 +52,14 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
   }
 
   Widget _buildSlots() {
-    final dateStr = selectedDate!.toUtc().toIso8601String();
-    final asyncSlots =
-        ref.watch(slotsByDateProvider(SlotsByDateParams(activityId: widget.activity.id, date: dateStr)));
+    final asyncSlots = ref.watch(
+      slotsByDateProvider(
+        SlotsByDateParams(
+          activityId: widget.activity.id,
+          date: selectedDate!,
+        ),
+      ),
+    );
     return asyncSlots.when(
       loading: () => const Center(child: CircularProgressIndicator()),
       error: (e, __) => Center(child: Text('Error: $e')),

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -38,10 +38,16 @@ class SlotService {
         .toList(growable: false);
   }
 
-  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+  Future<List<Slot>> fetchByActivityDate(int activityId, DateTime date) async {
+    final start = DateTime(date.year, date.month, date.day);
+    final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
       '/slots/',
-      queryParameters: {'activity': activityId, 'after': date},
+      queryParameters: {
+        'activity': activityId,
+        'after': start.toIso8601String(),
+        'before': end.toIso8601String(),
+      },
     );
 
     final dynamic payload = res.data;


### PR DESCRIPTION
## Summary
- fetch slots between start and end of selected day
- update provider to pass DateTime values
- adjust booking page to use new provider

## Testing
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_6880d3fc8e088326b80fd7fe5141e160