### PR TITLE
Show upcoming slot dates in booking page

### DIFF
--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -22,10 +22,16 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
   return slotService.fetchBySport(sportId);
 });
 
+/// Upcoming slots for an activity, used to limit available dates.
+final activitySlotsProvider =
+    FutureProvider.family<List<Slot>, int>((ref, activityId) {
+  return slotService.fetchByActivity(activityId);
+});
+
 class SlotsByDateParams {
   const SlotsByDateParams({required this.activityId, required this.date});
   final int activityId;
-  final String date;
+  final DateTime date;
 }
 
 final slotsByDateProvider =

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -23,6 +23,26 @@ class SlotService {
         .toList(growable: false);
   }
 
+  /// All upcoming slots for an activity. Uses `after` filter to
+  /// only return slots from now onwards.
+  Future<List<Slot>> fetchByActivity(int activityId) async {
+    final Response res = await apiClient.get(
+      '/slots/',
+      queryParameters: {
+        'activity': activityId,
+        'after': DateTime.now().toIso8601String(),
+      },
+    );
+
+    final dynamic payload = res.data;
+    final List data = payload is Map ? payload['results'] as List : payload as List;
+
+    return data
+        .cast<dynamic>()
+        .map((e) => Slot.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
   Future<List<Slot>> fetchBySportDate(int sportId, String date) async {
     final Response res = await apiClient.get(
       '/slots/',
@@ -38,10 +58,16 @@ class SlotService {
         .toList(growable: false);
   }
 
-  Future<List<Slot>> fetchByActivityDate(int activityId, String date) async {
+  Future<List<Slot>> fetchByActivityDate(int activityId, DateTime date) async {
+    final start = DateTime(date.year, date.month, date.day);
+    final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
       '/slots/',
-      queryParameters: {'activity': activityId, 'after': date},
+      queryParameters: {
+        'activity': activityId,
+        'after': start.toIso8601String(),
+        'before': end.toIso8601String(),
+      },
     );
 
     final dynamic payload = res.data;


### PR DESCRIPTION
## Summary
- refactor ActivityBookingPage to load upcoming slots
- display date chips at the top and remove the Choose Date button
- keep slot list filtered by selected date

## Testing
- `flutter test` *(fails: command not found)*
- `(cd backend && DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest -q)` *(fails: SpatiaLite requires SQLite extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_6880d3fc8e088326b80fd7fe5141e160