### PR TITLE
Fix slot sport auto-population

### DIFF
--- a/backend/sports/migrations/0014_fill_slot_sport.py
+++ b/backend/sports/migrations/0014_fill_slot_sport.py
@@ -1,0 +1,22 @@
+from django.db import migrations
+
+def forwards(apps, schema_editor):
+    Slot = apps.get_model('sports', 'Slot')
+    for slot in Slot.objects.filter(sport__isnull=True, activity__isnull=False):
+        slot.sport_id = slot.activity.sport_id
+        slot.save(update_fields=['sport'])
+
+
+def backwards(apps, schema_editor):
+    # No-op
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0013_slot_activity_required'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -205,6 +205,12 @@ class Slot(models.Model):
     def seats_left(self) -> int:
         return max(self.capacity - self.current_participants, 0)
 
+    def save(self, *args, **kwargs):
+        """Ensure sport always matches the related activity."""
+        if self.activity_id and not self.sport_id:
+            self.sport_id = self.activity.sport_id
+        super().save(*args, **kwargs)
+
     def __str__(self) -> str:                # pragma: no cover
         return f"{self.title} @ {self.begins_at:%Y-%m-%d %H:%M}"
 


### PR DESCRIPTION
## Summary
- ensure Slot.save populates sport from activity
- backfill sport field for existing slots

## Testing
- `pytest -q` *(fails: SpatiaLite requires SQLite with loadable extension support)*

------
https://chatgpt.com/codex/tasks/task_e_688117ac8eac8326bedaa058f790fa5c