### PR TITLE
Fix slot selection and add payment flow

### DIFF
--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -11,6 +11,7 @@ import 'services/api_client.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'models/profile.dart';
 import 'services/profile_service.dart';
+import 'package:meta/meta.dart';
 
 // ───────── Sports list ─────────
 final sportsProvider = FutureProvider<List<Sport>>((ref) async {
@@ -28,14 +29,27 @@ final activitySlotsProvider =
   return slotService.fetchByActivity(activityId);
 });
 
+@immutable
 class SlotsByDateParams {
   const SlotsByDateParams({required this.activityId, required this.date});
+
   final int activityId;
   final DateTime date;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is SlotsByDateParams &&
+          runtimeType == other.runtimeType &&
+          activityId == other.activityId &&
+          date == other.date;
+
+  @override
+  int get hashCode => Object.hash(activityId, date);
 }
 
 final slotsByDateProvider =
-    FutureProvider.family<List<Slot>, SlotsByDateParams>((ref, params) {
+    FutureProvider.autoDispose.family<List<Slot>, SlotsByDateParams>((ref, params) {
   return slotService.fetchByActivityDate(params.activityId, params.date);
 });
 

--- a/lib/screens/activity_booking_page.dart
+++ b/lib/screens/activity_booking_page.dart
@@ -16,6 +16,26 @@ class ActivityBookingPage extends ConsumerStatefulWidget {
 
 class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
   DateTime? selectedDate;
+  Slot? selectedSlot;
+  bool isLoading = false;
+
+  Future<void> _continue() async {
+    if (selectedSlot == null) return;
+    setState(() => isLoading = true);
+    try {
+      final booking = await Navigator.push(
+        context,
+        MaterialPageRoute(
+          builder: (_) => PaymentPage(slot: selectedSlot!),
+        ),
+      );
+      if (booking != null && context.mounted) {
+        Navigator.pop(context, booking);
+      }
+    } finally {
+      if (mounted) setState(() => isLoading = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -63,6 +83,21 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
                     ? const SizedBox.shrink()
                     : _buildSlots(),
               ),
+              Padding(
+                padding: const EdgeInsets.all(16),
+                child: ElevatedButton(
+                  onPressed: selectedSlot != null && !isLoading
+                      ? _continue
+                      : null,
+                  child: isLoading
+                      ? const SizedBox(
+                          height: 20,
+                          width: 20,
+                          child: CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : const Text('Continue'),
+                ),
+              ),
             ],
           );
         },
@@ -94,17 +129,8 @@ class _ActivityBookingPageState extends ConsumerState<ActivityBookingPage> {
             final Slot s = slots[i];
             return SlotCard(
               slot: s,
-              onTap: () async {
-                final booking = await Navigator.push(
-                  context,
-                  MaterialPageRoute(
-                    builder: (_) => PaymentPage(slot: s),
-                  ),
-                );
-                if (booking != null) {
-                  if (context.mounted) Navigator.pop(context, booking);
-                }
-              },
+              selected: selectedSlot?.id == s.id,
+              onTap: () => setState(() => selectedSlot = s),
             );
           },
         );

--- a/lib/widgets/slot_card.dart
+++ b/lib/widgets/slot_card.dart
@@ -7,10 +7,12 @@ class SlotCard extends StatelessWidget {
     super.key,
     required this.slot,
     required this.onTap,
+    this.selected = false,
   });
 
   final Slot slot;
   final VoidCallback onTap;
+  final bool selected;
 
   @override
   Widget build(BuildContext context) {
@@ -20,6 +22,16 @@ class SlotCard extends StatelessWidget {
         width: 220,
         child: Card(
           clipBehavior: Clip.hardEdge,
+          shape: selected
+              ? RoundedRectangleBorder(
+                  side: BorderSide(
+                    color: Theme.of(context).colorScheme.primary,
+                    width: 2,
+                  ),
+                  borderRadius: BorderRadius.circular(12),
+                )
+              : null,
+          color: selected ? Colors.blue.shade50 : null,
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [

--- a/test/activity_booking_test.dart
+++ b/test/activity_booking_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:sports_booking_app/screens/activity_booking_page.dart';
+import 'package:sports_booking_app/providers.dart';
+import 'package:sports_booking_app/models/activity.dart';
+import 'package:sports_booking_app/models/slot.dart';
+import 'package:sports_booking_app/models/sport.dart';
+import 'package:sports_booking_app/widgets/slot_card.dart';
+
+void main() {
+  testWidgets('select slot shows CTA and navigates to payment page', (tester) async {
+    final sport = Sport(id: 1, name: 'Tennis', banner: '', description: '');
+    final slot = Slot(
+      id: 1,
+      sport: sport,
+      title: 'Morning',
+      location: 'Court',
+      beginsAt: DateTime(2024, 1, 1, 10),
+      endsAt: DateTime(2024, 1, 1, 11),
+      capacity: 10,
+      price: 20,
+      rating: 5,
+      seatsLeft: 5,
+    );
+    final activity = Activity(
+      id: 1,
+      sport: 1,
+      discipline: 1,
+      variant: null,
+      image: '',
+      imageUrl: null,
+      title: 'Play',
+      description: '',
+      difficulty: 1,
+      duration: 60,
+      basePrice: 20,
+    );
+
+    await tester.pumpWidget(
+      ProviderScope(
+        overrides: [
+          activitySlotsProvider.overrideWith((ref, id) async => [slot]),
+          slotsByDateProvider.overrideWith((ref, params) async => [slot]),
+        ],
+        child: MaterialApp(
+          home: ActivityBookingPage(activity: activity),
+        ),
+      ),
+    );
+
+    await tester.pump();
+    expect(find.byType(CircularProgressIndicator), findsNothing);
+
+    await tester.tap(find.byType(SlotCard));
+    await tester.pump();
+
+    expect(find.text('Continue'), findsOneWidget);
+
+    await tester.tap(find.text('Continue'));
+    await tester.pumpAndSettle();
+
+    expect(find.text('Pay & Book'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- highlight SlotCard when selected
- add Continue button to ActivityBookingPage
- push PaymentPage only after selecting a slot
- widget test for slot selection flow

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6883a352dde483268a1b2323009dee01