### PR TITLE
Fix Stripe init and booking creation

### DIFF
--- a/android/app/build.gradle.kts
+++ b/android/app/build.gradle.kts
@@ -24,7 +24,8 @@ android {
         applicationId = "com.example.sports_booking_app"
         // You can update the following values to match your application needs.
         // For more information, see: https://flutter.dev/to/review-gradle-config.
-        minSdk = flutter.minSdkVersion
+        // Stripe requires Android 5.0+ (API 21)
+        minSdk = 21
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     <!-- Needed for geolocator -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <!-- Networking permission required for API calls and Stripe -->
+    <uses-permission android:name="android.permission.INTERNET" />
     <application
         android:label="sports_booking_app"
         android:name="${applicationName}"

--- a/android/app/src/main/kotlin/com/example/sports_booking_app/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/sports_booking_app/MainActivity.kt
@@ -1,5 +1,5 @@
 package com.example.sports_booking_app
 
-import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.android.FlutterFragmentActivity
 
-class MainActivity : FlutterActivity()
+class MainActivity : FlutterFragmentActivity()

--- a/android/settings.gradle.kts
+++ b/android/settings.gradle.kts
@@ -19,7 +19,8 @@ pluginManagement {
 plugins {
     id("dev.flutter.flutter-plugin-loader") version "1.0.0"
     id("com.android.application") version "8.7.3" apply false
-    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    // Kotlin 1.9.x is compatible with current Flutter and AGP
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
 }
 
 include(":app")

--- a/backend/payments/views.py
+++ b/backend/payments/views.py
@@ -4,6 +4,7 @@ from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 from rest_framework import status
+from django.db import IntegrityError
 
 from sports.models import Slot, Booking
 
@@ -39,19 +40,11 @@ class StripeCheckoutView(APIView):
             return Response({'detail': str(e)}, status=400)
         except Exception as e:
             return Response({'detail': f'server error: {e}'}, status=500)
-        booking = Booking.objects.create(
-            slot=slot,
-            activity=slot.activity,
-            user=request.user,
-            status="pending",
-            paid=False,
-            pax=1,
-        )
+
         return Response(
             {
                 'client_secret': intent.client_secret,
                 'intent_id': intent.id,
-                'booking_id': booking.id,
             },
             status=200,
         )
@@ -83,9 +76,18 @@ class StripeWebhookView(APIView):
             intent = event['data']['object']
             slot_id = intent['metadata'].get('slot_id')
             user_id = intent['metadata'].get('user_id')
-            booking = Booking.objects.filter(slot_id=slot_id, user_id=user_id).first()
-            if booking:
-                booking.paid = True
-                booking.status = 'confirmed'
-                booking.save(update_fields=['paid', 'status'])
+            try:
+                slot = Slot.objects.get(pk=slot_id)
+                Booking.objects.create(
+                    slot=slot,
+                    activity=slot.activity,
+                    user_id=user_id,
+                    status='confirmed',
+                    paid=True,
+                    pax=1,
+                )
+            except IntegrityError:
+                Booking.objects.filter(slot_id=slot_id, user_id=user_id).update(
+                    paid=True, status='confirmed'
+                )
         return Response({'status': 'ok'})

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -169,7 +169,7 @@ def test_continue_planning_endpoint():
     assert resp.data[0]["title"] == "Morning Run"
 
 
-def test_webhook_updates_booking(client=None):
+def test_webhook_creates_booking(client=None):
     sport = Sport.objects.create(name="Foot")
     cat = Category.objects.create(name="Play")
     act = Activity.objects.create(
@@ -193,7 +193,6 @@ def test_webhook_updates_booking(client=None):
         rating=0,
     )
     user = User.objects.create_user("web")
-    booking = Booking.objects.create(slot=slot, activity=act, user=user)
     client = APIClient()
     event = {
         "type": "payment_intent.succeeded",
@@ -205,6 +204,6 @@ def test_webhook_updates_booking(client=None):
         content_type="application/json",
     )
     assert res.status_code == 200
-    booking.refresh_from_db()
+    booking = Booking.objects.get(slot=slot, user=user)
     assert booking.paid
     assert booking.status == "confirmed"

--- a/backend/tests/test_payment_checkout.py
+++ b/backend/tests/test_payment_checkout.py
@@ -51,7 +51,7 @@ def test_checkout_no_key_returns_500(auth_client, slot, monkeypatch):
     assert 'misconfigured' in resp.data['detail']
 
 
-def test_checkout_success_creates_booking(auth_client, slot, monkeypatch):
+def test_checkout_success_returns_intent(auth_client, slot, monkeypatch):
     class FakeIntent:
         id = 'pi_123'
         client_secret = 'sec'
@@ -62,7 +62,5 @@ def test_checkout_success_creates_booking(auth_client, slot, monkeypatch):
     assert resp.status_code == 200
     data = resp.data
     assert data['intent_id'] == 'pi_123'
-    booking = Booking.objects.get(id=data['booking_id'])
-    assert booking.slot == slot
-    assert booking.status == 'pending'
-    assert not booking.paid
+    assert 'client_secret' in data
+    assert Booking.objects.count() == 0

--- a/backend/tests/test_payment_webhook.py
+++ b/backend/tests/test_payment_webhook.py
@@ -9,7 +9,7 @@ django.setup()
 pytestmark = pytest.mark.django_db
 
 
-def test_payment_webhook_updates_booking():
+def test_payment_webhook_creates_booking():
     sport = Sport.objects.create(name="Pay")
     cat = Category.objects.create(name="Cat")
     act = Activity.objects.create(
@@ -33,7 +33,6 @@ def test_payment_webhook_updates_booking():
         rating=0,
     )
     user_id = 1
-    booking = Booking.objects.create(slot=slot, activity=act, user_id=user_id)
     client = APIClient()
     event = {
         "type": "payment_intent.succeeded",
@@ -49,6 +48,6 @@ def test_payment_webhook_updates_booking():
         content_type="application/json",
     )
     assert res.status_code == 200
-    booking.refresh_from_db()
+    booking = Booking.objects.get(slot=slot, user_id=user_id)
     assert booking.paid
     assert booking.status == "confirmed"

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,6 +22,9 @@ Future<void> main() async {
   // <-- load .env variables
 
   Stripe.publishableKey = dotenv.env['STRIPE_PUBLIC_KEY'] ?? '';
+  if (Stripe.publishableKey.isNotEmpty) {
+    await Stripe.instance.applySettings();
+  }
 
   initApiClient();
   initAuthInterceptor();

--- a/lib/screens/payment_page.dart
+++ b/lib/screens/payment_page.dart
@@ -4,6 +4,8 @@ import '../models/slot.dart';
 import '../services/booking_service.dart';
 import '../services/payment_service.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
+import 'package:flutter/services.dart';
+import 'package:dio/dio.dart';
 import '../providers.dart';
 import 'booking_confirmation_page.dart';
 
@@ -42,6 +44,13 @@ class _PaymentPageState extends ConsumerState<PaymentPage> {
   }
 
   Future<void> _pay() async {
+    if (Stripe.publishableKey.isEmpty) {
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Stripe key missing')),
+      );
+      return;
+    }
+
     setState(() => loading = true);
     try {
       final data = await paymentService.createIntent(widget.slot.id);
@@ -52,8 +61,13 @@ class _PaymentPageState extends ConsumerState<PaymentPage> {
         ),
       );
       await Stripe.instance.presentPaymentSheet();
+
       await Future.delayed(const Duration(seconds: 2));
-      final booking = await paymentService.fetchBooking(data['booking_id'] as int);
+      final bookings = await bookingService.fetchMine();
+      final booking = bookings.firstWhere(
+        (b) => b.slot.id == widget.slot.id,
+        orElse: () => bookings.first,
+      );
       ref.invalidate(bookingsProvider);
       if (!mounted) return;
       Navigator.pushReplacement(
@@ -62,6 +76,22 @@ class _PaymentPageState extends ConsumerState<PaymentPage> {
           builder: (_) => BookingConfirmationPage(booking: booking),
         ),
       );
+    } on DioException catch (e) {
+      final detail = e.response?.data is Map
+          ? e.response?.data['detail']?.toString()
+          : null;
+      final msg = detail ?? 'HTTP ${e.response?.statusCode ?? ''}: ${e.message}';
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text(msg)));
+      }
+    } on PlatformException catch (e) {
+      if (e.code == FailureCode.Canceled) {
+        // user dismissed sheet
+      } else if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('${e.code}: ${e.message}')));
+      }
     } catch (e) {
       if (mounted) {
         ScaffoldMessenger.of(context)

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -1,5 +1,4 @@
 import 'package:dio/dio.dart';
-import '../models/booking.dart';
 import 'api_client.dart';
 
 class PaymentService {
@@ -13,11 +12,6 @@ class PaymentService {
           : e.message;
       throw Exception(msg ?? 'Payment checkout failed');
     }
-  }
-
-  Future<Booking> fetchBooking(int bookingId) async {
-    final res = await apiClient.get('/bookings/' + bookingId.toString() + '/');
-    return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 }
 


### PR DESCRIPTION
## Android
- `MainActivity` now extends `FlutterFragmentActivity`
- minSdk set to 21
- Kotlin plugin version set to 1.9.22
- Manifest adds `INTERNET` permission

## Flutter
- Stripe publishable key loaded before `runApp` and `applySettings` called
- Payment button handles duplicate taps and shows better errors

## Backend (Path A)
- `/payments/checkout/` only creates a `PaymentIntent`
- `payment_intent.succeeded` webhook creates the booking
- Tests updated accordingly

## Verification steps
1. `flutter clean && flutter pub get && flutter run`
2. First tap on **Pay & Book** shows PaymentSheet without `FlutterFragmentActivity` error
3. Pay with `4242 4242 4242 4242` → booking confirmed
4. Canceling payment allows retry without conflict


------
https://chatgpt.com/codex/tasks/task_e_68864d40de088326b4abe740b1a9b139