### PR TITLE
Implement category results filtering

### DIFF
--- a/backend/sports/admin.py
+++ b/backend/sports/admin.py
@@ -43,6 +43,7 @@ class CategoryAdmin(admin.ModelAdmin):
     def image_preview(self, obj):
         if obj.image:
             from django.utils.html import format_html
+
             return format_html('<img src="{}" style="height:50px"/>', obj.image.url)
         return "-"
 
@@ -83,14 +84,15 @@ class ActivityAdmin(admin.ModelAdmin):
     def image_preview(self, obj):
         if obj.image:
             from django.utils.html import format_html
+
             return format_html('<img src="{}" style="height:60px"/>', obj.image.url)
         return "-"
 
 
 @admin.register(FeaturedCategory)
 class FeaturedCategoryAdmin(admin.ModelAdmin):
-    list_display = ("category", "order")
-    list_editable = ("order",)
+    list_display = ("category", "display_order", "show_on_home")
+    list_editable = ("display_order", "show_on_home")
 
 
 @admin.register(FeaturedActivity)

--- a/backend/sports/migrations/0016_home_category_update.py
+++ b/backend/sports/migrations/0016_home_category_update.py
@@ -1,0 +1,24 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("sports", "0015_add_payment_intent_id"),
+    ]
+
+    operations = [
+        migrations.RenameField(
+            model_name="featuredcategory",
+            old_name="order",
+            new_name="display_order",
+        ),
+        migrations.AddField(
+            model_name="featuredcategory",
+            name="show_on_home",
+            field=models.BooleanField(default=True),
+        ),
+        migrations.AlterModelOptions(
+            name="featuredcategory",
+            options={"ordering": ("display_order",)},
+        ),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -21,7 +21,7 @@ class Sport(models.Model):
     class Meta:
         ordering = ("name",)
 
-    def __str__(self) -> str:                # pragma: no cover
+    def __str__(self) -> str:  # pragma: no cover
         return self.name
 
 
@@ -40,7 +40,9 @@ class SportCategory(models.Model):
 
     class Meta:
         ordering = ("name",)
-        constraints = [UniqueConstraint(fields=["parent", "name"], name="uniq_cat_parent_name")]
+        constraints = [
+            UniqueConstraint(fields=["parent", "name"], name="uniq_cat_parent_name")
+        ]
 
     def __str__(self) -> str:  # pragma: no cover
         return self.full_path
@@ -53,6 +55,7 @@ class SportCategory(models.Model):
             parts.append(p.name)
             p = p.parent
         return " / ".join(reversed(parts))
+
 
 # ───────────────────────────────── Category ───────────────────────────────
 class Category(models.Model):
@@ -180,15 +183,12 @@ class Slot(models.Model):
     begins_at = models.DateTimeField()
     ends_at = models.DateTimeField()
 
-    capacity = models.PositiveSmallIntegerField(
-        validators=[MinValueValidator(1)]
-    )
+    capacity = models.PositiveSmallIntegerField(validators=[MinValueValidator(1)])
     price = models.DecimalField(  # 0.00 ⇒ free
         max_digits=7, decimal_places=2, default=0
     )
     rating = models.DecimalField(  # NEW: matches serializer / seed
-        max_digits=3, decimal_places=1, default=0,
-        help_text="Average rating 0–5"
+        max_digits=3, decimal_places=1, default=0, help_text="Average rating 0–5"
     )
     activity = models.ForeignKey(
         "Activity",
@@ -211,7 +211,7 @@ class Slot(models.Model):
             self.sport_id = self.activity.sport_id
         super().save(*args, **kwargs)
 
-    def __str__(self) -> str:                # pragma: no cover
+    def __str__(self) -> str:  # pragma: no cover
         return f"{self.title} @ {self.begins_at:%Y-%m-%d %H:%M}"
 
 
@@ -219,9 +219,7 @@ class Slot(models.Model):
 class Booking(models.Model):
     """User reservation of a slot (unique per user+slot)."""
 
-    slot = models.ForeignKey(
-        Slot, related_name="bookings", on_delete=models.PROTECT
-    )
+    slot = models.ForeignKey(Slot, related_name="bookings", on_delete=models.PROTECT)
     activity = models.ForeignKey(
         "Activity",
         related_name="bookings",
@@ -244,7 +242,7 @@ class Booking(models.Model):
         ordering = ("-booked_at",)
         unique_together = ("slot", "user")
 
-    def __str__(self) -> str:                # pragma: no cover
+    def __str__(self) -> str:  # pragma: no cover
         return f"{self.user} → {self.slot} ({self.pax})"
 
 
@@ -254,10 +252,11 @@ class FeaturedCategory(models.Model):
 
     category = models.ForeignKey(Category, on_delete=models.CASCADE)
     image = models.ImageField(upload_to="home_categories/")
-    order = models.PositiveSmallIntegerField(default=0)
+    display_order = models.PositiveSmallIntegerField(default=0)
+    show_on_home = models.BooleanField(default=True)
 
     class Meta:
-        ordering = ("order",)
+        ordering = ("display_order",)
 
     def __str__(self) -> str:  # pragma: no cover
         return self.category.name
@@ -284,7 +283,9 @@ class Review(models.Model):
         on_delete=models.CASCADE,
     )
     user = models.ForeignKey("auth.User", on_delete=models.CASCADE)
-    rating = models.PositiveSmallIntegerField(validators=[MinValueValidator(1), MaxValueValidator(5)])
+    rating = models.PositiveSmallIntegerField(
+        validators=[MinValueValidator(1), MaxValueValidator(5)]
+    )
     comment = models.TextField(blank=True)
     created_at = models.DateTimeField(default=timezone.now)
 
@@ -323,4 +324,3 @@ class UserActivityHistory(models.Model):
 
     class Meta:
         ordering = ("-timestamp",)
-

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -168,7 +168,7 @@ class ActivitySimpleSerializer(serializers.ModelSerializer):
 class FeaturedCategorySerializer(serializers.ModelSerializer):
     class Meta:
         model = FeaturedCategory
-        fields = ("id", "category", "image", "order")
+        fields = ("id", "category", "image", "display_order", "show_on_home")
 
 
 class FeaturedActivitySerializer(serializers.ModelSerializer):

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -2,7 +2,8 @@
 from django.db import models, transaction
 from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
-from rest_framework import viewsets, permissions, status, serializers
+from rest_framework import viewsets, permissions, status, serializers, pagination
+from django.db.models import Avg, Min
 from accounts.permissions import IsVendor
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -61,6 +62,12 @@ class FeaturedCategoryViewSet(viewsets.ModelViewSet):
             return [permissions.IsAdminUser()]
         return [permissions.AllowAny]
 
+    def get_queryset(self):
+        qs = super().get_queryset()
+        if self.request.query_params.get("home") == "true":
+            qs = qs.filter(show_on_home=True).order_by("display_order")
+        return qs
+
 
 class FeaturedActivityViewSet(viewsets.ModelViewSet):
     queryset = FeaturedActivity.objects.select_related("activity")
@@ -94,10 +101,13 @@ class SportCategoryViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         parent = serializer.validated_data.get("parent")
         name = serializer.validated_data.get("name")
-        if SportCategory.objects.filter(parent=parent, name=name).exclude(pk=serializer.instance.pk).exists():
+        if (
+            SportCategory.objects.filter(parent=parent, name=name)
+            .exclude(pk=serializer.instance.pk)
+            .exists()
+        ):
             raise serializers.ValidationError({"name": "Name exists"})
         serializer.save()
-
 
 
 class VariantViewSet(viewsets.ReadOnlyModelViewSet):
@@ -108,6 +118,13 @@ class VariantViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ActivityViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitySerializer
+
+    class Pagination(pagination.PageNumberPagination):
+        page_size = 10
+        page_size_query_param = "page_size"
+
+    pagination_class = Pagination
+
     def get_permissions(self):
         if self.action in ("create", "update", "partial_update", "destroy"):
             perms = [permissions.IsAuthenticated, IsVendor]
@@ -120,9 +137,52 @@ class ActivityViewSet(viewsets.ModelViewSet):
         mine = self.request.query_params.get("mine")
         if mine == "1" and self.request.user.is_authenticated:
             qs = qs.filter(owner=self.request.user)
+
         nearby = self.request.query_params.get("nearby")
         if nearby == "1":
             qs = qs.filter(is_nearby=True)
+
+        category_ids = self.request.query_params.get("category")
+        if category_ids:
+            try:
+                ids = [int(c) for c in category_ids.split(",")]
+                qs = qs.filter(discipline_id__in=ids)
+            except ValueError:
+                pass
+
+        after = self.request.query_params.get("after")
+        if after:
+            try:
+                dt = timezone.datetime.fromisoformat(after)
+                qs = qs.filter(slots__begins_at__gte=dt)
+            except ValueError:
+                pass
+
+        before = self.request.query_params.get("before")
+        if before:
+            try:
+                dt = timezone.datetime.fromisoformat(before)
+                qs = qs.filter(slots__begins_at__lte=dt)
+            except ValueError:
+                pass
+
+        qs = qs.annotate(
+            next_slot=Min("slots__begins_at"),
+            avg_rating=Avg("reviews__rating"),
+        ).distinct()
+
+        ordering = self.request.query_params.get("ordering")
+        mapping = {
+            "price": "base_price",
+            "-price": "-base_price",
+            "rating": "avg_rating",
+            "-rating": "-avg_rating",
+            "begins_at": "next_slot",
+            "-begins_at": "-next_slot",
+        }
+        if ordering in mapping:
+            qs = qs.order_by(mapping[ordering])
+
         return qs
 
     def perform_create(self, serializer):
@@ -243,12 +303,17 @@ class BookingViewSet(viewsets.ModelViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+
 class ActivityReviewList(APIView):
     permission_classes = [permissions.AllowAny]
 
     def get(self, request, activity_id):
         limit = request.query_params.get("limit")
-        qs = Review.objects.filter(activity_id=activity_id).select_related("user").order_by("-created_at")
+        qs = (
+            Review.objects.filter(activity_id=activity_id)
+            .select_related("user")
+            .order_by("-created_at")
+        )
         if limit:
             try:
                 qs = qs[: int(limit)]
@@ -271,18 +336,16 @@ class ContinuePlanningView(APIView):
 
     def get(self, request):
         user = request.user
-        histories = (
-            UserActivityHistory.objects.filter(user=user)
-            .order_by("-timestamp")[:20]
-        )
+        histories = UserActivityHistory.objects.filter(user=user).order_by(
+            "-timestamp"
+        )[:20]
         act_ids = []
         for h in histories:
             if h.activity_id not in act_ids:
                 act_ids.append(h.activity_id)
 
-        unfinished = (
-            Booking.objects.filter(user=user, paid=False)
-            .values_list("activity_id", flat=True)
+        unfinished = Booking.objects.filter(user=user, paid=False).values_list(
+            "activity_id", flat=True
         )
         for aid in unfinished:
             if aid and aid not in act_ids:
@@ -290,9 +353,7 @@ class ContinuePlanningView(APIView):
 
         acts = {a.id: a for a in Activity.objects.filter(id__in=act_ids)}
         ordered = [acts[a] for a in act_ids if a in acts]
-        ser = ActivitySimpleSerializer(
-            ordered, many=True, context={"request": request}
-        )
+        ser = ActivitySimpleSerializer(ordered, many=True, context={"request": request})
         return Response(ser.data)
 
 
@@ -303,12 +364,8 @@ class BulkSlotCreateView(APIView):
         try:
             facility = Facility.objects.get(pk=request.data.get("facility"))
             sport = Sport.objects.get(pk=request.data.get("sport"))
-            start = timezone.datetime.fromisoformat(
-                request.data.get("start_time")
-            )
-            end = timezone.datetime.fromisoformat(
-                request.data.get("end_time")
-            )
+            start = timezone.datetime.fromisoformat(request.data.get("start_time"))
+            end = timezone.datetime.fromisoformat(request.data.get("end_time"))
             interval = int(request.data.get("interval"))
         except Exception:
             return Response({"detail": "Invalid parameters"}, status=400)
@@ -323,8 +380,7 @@ class BulkSlotCreateView(APIView):
                     title=f"{sport.name} {current:%H:%M}",
                     location=facility.name,
                     begins_at=current,
-                    ends_at=current
-                    + timezone.timedelta(minutes=interval),
+                    ends_at=current + timezone.timedelta(minutes=interval),
                     capacity=request.data.get("capacity", 1),
                     price=request.data.get("price", 0),
                 )

--- a/backend/tests/test_activity_filters.py
+++ b/backend/tests/test_activity_filters.py
@@ -1,0 +1,62 @@
+import pytest
+from django.utils import timezone
+from rest_framework.test import APIClient
+from sports.models import Sport, Category, Activity, Slot, FeaturedCategory
+
+pytestmark = pytest.mark.django_db
+
+
+def create_activity(cat, sport, title="A"):
+    act = Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title=title,
+        difficulty=1,
+        duration=60,
+        base_price=10,
+    )
+    Slot.objects.create(
+        sport=sport,
+        activity=act,
+        title="S",
+        location="L",
+        begins_at=timezone.now() + timezone.timedelta(hours=1),
+        ends_at=timezone.now() + timezone.timedelta(hours=2),
+        capacity=5,
+        price=0,
+        rating=0,
+    )
+    return act
+
+
+def test_filter_activities_by_category():
+    client = APIClient()
+    sport = Sport.objects.create(name="Surf")
+    cat1 = Category.objects.create(name="Water")
+    cat2 = Category.objects.create(name="Land")
+    create_activity(cat1, sport, "A1")
+    create_activity(cat2, sport, "A2")
+    resp = client.get("/api/activities/", {"category": cat1.id})
+    assert resp.status_code == 200
+    assert all(a["discipline"] == cat1.id for a in resp.data["results"])
+
+
+def test_filter_includes_descendants():
+    client = APIClient()
+    sport = Sport.objects.create(name="Run")
+    cat = Category.objects.create(name="Parent")
+    create_activity(cat, sport, "ParentAct")
+    resp = client.get("/api/activities/", {"category": cat.id})
+    assert resp.status_code == 200
+    assert len(resp.data["results"]) == 1
+
+
+def test_featured_categories_ordering():
+    client = APIClient()
+    cat = Category.objects.create(name="C")
+    f1 = FeaturedCategory.objects.create(category=cat, image="a.jpg", display_order=2)
+    f2 = FeaturedCategory.objects.create(category=cat, image="b.jpg", display_order=1)
+    resp = client.get("/api/featured-categories/", {"home": "true"})
+    assert resp.status_code == 200
+    ids = [f["id"] for f in resp.data]
+    assert ids == [f2.id, f1.id]

--- a/lib/models/activity_page.dart
+++ b/lib/models/activity_page.dart
@@ -1,0 +1,16 @@
+import 'activity.dart';
+
+class ActivityPage {
+  ActivityPage({required this.results, required this.count});
+
+  final List<Activity> results;
+  final int count;
+
+  factory ActivityPage.fromJson(Map<String, dynamic> j) => ActivityPage(
+        results: (j['results'] as List)
+            .cast<Map<String, dynamic>>()
+            .map(Activity.fromJson)
+            .toList(growable: false),
+        count: j['count'] as int? ?? 0,
+      );
+}

--- a/lib/models/featured_category.dart
+++ b/lib/models/featured_category.dart
@@ -1,15 +1,17 @@
 class FeaturedCategory {
-  FeaturedCategory({required this.id, required this.category, required this.image, required this.order});
+  FeaturedCategory({required this.id, required this.category, required this.image, required this.displayOrder, required this.showOnHome});
 
   final int id;
   final int category;
   final String image;
-  final int order;
+  final int displayOrder;
+  final bool showOnHome;
 
   factory FeaturedCategory.fromJson(Map<String, dynamic> j) => FeaturedCategory(
         id: j['id'] as int,
         category: j['category'] as int,
         image: j['image'] as String? ?? '',
-        order: j['order'] as int? ?? 0,
+        displayOrder: j['display_order'] as int? ?? 0,
+        showOnHome: j['show_on_home'] as bool? ?? true,
       );
 }

--- a/lib/providers/activity_by_category_provider.dart
+++ b/lib/providers/activity_by_category_provider.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/activity_page.dart';
+import '../services/activity_service.dart';
+
+class ActivityQuery {
+  const ActivityQuery({required this.categoryId, this.ordering, this.page = 1});
+  final int categoryId;
+  final String? ordering;
+  final int page;
+}
+
+final activitiesByCategoryProvider =
+    FutureProvider.family<ActivityPage, ActivityQuery>((ref, query) async {
+  return activityService.fetchByCategory(
+    query.categoryId,
+    ordering: query.ordering,
+    page: query.page,
+  );
+});

--- a/lib/screens/categories_page.dart
+++ b/lib/screens/categories_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/category_card.dart';
 import '../providers/category_provider.dart';
+import 'category_results_page.dart';
 
 class CategoriesPage extends ConsumerWidget {
   const CategoriesPage({super.key});
@@ -29,7 +30,15 @@ class CategoriesPage extends ConsumerWidget {
               title: cats[i].name,
               asset: cats[i].icon,
               imageUrl: cats[i].imageUrl,
-              onTap: () {},
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => CategoryResultsPage(
+                    categoryId: cats[i].id,
+                    title: cats[i].name,
+                  ),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/screens/category_results_page.dart
+++ b/lib/screens/category_results_page.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/activity.dart';
+import '../providers/activity_by_category_provider.dart';
+import '../widgets/activity_card.dart';
+import 'activity_detail_page.dart';
+
+class CategoryResultsPage extends ConsumerStatefulWidget {
+  const CategoryResultsPage({super.key, required this.categoryId, required this.title});
+  final int categoryId;
+  final String title;
+
+  @override
+  ConsumerState<CategoryResultsPage> createState() => _CategoryResultsPageState();
+}
+
+class _CategoryResultsPageState extends ConsumerState<CategoryResultsPage> {
+  int _page = 1;
+  String? _ordering;
+  final List<Activity> _activities = [];
+  bool _loadingMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async {
+    final page = await ref
+        .read(activitiesByCategoryProvider(ActivityQuery(categoryId: widget.categoryId, ordering: _ordering, page: _page)).future);
+    setState(() {
+      if (_page == 1) _activities.clear();
+      _activities.addAll(page.results);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.title)),
+      body: ListView.builder(
+        padding: const EdgeInsets.all(16),
+        itemCount: _activities.length + 1,
+        itemBuilder: (_, i) {
+          if (i < _activities.length) {
+            final act = _activities[i];
+            final img = act.imageUrl ?? act.image;
+            return Padding(
+              padding: const EdgeInsets.only(bottom: 12),
+              child: ActivityCard(
+                title: act.title,
+                location: '',
+                price: act.basePrice,
+                rating: 0,
+                reviews: 0,
+                asset: img,
+                onTap: () => Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => ActivityDetailPage(activity: act)),
+                ),
+                onFavorite: () {},
+                isFavorite: false,
+              ),
+            );
+          }
+          if (_loadingMore) {
+            return const Center(child: Padding(padding: EdgeInsets.all(16), child: CircularProgressIndicator()));
+          }
+          return ElevatedButton(
+            onPressed: () async {
+              setState(() => _loadingMore = true);
+              _page += 1;
+              await _load();
+              setState(() => _loadingMore = false);
+            },
+            child: const Text('Load More'),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -11,6 +11,7 @@ import '../widgets/activity_card.dart';
 import '../widgets/project_card.dart';
 import '../widgets/search_bar.dart';
 import 'categories_page.dart';
+import 'category_results_page.dart';
 
 import '../providers.dart';                                   // ← new (sportsProvider)
 import '../providers/category_provider.dart';
@@ -237,7 +238,15 @@ class _HomePageState extends ConsumerState<HomePage> {
                           title: c.name,
                           asset: c.icon,
                           imageUrl: c.imageUrl,
-                          onTap: () {},
+                          onTap: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => CategoryResultsPage(
+                                categoryId: c.id,
+                                title: c.name,
+                              ),
+                            ),
+                          ),
                         );
                       }
                       return MoreCategoryCard(

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -24,6 +24,21 @@ class ActivityService {
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
+  Future<ActivityPage> fetchByCategory(
+    int categoryId, {
+    String? ordering,
+    int page = 1,
+    int pageSize = 10,
+  }) async {
+    final res = await apiClient.get('/activities/', queryParameters: {
+      'category': categoryId,
+      if (ordering != null) 'ordering': ordering,
+      'page': page,
+      'page_size': pageSize,
+    });
+    return ActivityPage.fromJson(res.data as Map<String, dynamic>);
+  }
+
   Future<void> createActivity(
     int sport,
     int discipline,


### PR DESCRIPTION
## Summary
- extend FeaturedCategory with display_order and show_on_home
- add filtering/sorting to ActivityViewSet
- expose home categories filtering endpoint
- create ActivityPage models and providers
- add CategoryResultsPage and navigation
- add backend tests for new filters

## Testing
- `black backend/sports` *(passed)*
- `flake8 backend/sports` *(failed: E501 and others)*
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend/tests/test_activity_filters.py -q` *(failed: SpatiaLite requires SQLite to allow extension loading)*

------
https://chatgpt.com/codex/tasks/task_e_688748b1d8108326aabca8bcd3139dfc