### PR TITLE
Add category filter and list page

### DIFF
--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -123,6 +123,12 @@ class ActivityViewSet(viewsets.ModelViewSet):
         nearby = self.request.query_params.get("nearby")
         if nearby == "1":
             qs = qs.filter(is_nearby=True)
+        category_id = self.request.query_params.get("category")
+        if category_id:
+            try:
+                qs = qs.filter(discipline_id=int(category_id))
+            except (TypeError, ValueError):
+                qs = qs.none()
         return qs
 
     def perform_create(self, serializer):

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../models/category.dart';
+import '../models/activity.dart';
+import '../services/activity_service.dart';
+import '../widgets/activity_card.dart';
+import 'activity_detail_page.dart';
+
+class ActivitiesByCategoryPage extends ConsumerWidget {
+  final Category category;
+  const ActivitiesByCategoryPage({super.key, required this.category});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final asyncActs = ref.watch(_activitiesByCategoryProvider(category.id));
+    return Scaffold(
+      appBar: AppBar(title: Text(category.name)),
+      body: asyncActs.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(child: Text('Failed: $e')),
+        data: (items) => items.isEmpty
+            ? const Center(child: Text('No activities in this category yet'))
+            : ListView.separated(
+                padding: const EdgeInsets.all(16),
+                itemCount: items.length,
+                separatorBuilder: (_, __) => const SizedBox(height: 12),
+                itemBuilder: (_, i) {
+                  final a = items[i];
+                  final image = a.imageUrl ?? a.image;
+                  return ActivityCard(
+                    title: a.title,
+                    location: '',
+                    price: a.basePrice,
+                    rating: 0,
+                    reviews: 0,
+                    asset: image,
+                    isFavorite: false,
+                    onFavorite: () {},
+                    onTap: () => Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (_) => ActivityDetailPage(activity: a),
+                      ),
+                    ),
+                  );
+                },
+              ),
+      ),
+    );
+  }
+}
+
+final _activitiesByCategoryProvider =
+    FutureProvider.family<List<Activity>, int>((ref, id) async {
+  return activityService.fetchByCategory(id);
+});
+

--- a/lib/screens/categories_page.dart
+++ b/lib/screens/categories_page.dart
@@ -3,6 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/category_card.dart';
 import '../providers/category_provider.dart';
+import '../models/category.dart';
+import 'activities_by_category_page.dart';
 
 class CategoriesPage extends ConsumerWidget {
   const CategoriesPage({super.key});
@@ -29,7 +31,13 @@ class CategoriesPage extends ConsumerWidget {
               title: cats[i].name,
               asset: cats[i].icon,
               imageUrl: cats[i].imageUrl,
-              onTap: () {},
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) =>
+                      ActivitiesByCategoryPage(category: cats[i]),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -11,6 +11,8 @@ import '../widgets/activity_card.dart';
 import '../widgets/project_card.dart';
 import '../widgets/search_bar.dart';
 import 'categories_page.dart';
+import '../models/category.dart';
+import 'activities_by_category_page.dart';
 
 import '../providers.dart';                                   // ← new (sportsProvider)
 import '../providers/category_provider.dart';
@@ -237,7 +239,21 @@ class _HomePageState extends ConsumerState<HomePage> {
                           title: c.name,
                           asset: c.icon,
                           imageUrl: c.imageUrl,
-                          onTap: () {},
+                          onTap: () {
+                            final cat = Category(
+                              id: c.id,
+                              name: c.name,
+                              icon: c.icon,
+                              imageUrl: c.imageUrl,
+                            );
+                            Navigator.push(
+                              context,
+                              MaterialPageRoute(
+                                builder: (_) =>
+                                    ActivitiesByCategoryPage(category: cat),
+                              ),
+                            );
+                          },
                         );
                       }
                       return MoreCategoryCard(

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -19,6 +19,15 @@ class ActivityService {
         .toList();
   }
 
+  Future<List<Activity>> fetchByCategory(int categoryId) async {
+    final res = await apiClient
+        .get('/activities/', queryParameters: {'category': '$categoryId'});
+    return (res.data as List)
+        .cast<Map<String, dynamic>>()
+        .map(Activity.fromJson)
+        .toList();
+  }
+
   Future<Activity> fetchById(int id) async {
     final Response res = await apiClient.get('/activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);


### PR DESCRIPTION
## Summary
- filter activities by category on the backend
- add ActivityService.fetchByCategory
- new ActivitiesByCategoryPage showing activities under a category
- hook up category taps on home and all categories pages

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend/tests/test_activity_api.py::test_activity_list -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_688757f5d8308326a27375d3d6279cbb