### PR TITLE
Implement category activity list

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,22 @@ provider profile which can be updated via `/api/provider/profile/`.
 - JWT authentication with email or Google
 - Flutter client using Riverpod state management
 
+## Activities by Category API
+
+`GET /api/activities/?category=<id>&page=<n>&page_size=<m>` returns activities
+filtered by the given category. Results are paginated using DRF's standard
+structure.
+
+```bash
+curl -s "http://127.0.0.1:8000/api/activities/?category=1&page=1&page_size=20"
+```
+
+Ensure the backend is running (`python backend/manage.py runserver`) before
+issuing the request.
+
+On the client you can tap any category card to view its activities, pull down to
+refresh and load more when reaching the end of the list.
+
 ## Payments and Stripe
 
 The backend uses Stripe for processing payments. Obtain test keys from your

--- a/README.md
+++ b/README.md
@@ -123,11 +123,15 @@ provider profile which can be updated via `/api/provider/profile/`.
 ## Activities by Category API
 
 `GET /api/activities/?category=<id>&page=<n>&page_size=<m>` returns activities
-filtered by the given category. Results are paginated using DRF's standard
-structure.
+filtered by the given category. All activity list endpoints now return a
+paginated JSON object with `count`, `next`, `previous` and `results` fields.
+Use the items under `results` on the client.
+
+Disable pagination temporarily by passing `?no_page=1`.
 
 ```bash
 curl -s "http://127.0.0.1:8000/api/activities/?category=1&page=1&page_size=20"
+curl -s "http://127.0.0.1:8000/api/activities/?no_page=1"
 ```
 
 Ensure the backend is running (`python backend/manage.py runserver`) before

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -1,11 +1,12 @@
 # sports/views.py
-from django.db import models, transaction
+from django.db import transaction
 from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
 from rest_framework import viewsets, permissions, status, serializers
 from accounts.permissions import IsVendor
 from rest_framework.views import APIView
 from rest_framework.response import Response
+from rest_framework.pagination import PageNumberPagination
 from django.utils import timezone
 
 from .models import (
@@ -38,6 +39,13 @@ from .serializers import (
     ReviewSerializer,
     SlotCreateSerializer,
 )
+
+
+class DefaultPagination(PageNumberPagination):
+    """Simple page-number pagination with 20 items per page."""
+
+    page_size = 20
+    page_size_query_param = "page_size"
 
 
 class SportViewSet(viewsets.ReadOnlyModelViewSet):
@@ -94,10 +102,13 @@ class SportCategoryViewSet(viewsets.ModelViewSet):
     def perform_update(self, serializer):
         parent = serializer.validated_data.get("parent")
         name = serializer.validated_data.get("name")
-        if SportCategory.objects.filter(parent=parent, name=name).exclude(pk=serializer.instance.pk).exists():
+        if (
+            SportCategory.objects.filter(parent=parent, name=name)
+            .exclude(pk=serializer.instance.pk)
+            .exists()
+        ):
             raise serializers.ValidationError({"name": "Name exists"})
         serializer.save()
-
 
 
 class VariantViewSet(viewsets.ReadOnlyModelViewSet):
@@ -108,6 +119,8 @@ class VariantViewSet(viewsets.ReadOnlyModelViewSet):
 
 class ActivityViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitySerializer
+    pagination_class = DefaultPagination
+
     def get_permissions(self):
         if self.action in ("create", "update", "partial_update", "destroy"):
             perms = [permissions.IsAuthenticated, IsVendor]
@@ -123,6 +136,12 @@ class ActivityViewSet(viewsets.ModelViewSet):
         nearby = self.request.query_params.get("nearby")
         if nearby == "1":
             qs = qs.filter(is_nearby=True)
+        category = self.request.query_params.get("category")
+        if category:
+            try:
+                qs = qs.filter(discipline_id=int(category))
+            except (TypeError, ValueError):
+                qs = qs.none()
         return qs
 
     def perform_create(self, serializer):
@@ -192,12 +211,14 @@ class SlotViewSet(viewsets.ReadOnlyModelViewSet):
             qs = qs.filter(activity_id=activity_id)
         if after:
             try:
-                qs = qs.filter(begins_at__gte=timezone.datetime.fromisoformat(after))
+                dt = timezone.datetime.fromisoformat(after)
+                qs = qs.filter(begins_at__gte=dt)
             except ValueError:
                 pass
         if before:
             try:
-                qs = qs.filter(begins_at__lte=timezone.datetime.fromisoformat(before))
+                dt = timezone.datetime.fromisoformat(before)
+                qs = qs.filter(begins_at__lte=dt)
             except ValueError:
                 pass
         return qs
@@ -243,12 +264,17 @@ class BookingViewSet(viewsets.ModelViewSet):
             status=status.HTTP_201_CREATED,
         )
 
+
 class ActivityReviewList(APIView):
     permission_classes = [permissions.AllowAny]
 
     def get(self, request, activity_id):
         limit = request.query_params.get("limit")
-        qs = Review.objects.filter(activity_id=activity_id).select_related("user").order_by("-created_at")
+        qs = (
+            Review.objects.filter(activity_id=activity_id)
+            .select_related("user")
+            .order_by("-created_at")
+        )
         if limit:
             try:
                 qs = qs[: int(limit)]
@@ -351,8 +377,9 @@ class MerchantBookingList(APIView):
     permission_classes = [permissions.IsAuthenticated, IsVendor]
 
     def get(self, request):
-        qs = Booking.objects.filter(activity__owner=request.user).select_related(
-            "slot", "user"
+        qs = (
+            Booking.objects.filter(activity__owner=request.user)
+            .select_related("slot", "user")
         )
         ser = BookingSerializer(qs, many=True)
         return Response(ser.data)

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -144,6 +144,11 @@ class ActivityViewSet(viewsets.ModelViewSet):
                 qs = qs.none()
         return qs
 
+    def list(self, request, *args, **kwargs):
+        if request.query_params.get("no_page") == "1":
+            self.pagination_class = None
+        return super().list(request, *args, **kwargs)
+
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
 

--- a/backend/tests/test_activity_api.py
+++ b/backend/tests/test_activity_api.py
@@ -1,13 +1,13 @@
 import django
 django.setup()  # noqa: E402
 import pytest  # noqa: E402
-from rest_framework.test import APIClient  # noqa: E402
 from sports.models import (  # noqa: E402
     Sport,
     Category,
     Variant,
     Facility,
     Slot,
+    Activity,
 )
 from django.utils import timezone  # noqa: E402
 
@@ -73,3 +73,37 @@ def test_bulk_slot_create(auth_client):
     assert resp.status_code == 201
     assert resp.data["created"] >= 1
     assert Slot.objects.count() == resp.data["created"]
+
+
+def test_filter_activities_by_category(client):
+    sport = Sport.objects.create(name="Row")
+    cat1 = Category.objects.create(name="Water")
+    cat2 = Category.objects.create(name="Land")
+    act = Activity.objects.create(
+        sport=sport,
+        discipline=cat1,
+        title="Rowing",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    )
+    Activity.objects.create(
+        sport=sport,
+        discipline=cat2,
+        title="Biking",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    )
+    resp = client.get("/api/activities/", {"category": cat1.id})
+    assert resp.status_code == 200
+    assert resp.data["count"] == 1
+    assert resp.data["results"][0]["id"] == act.id
+
+
+def test_filter_activities_invalid_category(client):
+    resp = client.get("/api/activities/", {"category": "bad"})
+    assert resp.status_code == 200
+    assert resp.data["results"] == []

--- a/backend/tests/test_activity_api.py
+++ b/backend/tests/test_activity_api.py
@@ -107,3 +107,22 @@ def test_filter_activities_invalid_category(client):
     resp = client.get("/api/activities/", {"category": "bad"})
     assert resp.status_code == 200
     assert resp.data["results"] == []
+
+
+def test_list_no_pagination(client):
+    sport = Sport.objects.create(name="Run")
+    cat = Category.objects.create(name="Track")
+    for i in range(5):
+        Activity.objects.create(
+            sport=sport,
+            discipline=cat,
+            title=f"Run {i}",
+            description="",
+            difficulty=1,
+            duration=60,
+            base_price=0,
+        )
+    resp = client.get("/api/activities/", {"no_page": 1})
+    assert resp.status_code == 200
+    assert isinstance(resp.data, list)
+    assert len(resp.data) >= 5

--- a/lib/models/paginated.dart
+++ b/lib/models/paginated.dart
@@ -27,4 +27,16 @@ class Paginated<T> {
       results: list,
     );
   }
+
+  factory Paginated.fromList(
+    List<Map<String, dynamic>> list,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    return Paginated(
+      count: list.length,
+      next: null,
+      previous: null,
+      results: list.map(fromJson).toList(growable: false),
+    );
+  }
 }

--- a/lib/models/paginated.dart
+++ b/lib/models/paginated.dart
@@ -1,0 +1,30 @@
+class Paginated<T> {
+  Paginated({
+    required this.count,
+    required this.next,
+    required this.previous,
+    required this.results,
+  });
+
+  final int count;
+  final String? next;
+  final String? previous;
+  final List<T> results;
+
+  factory Paginated.fromJson(
+    Map<String, dynamic> json,
+    T Function(Map<String, dynamic>) fromJson,
+  ) {
+    final list = (json['results'] as List?)
+            ?.cast<Map<String, dynamic>>()
+            .map(fromJson)
+            .toList(growable: false) ??
+        <T>[];
+    return Paginated(
+      count: json['count'] as int? ?? 0,
+      next: json['next'] as String?,
+      previous: json['previous'] as String?,
+      results: list,
+    );
+  }
+}

--- a/lib/providers/activity_provider.dart
+++ b/lib/providers/activity_provider.dart
@@ -3,11 +3,11 @@ import '../models/activity.dart';
 import '../models/paginated.dart';
 import '../services/activity_service.dart';
 
-final activitiesProvider = FutureProvider<List<Activity>>((ref) async {
+final activitiesProvider = FutureProvider<Paginated<Activity>>((ref) async {
   return activityService.fetchMine();
 });
 
-final nearbyActivitiesProvider = FutureProvider<List<Activity>>((ref) async {
+final nearbyActivitiesProvider = FutureProvider<Paginated<Activity>>((ref) async {
   return activityService.fetchNearby();
 });
 

--- a/lib/providers/activity_provider.dart
+++ b/lib/providers/activity_provider.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/activity.dart';
+import '../models/paginated.dart';
 import '../services/activity_service.dart';
 
 final activitiesProvider = FutureProvider<List<Activity>>((ref) async {
@@ -8,4 +9,9 @@ final activitiesProvider = FutureProvider<List<Activity>>((ref) async {
 
 final nearbyActivitiesProvider = FutureProvider<List<Activity>>((ref) async {
   return activityService.fetchNearby();
+});
+
+final activitiesByCategoryProvider =
+    FutureProvider.family<Paginated<Activity>, int>((ref, categoryId) async {
+  return activityService.fetchActivitiesByCategory(categoryId);
 });

--- a/lib/providers/home_provider.dart
+++ b/lib/providers/home_provider.dart
@@ -2,6 +2,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/featured_category.dart';
 import '../models/featured_activity.dart';
 import '../models/activity.dart';
+import '../models/paginated.dart';
 import '../services/home_service.dart';
 
 final featuredCategoriesProvider =
@@ -14,6 +15,6 @@ final featuredActivitiesProvider =
   return homeService.fetchFeaturedActivities();
 });
 
-final continuePlanningProvider = FutureProvider<List<Activity>>((ref) async {
+final continuePlanningProvider = FutureProvider<Paginated<Activity>>((ref) async {
   return homeService.fetchContinuePlanning();
 });

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -1,0 +1,153 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/category.dart';
+import '../models/activity.dart';
+import '../providers/activity_provider.dart';
+import '../services/activity_service.dart';
+import 'activity_detail_page.dart';
+import '../widgets/activity_card.dart';
+
+class ActivitiesByCategoryPage extends ConsumerStatefulWidget {
+  final Category category;
+  const ActivitiesByCategoryPage({super.key, required this.category});
+
+  @override
+  ConsumerState<ActivitiesByCategoryPage> createState() =>
+      _ActivitiesByCategoryPageState();
+}
+
+class _ActivitiesByCategoryPageState
+    extends ConsumerState<ActivitiesByCategoryPage> {
+  final _items = <Activity>[];
+  int _page = 1;
+  bool _hasNext = true;
+  bool _loadingMore = false;
+
+  @override
+  void initState() {
+    super.initState();
+    debugPrint('view_category: id=${widget.category.id} name=${widget.category.name}');
+  }
+
+  Future<void> _refresh() async {
+    final paginated =
+        await activityService.fetchActivitiesByCategory(widget.category.id);
+    setState(() {
+      _items
+        ..clear()
+        ..addAll(paginated.results);
+      _page = 1;
+      _hasNext = paginated.next != null;
+    });
+  }
+
+  Future<void> _loadMore() async {
+    if (_loadingMore || !_hasNext) return;
+    setState(() => _loadingMore = true);
+    try {
+      final paginated = await activityService.fetchActivitiesByCategory(
+        widget.category.id,
+        page: _page + 1,
+      );
+      setState(() {
+        _page += 1;
+        _hasNext = paginated.next != null;
+        _items.addAll(paginated.results);
+      });
+    } finally {
+      setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final async = ref.watch(activitiesByCategoryProvider(widget.category.id));
+    return Scaffold(
+      appBar: AppBar(title: Text(widget.category.name)),
+      body: async.when(
+        loading: () => const Center(child: CircularProgressIndicator()),
+        error: (e, _) => Center(
+          child: Column(
+            mainAxisAlignment: MainAxisAlignment.center,
+            children: [
+              Text('Error: $e'),
+              const SizedBox(height: 12),
+              ElevatedButton(onPressed: () => ref.refresh(activitiesByCategoryProvider(widget.category.id)), child: const Text('Retry')),
+            ],
+          ),
+        ),
+        data: (page) {
+          if (_items.isEmpty) {
+            _items.addAll(page.results);
+            _hasNext = page.next != null;
+          }
+          if (_items.isEmpty) {
+            return Center(
+              child: Column(
+                mainAxisAlignment: MainAxisAlignment.center,
+                children: [
+                  const Text('No activities found'),
+                  const SizedBox(height: 12),
+                  ElevatedButton(
+                    onPressed: () => Navigator.pop(context),
+                    child: const Text('Back'),
+                  ),
+                ],
+              ),
+            );
+          }
+          return RefreshIndicator(
+            onRefresh: _refresh,
+            child: ListView.builder(
+              padding: const EdgeInsets.all(16),
+              itemCount: _items.length + 1,
+              itemBuilder: (context, i) {
+                if (i == _items.length) {
+                  if (_loadingMore) {
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(child: CircularProgressIndicator()),
+                    );
+                  }
+                  if (!_hasNext) return const SizedBox.shrink();
+                  return Center(
+                    child: ElevatedButton(
+                      onPressed: _loadMore,
+                      child: const Text('Load more'),
+                    ),
+                  );
+                }
+                final act = _items[i];
+                return Semantics(
+                  label: act.title,
+                  child: Padding(
+                    padding: const EdgeInsets.only(bottom: 12),
+                    child: ActivityCard(
+                      title: act.title,
+                      location: '',
+                      price: act.basePrice,
+                      rating: 0,
+                      reviews: 0,
+                      asset: act.imageUrl ?? act.image,
+                      isFavorite: false,
+                      onFavorite: () {},
+                      onTap: () {
+                        debugPrint('view_activity_from_category: categoryId=${widget.category.id} activityId=${act.id}');
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (_) => ActivityDetailPage(activity: act),
+                          ),
+                        );
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/lib/screens/categories_page.dart
+++ b/lib/screens/categories_page.dart
@@ -2,6 +2,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../widgets/category_card.dart';
+import 'activities_by_category_page.dart';
 import '../providers/category_provider.dart';
 
 class CategoriesPage extends ConsumerWidget {
@@ -29,7 +30,12 @@ class CategoriesPage extends ConsumerWidget {
               title: cats[i].name,
               asset: cats[i].icon,
               imageUrl: cats[i].imageUrl,
-              onTap: () {},
+              onTap: () => Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ActivitiesByCategoryPage(category: cats[i]),
+                ),
+              ),
             ),
           ),
         ),

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -11,6 +11,7 @@ import '../widgets/activity_card.dart';
 import '../widgets/project_card.dart';
 import '../widgets/search_bar.dart';
 import 'categories_page.dart';
+import 'activities_by_category_page.dart';
 
 import '../providers.dart';                                   // ← new (sportsProvider)
 import '../providers/category_provider.dart';
@@ -237,7 +238,12 @@ class _HomePageState extends ConsumerState<HomePage> {
                           title: c.name,
                           asset: c.icon,
                           imageUrl: c.imageUrl,
-                          onTap: () {},
+                          onTap: () => Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => ActivitiesByCategoryPage(category: c),
+                            ),
+                          ),
                         );
                       }
                       return MoreCategoryCard(

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -299,7 +299,8 @@ class _HomePageState extends ConsumerState<HomePage> {
             ),
 
             // ❸ data state
-            data: (acts) {
+            data: (page) {
+              final acts = page.results;
               if (acts.isEmpty) {
                 return SliverToBoxAdapter(
                   child: Padding(
@@ -366,14 +367,15 @@ class _HomePageState extends ConsumerState<HomePage> {
             error: (e, __) => SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.all(16),
-                child: Text('Error: \$e',
+                child: Text('Error: $e',
                     style: Theme.of(context)
                         .textTheme
                         .bodyMedium
                         ?.copyWith(color: Colors.red)),
               ),
             ),
-            data: (acts) {
+            data: (page) {
+              final acts = page.results;
               if (acts.isEmpty) {
                 return SliverToBoxAdapter(
                   child: Padding(

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -41,22 +41,25 @@ class ProviderDashboardPage extends ConsumerWidget {
       body: asyncActivities.when(
         loading: () => const Center(child: CircularProgressIndicator()),
         error: (e, _) => Center(child: Text('Error: $e')),
-        data: (list) => ListView.builder(
-          itemCount: list.length,
+        data: (page) => ListView.builder(
+          itemCount: page.results.length,
           itemBuilder: (_, i) => ListTile(
-            leading: (list[i].imageUrl != null && list[i].imageUrl!.isNotEmpty)
-                ? Image.network(list[i].imageUrl!, width: 50, fit: BoxFit.cover)
-                : list[i].image.isNotEmpty
-                    ? Image.network(list[i].image, width: 50, fit: BoxFit.cover)
+            leading: (page.results[i].imageUrl != null &&
+                    page.results[i].imageUrl!.isNotEmpty)
+                ? Image.network(page.results[i].imageUrl!,
+                    width: 50, fit: BoxFit.cover)
+                : page.results[i].image.isNotEmpty
+                    ? Image.network(page.results[i].image,
+                        width: 50, fit: BoxFit.cover)
                     : null,
-            title: Text(list[i].title),
+            title: Text(page.results[i].title),
             trailing: IconButton(
               icon: const Icon(Icons.schedule),
               onPressed: () async {
                 final created = await Navigator.push(
                   context,
                   MaterialPageRoute(
-                    builder: (_) => AddSlotPage(activityId: list[i].id),
+                    builder: (_) => AddSlotPage(activityId: page.results[i].id),
                   ),
                 );
                 if (created == true) {
@@ -69,9 +72,9 @@ class ProviderDashboardPage extends ConsumerWidget {
             onTap: () async {
               final updated = await Navigator.push(
                 context,
-                MaterialPageRoute(
-                  builder: (_) => AddActivityPage(activity: list[i]),
-                ),
+                  MaterialPageRoute(
+                    builder: (_) => AddActivityPage(activity: page.results[i]),
+                  ),
               );
               if (updated == true) {
                 ref.invalidate(activitiesProvider);

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -4,20 +4,30 @@ import '../models/paginated.dart';
 import 'api_client.dart';
 
 class ActivityService {
-  Future<List<Activity>> fetchMine() async {
-    final res = await apiClient.get('/activities/', queryParameters: {'mine': '1'});
-    return (res.data as List)
-        .cast<Map<String, dynamic>>()
-        .map(Activity.fromJson)
-        .toList();
+  Paginated<Activity> _parsePage(Object data) {
+    if (data is List) {
+      return Paginated.fromList(
+        data.cast<Map<String, dynamic>>(),
+        Activity.fromJson,
+      );
+    }
+    if (data is Map<String, dynamic>) {
+      return Paginated.fromJson(data, Activity.fromJson);
+    }
+    return Paginated(count: 0, next: null, previous: null, results: const []);
   }
 
-  Future<List<Activity>> fetchNearby() async {
-    final res = await apiClient.get('/activities/', queryParameters: {'nearby': '1'});
-    return (res.data as List)
-        .cast<Map<String, dynamic>>()
-        .map(Activity.fromJson)
-        .toList();
+  Future<Paginated<Activity>> fetchActivities({Map<String, dynamic>? params}) async {
+    final res = await apiClient.get('/activities/', queryParameters: params);
+    return _parsePage(res.data);
+  }
+
+  Future<Paginated<Activity>> fetchMine() async {
+    return fetchActivities(params: {'mine': '1'});
+  }
+
+  Future<Paginated<Activity>> fetchNearby() async {
+    return fetchActivities(params: {'nearby': '1'});
   }
 
   Future<Paginated<Activity>> fetchActivitiesByCategory(
@@ -25,15 +35,11 @@ class ActivityService {
     int page = 1,
     int pageSize = 20,
   }) async {
-    final res = await apiClient.get('/activities/', queryParameters: {
+    return fetchActivities(params: {
       'category': categoryId,
       'page': page,
       'page_size': pageSize,
     });
-    return Paginated.fromJson(
-      res.data as Map<String, dynamic>,
-      Activity.fromJson,
-    );
   }
 
   Future<Activity> fetchById(int id) async {

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -1,5 +1,6 @@
 import 'package:dio/dio.dart';
 import '../models/activity.dart';
+import '../models/paginated.dart';
 import 'api_client.dart';
 
 class ActivityService {
@@ -17,6 +18,22 @@ class ActivityService {
         .cast<Map<String, dynamic>>()
         .map(Activity.fromJson)
         .toList();
+  }
+
+  Future<Paginated<Activity>> fetchActivitiesByCategory(
+    int categoryId, {
+    int page = 1,
+    int pageSize = 20,
+  }) async {
+    final res = await apiClient.get('/activities/', queryParameters: {
+      'category': categoryId,
+      'page': page,
+      'page_size': pageSize,
+    });
+    return Paginated.fromJson(
+      res.data as Map<String, dynamic>,
+      Activity.fromJson,
+    );
   }
 
   Future<Activity> fetchById(int id) async {

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -1,6 +1,7 @@
 import '../models/featured_category.dart';
 import '../models/featured_activity.dart';
 import '../models/activity.dart';
+import '../models/paginated.dart';
 import 'api_client.dart';
 
 class HomeService {
@@ -20,12 +21,22 @@ class HomeService {
         .toList(growable: false);
   }
 
-  Future<List<Activity>> fetchContinuePlanning() async {
+  Paginated<Activity> _parse(Object data) {
+    if (data is List) {
+      return Paginated.fromList(
+        data.cast<Map<String, dynamic>>(),
+        Activity.fromJson,
+      );
+    }
+    if (data is Map<String, dynamic>) {
+      return Paginated.fromJson(data, Activity.fromJson);
+    }
+    return Paginated(count: 0, next: null, previous: null, results: const []);
+  }
+
+  Future<Paginated<Activity>> fetchContinuePlanning() async {
     final res = await apiClient.get('/home/continue-planning/');
-    return (res.data as List)
-        .cast<Map<String, dynamic>>()
-        .map(Activity.fromJson)
-        .toList(growable: false);
+    return _parse(res.data);
   }
 }
 


### PR DESCRIPTION
## Path mapping
- `backend/sports/views.py` → `ActivityViewSet` and pagination
- `backend/tests/test_activity_api.py` → add tests
- `lib/screens/home_page.dart` & `lib/screens/categories_page.dart` → open new list page
- `lib/screens/activities_by_category_page.dart` → new list page
- `lib/services/activity_service.dart` & `lib/providers/activity_provider.dart` → fetch API
- `lib/models/paginated.dart` → pagination model
- `README.md` updated docs

## Summary
- add DefaultPagination and category filter in backend
- create Paginated model and service method for category fetch
- add ActivitiesByCategoryPage with pagination and analytics logs
- wire category cards on home and categories pages
- document new API usage with curl sample

## Testing
- `flake8 backend/sports/views.py backend/tests/test_activity_api.py`
- `flutter analyze` *(fails: command not found)*
- `pytest backend/tests/test_activity_api.py::test_filter_activities_by_category` *(fails: missing GDAL)*

------
https://chatgpt.com/codex/tasks/task_e_68875901c58083268ba4b9d879a865da