### PR TITLE
Fix continue planning and category listing

### DIFF
--- a/lib/providers/activity_provider.dart
+++ b/lib/providers/activity_provider.dart
@@ -11,7 +11,8 @@ final nearbyActivitiesProvider = FutureProvider<Paginated<Activity>>((ref) async
   return activityService.fetchNearby();
 });
 
-final activitiesByCategoryProvider =
-    FutureProvider.family<Paginated<Activity>, int>((ref, categoryId) async {
+// autoDispose so that list refreshes when returning after adding new activity
+final activitiesByCategoryProvider = FutureProvider.autoDispose
+    .family<Paginated<Activity>, int>((ref, categoryId) async {
   return activityService.fetchActivitiesByCategory(categoryId);
 });

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -7,6 +7,8 @@ import '../services/activity_service.dart';
 import 'activity_detail_page.dart';
 import '../widgets/activity_card.dart';
 
+import "package:dio/dio.dart";
+import "../utils/snackbar.dart";
 class ActivitiesByCategoryPage extends ConsumerStatefulWidget {
   final Category category;
   const ActivitiesByCategoryPage({super.key, required this.category});
@@ -70,13 +72,18 @@ class _ActivitiesByCategoryPageState
           child: Column(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
-              Text('Error: $e'),
+              const Text('加载失败，请稍后重试'),
               const SizedBox(height: 12),
-              ElevatedButton(onPressed: () => ref.refresh(activitiesByCategoryProvider(widget.category.id)), child: const Text('Retry')),
+              ElevatedButton(
+                onPressed: () => ref.refresh(activitiesByCategoryProvider(widget.category.id)),
+                child: const Text('Retry'),
+              ),
             ],
+          ),
           ),
         ),
         data: (page) {
+          debugPrint('category_${widget.category.id}: ${page.results.length} items');
           if (_items.isEmpty) {
             _items.addAll(page.results);
             _hasNext = page.next != null;
@@ -86,11 +93,11 @@ class _ActivitiesByCategoryPageState
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('No activities found'),
+                  const Text('该分类暂无活动'),
                   const SizedBox(height: 12),
                   ElevatedButton(
-                    onPressed: () => Navigator.pop(context),
-                    child: const Text('Back'),
+                    onPressed: _refresh,
+                    child: const Text('Refresh'),
                   ),
                 ],
               ),

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -75,11 +75,11 @@ class _ActivitiesByCategoryPageState
               const Text('加载失败，请稍后重试'),
               const SizedBox(height: 12),
               ElevatedButton(
-                onPressed: () => ref.refresh(activitiesByCategoryProvider(widget.category.id)),
+                onPressed: () => ref.refresh(
+                    activitiesByCategoryProvider(widget.category.id)),
                 child: const Text('Retry'),
               ),
             ],
-          ),
           ),
         ),
         data: (page) {

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -75,8 +75,8 @@ class _ActivitiesByCategoryPageState
               const Text('加载失败，请稍后重试'),
               const SizedBox(height: 12),
               ElevatedButton(
-                onPressed: () => ref.refresh(
-                    activitiesByCategoryProvider(widget.category.id)),
+                onPressed: () =>
+                    ref.refresh(activitiesByCategoryProvider(widget.category.id)),
                 child: const Text('Retry'),
               ),
             ],
@@ -88,69 +88,84 @@ class _ActivitiesByCategoryPageState
             _items.addAll(page.results);
             _hasNext = page.next != null;
           }
-          if (_items.isEmpty) {
-            return Center(
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  const Text('该分类暂无活动'),
-                  const SizedBox(height: 12),
-                  ElevatedButton(
-                    onPressed: _refresh,
-                    child: const Text('Refresh'),
-                  ),
-                ],
-              ),
-            );
-          }
           return RefreshIndicator(
             onRefresh: _refresh,
-            child: ListView.builder(
-              padding: const EdgeInsets.all(16),
-              itemCount: _items.length + 1,
-              itemBuilder: (context, i) {
-                if (i == _items.length) {
-                  if (_loadingMore) {
-                    return const Padding(
-                      padding: EdgeInsets.all(16),
-                      child: Center(child: CircularProgressIndicator()),
-                    );
-                  }
-                  if (!_hasNext) return const SizedBox.shrink();
-                  return Center(
-                    child: ElevatedButton(
-                      onPressed: _loadMore,
-                      child: const Text('Load more'),
-                    ),
-                  );
-                }
-                final act = _items[i];
-                return Semantics(
-                  label: act.title,
-                  child: Padding(
-                    padding: const EdgeInsets.only(bottom: 12),
-                    child: ActivityCard(
-                      title: act.title,
-                      location: '',
-                      price: act.basePrice,
-                      rating: 0,
-                      reviews: 0,
-                      asset: act.imageUrl ?? act.image,
-                      isFavorite: false,
-                      onFavorite: () {},
-                      onTap: () {
-                        debugPrint('view_activity_from_category: categoryId=${widget.category.id} activityId=${act.id}');
-                        Navigator.push(
-                          context,
-                          MaterialPageRoute(
-                            builder: (_) => ActivityDetailPage(activity: act),
+            child: CustomScrollView(
+              slivers: [
+                if (_items.isEmpty)
+                  SliverFillRemaining(
+                    hasScrollBody: false,
+                    child: Center(
+                      child: Column(
+                        mainAxisAlignment: MainAxisAlignment.center,
+                        children: [
+                          const Text('该分类暂无活动'),
+                          const SizedBox(height: 12),
+                          ElevatedButton(
+                            onPressed: _refresh,
+                            child: const Text('Refresh'),
                           ),
-                        );
-                      },
+                        ],
+                      ),
+                    ),
+                  )
+                else
+                  SliverPadding(
+                    padding: const EdgeInsets.all(16),
+                    sliver: SliverList(
+                      delegate: SliverChildBuilderDelegate(
+                        (context, i) {
+                          if (i == _items.length) {
+                            if (_loadingMore) {
+                              return const Padding(
+                                padding: EdgeInsets.all(16),
+                                child: Center(child: CircularProgressIndicator()),
+                              );
+                            }
+                            if (!_hasNext) {
+                              return const SizedBox(height: 16);
+                            }
+                            return Center(
+                              child: ElevatedButton(
+                                onPressed: _loadMore,
+                                child: const Text('Load more'),
+                              ),
+                            );
+                          }
+                          final act = _items[i];
+                          return Semantics(
+                            label: act.title,
+                            child: Padding(
+                              padding: const EdgeInsets.only(bottom: 12),
+                              child: ActivityCard(
+                                title: act.title,
+                                location: '',
+                                price: act.basePrice,
+                                rating: 0,
+                                reviews: 0,
+                                asset: act.imageUrl ?? act.image,
+                                isFavorite: false,
+                                onFavorite: () {},
+                                onTap: () {
+                                  debugPrint(
+                                      'view_activity_from_category: categoryId=${widget.category.id} activityId=${act.id}');
+                                  Navigator.push(
+                                    context,
+                                    MaterialPageRoute(
+                                      builder: (_) =>
+                                          ActivityDetailPage(activity: act),
+                                    ),
+                                  );
+                                },
+                              ),
+                            ),
+                          );
+                        },
+                        childCount: _items.length + 1,
+                      ),
                     ),
                   ),
-                );
-              },
+              ],
             ),
           );
         },

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -5,6 +5,9 @@ import 'package:sports_booking_app/screens/slots_page.dart';
 import '../services/activity_service.dart';
 import '../utils/theme.dart';
 import '../widgets/app_bottom_nav.dart';
+import 'package:dio/dio.dart';
+import '../utils/snackbar.dart';
+import '../utils/errors.dart';
 import '../widgets/category_card.dart';
 import '../widgets/more_category_card.dart';
 import '../widgets/activity_card.dart';
@@ -367,11 +370,35 @@ class _HomePageState extends ConsumerState<HomePage> {
             error: (e, __) => SliverToBoxAdapter(
               child: Padding(
                 padding: const EdgeInsets.all(16),
-                child: Text('Error: $e',
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium
-                        ?.copyWith(color: Colors.red)),
+                child: Column(
+                  children: [
+                    Text(
+                      e is FriendlyError ? e.message : '加载失败，请稍后重试',
+                      style: Theme.of(context)
+                          .textTheme
+                          .bodyMedium
+                          ?.copyWith(color: Colors.red),
+                    ),
+                    const SizedBox(height: 12),
+                    if (e is FriendlyError && e.unauthorized)
+                      ElevatedButton(
+                        onPressed: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (_) => const LoginPage(),
+                            ),
+                          );
+                        },
+                        child: const Text('去登录'),
+                      )
+                    else
+                      ElevatedButton(
+                        onPressed: () => ref.refresh(continuePlanningProvider),
+                        child: const Text('Retry'),
+                      ),
+                  ],
+                ),
               ),
             ),
             data: (page) {
@@ -399,12 +426,18 @@ class _HomePageState extends ConsumerState<HomePage> {
                         title: act.title,
                         imageUrl: act.imageUrl ?? act.image,
                         price: act.basePrice,
-                        onTap: () {
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(builder: (_) => ActivityDetailPage(activity: act)),
-                          );
-                        },
+                        onTap: () async {
+                            try {
+                              final detail = await activityService.fetchById(act.id);
+                              if (!context.mounted) return;
+                              Navigator.push(
+                                context,
+                                MaterialPageRoute(builder: (_) => ActivityDetailPage(activity: detail)),
+                              );
+                            } on DioException catch (e) {
+                              showApiError(context, e, "");
+                            }
+                          },
                       );
                     },
                   ),

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -1,8 +1,10 @@
+import 'package:dio/dio.dart';
 import '../models/featured_category.dart';
 import '../models/featured_activity.dart';
 import '../models/activity.dart';
 import '../models/paginated.dart';
 import 'api_client.dart';
+import '../utils/errors.dart';
 
 class HomeService {
   Future<List<FeaturedCategory>> fetchFeaturedCategories() async {
@@ -35,8 +37,39 @@ class HomeService {
   }
 
   Future<Paginated<Activity>> fetchContinuePlanning() async {
-    final res = await apiClient.get('/home/continue-planning/');
-    return _parse(res.data);
+    try {
+      final res = await apiClient.get('/home/continue-planning/');
+      final list = (res.data as List).cast<Map<String, dynamic>>();
+      final acts = list
+          .map(
+            (j) => Activity(
+              id: j['id'] as int,
+              title: j['title'] as String,
+              imageUrl: j['image_url'] as String?,
+              basePrice: (j['base_price'] as num?)?.toDouble() ?? 0.0,
+              sport: 0,
+              discipline: 0,
+              variant: null,
+              image: '',
+              description: '',
+              difficulty: 1,
+              duration: 60,
+            ),
+          )
+          .toList(growable: false);
+      return Paginated(
+        count: acts.length,
+        next: null,
+        previous: null,
+        results: acts,
+      );
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 401) {
+        throw const FriendlyError('请先登录后再查看 Continue planning',
+            unauthorized: true);
+      }
+      throw const FriendlyError('加载 Continue planning 失败，请稍后重试');
+    }
   }
 }
 

--- a/lib/utils/errors.dart
+++ b/lib/utils/errors.dart
@@ -1,0 +1,7 @@
+class FriendlyError implements Exception {
+  final String message;
+  final bool unauthorized;
+  const FriendlyError(this.message, {this.unauthorized = false});
+  @override
+  String toString() => message;
+}

--- a/lib/widgets/activity_card.dart
+++ b/lib/widgets/activity_card.dart
@@ -27,26 +27,20 @@ class ActivityCard extends StatelessWidget {
     required this.isFavorite,
   });
 
-  // ----- 私有：生成图片组件，自动判断网络 / 本地 -------------------------
+  // ----- 私有：生成图片组件，自动判断网络 / 本地，并提供占位符 ---------
   Widget _buildHeroImage() {
     if (asset.startsWith('http')) {
       return Image.network(
         asset,
-        height: 140,
-        width: double.infinity,
         fit: BoxFit.cover,
-        errorBuilder: (_, __, ___) => const ColoredBox(
-          color: Colors.black12,
-          child: Icon(Icons.broken_image, size: 40, color: Colors.grey),
-        ),
+        errorBuilder: (_, __, ___) =>
+            Image.asset('assets/images/default.jpg', fit: BoxFit.cover),
       );
     }
-    return Image.asset(
-      asset,
-      height: 140,
-      width: double.infinity,
-      fit: BoxFit.cover,
-    );
+    if (asset.isEmpty) {
+      return Image.asset('assets/images/default.jpg', fit: BoxFit.cover);
+    }
+    return Image.asset(asset, fit: BoxFit.cover);
   }
 
   @override
@@ -62,7 +56,10 @@ class ActivityCard extends StatelessWidget {
             children: [
               Stack(
                 children: [
-                  Hero(tag: asset, child: _buildHeroImage()),
+                  AspectRatio(
+                    aspectRatio: 16 / 9,
+                    child: Hero(tag: asset, child: _buildHeroImage()),
+                  ),
                   Positioned(
                     top: 8,
                     right: 8,


### PR DESCRIPTION
## Summary
- handle simplified continue-planning payload and auth errors
- show friendly messages on home page and load full detail on tap
- improve empty/error state for activities by category
- add FriendlyError helper

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'django')*
- `dart format` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688771936c9c8326992f5b1219084cc7