### PR TITLE
Fix continue planning parsing & refresh category list

### DIFF
--- a/lib/models/activity.dart
+++ b/lib/models/activity.dart
@@ -38,4 +38,20 @@ class Activity {
         duration: j['duration'] as int? ?? 60,
         basePrice: (j['base_price'] as num).toDouble(),
       );
+
+  /// Create an [Activity] from a simplified JSON structure used by
+  /// `/api/home/continue-planning/` which only contains a few fields.
+  factory Activity.fromSimple(Map<String, dynamic> j) => Activity(
+        id: j['id'] as int,
+        sport: 0,
+        discipline: 0,
+        variant: null,
+        image: '',
+        imageUrl: j['image_url'] as String?,
+        title: j['title'] as String,
+        description: '',
+        difficulty: 1,
+        duration: 60,
+        basePrice: (j['base_price'] as num?)?.toDouble() ?? 0.0,
+      );
 }

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -82,16 +82,33 @@ class _ActivitiesByCategoryPageState
             _items.addAll(page.results);
             _hasNext = page.next != null;
           }
+          // 当没有任何活动时，显示空态并提供返回或创建入口
           if (_items.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('No activities found'),
+                  const Text('该分类暂无活动'),
                   const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: () => Navigator.pop(context),
-                    child: const Text('Back'),
+                    child: const Text('返回'),
+                  ),
+                  const SizedBox(height: 8),
+                  ElevatedButton(
+                    onPressed: () async {
+                      final created = await Navigator.push(
+                        context,
+                        MaterialPageRoute(builder: (_) => const AddActivityPage()),
+                      );
+                      if (created == true) {
+                        await _refresh();
+                        ref.invalidate(
+                          activitiesByCategoryProvider(widget.category.id),
+                        );
+                      }
+                    },
+                    child: const Text('去创建'),
                   ),
                 ],
               ),
@@ -104,13 +121,22 @@ class _ActivitiesByCategoryPageState
               itemCount: _items.length + 1,
               itemBuilder: (context, i) {
                 if (i == _items.length) {
+                  // 调整加载更多尾部逻辑，避免在无更多数据时渲染空白
                   if (_loadingMore) {
                     return const Padding(
                       padding: EdgeInsets.all(16),
                       child: Center(child: CircularProgressIndicator()),
                     );
                   }
-                  if (!_hasNext) return const SizedBox.shrink();
+                  if (!_hasNext) {
+                    if (_items.isNotEmpty) {
+                      return const SizedBox(height: 16);
+                    }
+                    return const Padding(
+                      padding: EdgeInsets.all(16),
+                      child: Center(child: Text('没有更多数据')), 
+                    );
+                  }
                   return Center(
                     child: ElevatedButton(
                       onPressed: _loadMore,

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -6,6 +6,7 @@ import '../providers/activity_provider.dart';
 import '../services/activity_service.dart';
 import 'activity_detail_page.dart';
 import '../widgets/activity_card.dart';
+import 'add_activity_page.dart';
 
 class ActivitiesByCategoryPage extends ConsumerStatefulWidget {
   final Category category;
@@ -147,6 +148,19 @@ class _ActivitiesByCategoryPageState
             ),
           );
         },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final created = await Navigator.push(
+            context,
+            MaterialPageRoute(builder: (_) => const AddActivityPage()),
+          );
+          if (created == true) {
+            await _refresh();
+            ref.invalidate(activitiesByCategoryProvider(widget.category.id));
+          }
+        },
+        child: const Icon(Icons.add),
       ),
     );
   }

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -178,7 +178,6 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  imageCtrl.text,
                                 );
                               } else {
                                 await activityService.updateActivity(
@@ -191,7 +190,6 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  imageCtrl.text,
                                 );
                               }
                               if (context.mounted) {

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -386,6 +386,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                     const Text('加载失败，请重试'),
                     const SizedBox(height: 8),
                     ElevatedButton(
+                      // 触发重新拉取；refresh 或 invalidate 都可
                       onPressed: () => ref.refresh(continuePlanningProvider),
                       child: const Text('Retry'),
                     ),
@@ -399,13 +400,17 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
               );
             },
+            // 之前缺少的 data 分支：把页面渲染代码包进来
+            data: (page) {
               final acts = page.results;
               if (acts.isEmpty) {
                 return SliverToBoxAdapter(
                   child: Padding(
                     padding: const EdgeInsets.all(16),
-                    child: Text('No suggestions yet',
-                        style: Theme.of(context).textTheme.bodyMedium),
+                    child: Text(
+                      'No suggestions yet',
+                      style: Theme.of(context).textTheme.bodyMedium,
+                    ),
                   ),
                 );
               }

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';        // new
 import 'package:sports_booking_app/screens/slots_page.dart';
 import '../services/activity_service.dart';
+import 'package:dio/dio.dart';
 import '../utils/theme.dart';
 import '../widgets/app_bottom_nav.dart';
 import '../widgets/category_card.dart';
@@ -364,17 +365,40 @@ class _HomePageState extends ConsumerState<HomePage> {
                 child: Center(child: CircularProgressIndicator()),
               ),
             ),
-            error: (e, __) => SliverToBoxAdapter(
-              child: Padding(
-                padding: const EdgeInsets.all(16),
-                child: Text('Error: $e',
-                    style: Theme.of(context)
-                        .textTheme
-                        .bodyMedium
-                        ?.copyWith(color: Colors.red)),
-              ),
-            ),
-            data: (page) {
+            error: (e, __) {
+              Widget child;
+              if (e is DioException && e.response?.statusCode == 401) {
+                child = Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('请先登录查看 Continue planning'),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () => showAuthSheet(context),
+                      child: const Text('登录'),
+                    ),
+                  ],
+                );
+              } else {
+                child = Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text('加载失败，请重试'),
+                    const SizedBox(height: 8),
+                    ElevatedButton(
+                      onPressed: () => ref.refresh(continuePlanningProvider),
+                      child: const Text('Retry'),
+                    ),
+                  ],
+                );
+              }
+              return SliverToBoxAdapter(
+                child: Padding(
+                  padding: const EdgeInsets.all(16),
+                  child: child,
+                ),
+              );
+            },
               final acts = page.results;
               if (acts.isEmpty) {
                 return SliverToBoxAdapter(

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -56,7 +56,6 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice,
-    String image,
   ) async {
     await apiClient.post('/activities/', data: {
       'sport': sport,
@@ -67,7 +66,6 @@ class ActivityService {
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
-      'image': image,
     });
   }
 
@@ -81,7 +79,6 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice,
-    String image,
   ) async {
     await apiClient.patch('/activities/' + id.toString() + '/', data: {
       'sport': sport,
@@ -92,7 +89,6 @@ class ActivityService {
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
-      'image': image,
     });
   }
 }

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -36,7 +36,17 @@ class HomeService {
 
   Future<Paginated<Activity>> fetchContinuePlanning() async {
     final res = await apiClient.get('/home/continue-planning/');
-    return _parse(res.data);
+    final data = res.data;
+    if (data is List) {
+      return Paginated.fromList(
+        data.cast<Map<String, dynamic>>(),
+        Activity.fromSimple,
+      );
+    }
+    if (data is Map<String, dynamic>) {
+      return Paginated.fromJson(data, Activity.fromSimple);
+    }
+    return Paginated(count: 0, next: null, previous: null, results: const []);
   }
 }
 

--- a/lib/widgets/activity_card.dart
+++ b/lib/widgets/activity_card.dart
@@ -76,39 +76,32 @@ class ActivityCard extends StatelessWidget {
                   ),
                 ],
               ),
-              Expanded(                                     // 防止溢出
-                child: Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
-                  child: Column(
-                    crossAxisAlignment: CrossAxisAlignment.start,
-                    children: [
-                      Text(title, style: Theme.of(context).textTheme.titleMedium),
-                      const SizedBox(height: 4),
-                      Text(location, style: Theme.of(context).textTheme.bodySmall),
-                      const Spacer(),
-                      Row(
-                        children: [
-                          RatingBarIndicator(
-                            rating: rating,
-                            itemCount: 5,
-                            itemSize: 16,
-                            unratedColor: Colors.grey.shade300,
-                            itemBuilder: (_, __) =>
-                            const Icon(Icons.star_rounded, color: Colors.amber),
-                          ),
-                          const SizedBox(width: 4),
-                          Text('($reviews)',
-                              style: Theme.of(context).textTheme.bodySmall),
-                          const Spacer(),
-                          Text('\$${price.toStringAsFixed(0)}',
-                              style: Theme.of(context)
-                                  .textTheme
-                                  .titleMedium
-                                  ?.copyWith(fontWeight: FontWeight.w700)),
-                        ],
-                      ),
-                    ],
-                  ),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(title, style: Theme.of(context).textTheme.titleMedium),
+                    const SizedBox(height: 4),
+                    Text(location, style: Theme.of(context).textTheme.bodySmall),
+                    const SizedBox(height: 8),
+                    Row(
+                      children: [
+                        RatingBarIndicator(
+                          rating: rating,
+                          itemCount: 5,
+                          itemSize: 16,
+                          unratedColor: Colors.grey.shade300,
+                          itemBuilder: (_, __) => const Icon(Icons.star_rounded, color: Colors.amber),
+                        ),
+                        const SizedBox(width: 4),
+                        Text('($reviews)', style: Theme.of(context).textTheme.bodySmall),
+                        const Spacer(),
+                        Text('\$${price.toStringAsFixed(0)}',
+                            style: Theme.of(context).textTheme.titleMedium?.copyWith(fontWeight: FontWeight.w700)),
+                      ],
+                    ),
+                  ],
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- handle simple activity objects from `/home/continue-planning/`
- show friendly messages for unauthenticated users on Home
- refresh Activities by Category page after adding a new activity
- stop sending read-only `image` field when creating/updating activities

## Testing
- `dart --version` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6887754f1bbc8326a209139c9718fc7a