### PR TITLE
Implement activity search with DRF filtering and Flutter UI

### DIFF
--- a/backend/sports/urls.py
+++ b/backend/sports/urls.py
@@ -13,6 +13,7 @@ from .views import (
     FeaturedCategoryViewSet,
     FeaturedActivityViewSet,
     ActivityReviewList,
+    ActivitySearchSuggest,
     ContinuePlanningView,
     BulkSlotCreateView,
     MerchantSlotCreateView,
@@ -38,4 +39,5 @@ urlpatterns = router.urls + [
     path("merchant/bookings/", MerchantBookingList.as_view()),
     path("activities/<int:activity_id>/reviews/", ActivityReviewList.as_view(), name="activity-reviews"),
     path("home/continue-planning/", ContinuePlanningView.as_view()),
+    path("search/suggest/", ActivitySearchSuggest.as_view()),
 ]

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -4,6 +4,7 @@ from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
+from rest_framework.filters import SearchFilter, OrderingFilter
 from accounts.permissions import IsVendor
 from rest_framework.views import APIView
 from rest_framework.response import Response
@@ -124,6 +125,10 @@ class VariantViewSet(viewsets.ReadOnlyModelViewSet):
 class ActivityViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitySerializer
     pagination_class = DefaultPagination
+    filter_backends = [SearchFilter, OrderingFilter]
+    search_fields = ["title", "description", "discipline__name"]
+    ordering_fields = ["title", "base_price", "created_at"]
+    ordering = ["-created_at"]
 
     def get_permissions(self):
         if self.action in ("create", "update", "partial_update", "destroy"):
@@ -310,6 +315,22 @@ class ActivityReviewList(APIView):
         ser.is_valid(raise_exception=True)
         ser.save(activity_id=activity_id, user=request.user)
         return Response(ser.data, status=201)
+
+
+class ActivitySearchSuggest(APIView):
+    permission_classes = [permissions.AllowAny]
+
+    def get(self, request):
+        q = request.query_params.get("q", "").strip()
+        if not q:
+            return Response([])
+        qs = (
+            Activity.objects.filter(title__icontains=q)
+            .order_by("title")
+            .values_list("title", flat=True)
+            .distinct()[:10]
+        )
+        return Response(list(qs))
 
 
 class ContinuePlanningView(APIView):

--- a/lib/providers/search_providers.dart
+++ b/lib/providers/search_providers.dart
@@ -1,0 +1,50 @@
+import 'dart:async';
+import 'package:dio/dio.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/activity.dart';
+import '../models/paginated.dart';
+import '../services/activity_service.dart';
+
+final searchQueryProvider = StateProvider<String>((ref) => '');
+
+final debouncedQueryProvider = StreamProvider<String>((ref) {
+  final controller = StreamController<String>();
+  Timer? timer;
+  final sub = ref.listen<String>(searchQueryProvider, (prev, next) {
+    timer?.cancel();
+    timer = Timer(const Duration(milliseconds: 300), () {
+      if (!controller.isClosed) controller.add(next);
+    });
+  }, fireImmediately: true);
+  ref.onDispose(() {
+    timer?.cancel();
+    controller.close();
+    sub.close();
+  });
+  return controller.stream;
+});
+
+final searchPageProvider =
+    FutureProvider.family<Paginated<Activity>, int>((ref, page) async {
+  final query = await ref.watch(debouncedQueryProvider.future);
+  final q = query.trim();
+  if (q.isEmpty) {
+    return Paginated(count: 0, next: null, previous: null, results: const []);
+  }
+  final cancel = CancelToken();
+  ref.onDispose(() => cancel.cancel());
+  return activityService.searchActivities(
+    query: q,
+    page: page,
+    cancelToken: cancel,
+  );
+});
+
+final suggestionsProvider =
+    FutureProvider.family<List<String>, String>((ref, q) async {
+  final query = q.trim();
+  if (query.isEmpty) return <String>[];
+  final cancel = CancelToken();
+  ref.onDispose(() => cancel.cancel());
+  return activityService.suggestActivities(query);
+});

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -27,6 +27,7 @@ import '../widgets/auth_sheet.dart';
 import '../services/auth_service.dart';
 import 'bookings_page.dart';
 import 'favorites_page.dart';
+import 'search_page.dart';
 
 class HomePage extends ConsumerStatefulWidget {               // Stateful → ConsumerStateful
   const HomePage({super.key});
@@ -133,7 +134,15 @@ class _HomePageState extends ConsumerState<HomePage> {
                         opacity: opacity,
                         child: Row(
                           children: [
-                            const Expanded(child: RoundedSearchBar()),
+                            Expanded(
+                              child: RoundedSearchBar(
+                                onTap: () => Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) => const SearchPage()),
+                                ),
+                              ),
+                            ),
                             const SizedBox(width: 12),
                             IconButton(
                               icon: const Icon(Icons.person_outline),

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -27,7 +27,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
   void initState() {
     super.initState();
     _controller = TextEditingController(text: ref.read(searchQueryProvider));
-    ref.listen<String>(debouncedQueryProvider, (_, __) {
+    ref.listen(debouncedQueryProvider, (_, __) {
       setState(() {
         _items.clear();
         _page = 1;

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -1,0 +1,207 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/activity.dart';
+import '../providers/search_providers.dart';
+import '../providers/favorite_provider.dart';
+import '../widgets/activity_card.dart';
+import '../widgets/auth_sheet.dart';
+import '../providers.dart';
+import 'activity_detail_page.dart';
+
+class SearchPage extends ConsumerStatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  ConsumerState<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends ConsumerState<SearchPage> {
+  final _items = <Activity>[];
+  int _page = 1;
+  bool _hasNext = true;
+  bool _loadingMore = false;
+  late TextEditingController _controller;
+  String _lastQuery = '';
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = TextEditingController(text: ref.read(searchQueryProvider));
+    ref.listen<String>(debouncedQueryProvider, (_, __) {
+      setState(() {
+        _items.clear();
+        _page = 1;
+        _hasNext = true;
+      });
+    });
+  }
+
+  Future<void> _loadMore() async {
+    if (_loadingMore || !_hasNext) return;
+    setState(() => _loadingMore = true);
+    try {
+      final pageData =
+          await ref.read(searchPageProvider(_page + 1).future);
+      setState(() {
+        _page += 1;
+        _hasNext = pageData.next != null;
+        _items.addAll(pageData.results);
+      });
+    } finally {
+      if (mounted) setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final query = ref.watch(searchQueryProvider);
+    final pageAsync = ref.watch(searchPageProvider(1));
+    final favIds = ref.watch(favoriteIdsProvider);
+    final suggestionsAsync = ref.watch(suggestionsProvider(query));
+
+    Widget body = pageAsync.when(
+      loading: () => const Center(child: CircularProgressIndicator()),
+      error: (e, _) => Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Text('Network error'),
+            const SizedBox(height: 8),
+            ElevatedButton(
+              onPressed: () => ref.refresh(searchPageProvider(1)),
+              child: const Text('Tap to retry'),
+            ),
+          ],
+        ),
+      ),
+      data: (page) {
+        final q = query.trim();
+        if (q.isEmpty) {
+          return const Center(child: Text('Try searching for activities'));
+        }
+        if (_lastQuery != q) {
+          _items
+            ..clear()
+            ..addAll(page.results);
+          _page = 1;
+          _hasNext = page.next != null;
+          _lastQuery = q;
+        } else if (_items.isEmpty) {
+          _items.addAll(page.results);
+          _hasNext = page.next != null;
+        }
+        if (_items.isEmpty) {
+          return const Center(child: Text('No results. Try different keywords.'));
+        }
+        return ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: _items.length + 1,
+          separatorBuilder: (_, __) => const SizedBox(height: 12),
+          itemBuilder: (context, i) {
+            if (i == _items.length) {
+              if (_loadingMore) {
+                return const Padding(
+                  padding: EdgeInsets.all(16),
+                  child: Center(child: CircularProgressIndicator()),
+                );
+              }
+              if (!_hasNext) {
+                return const SizedBox(height: 16);
+              }
+              return Center(
+                child: ElevatedButton(
+                  onPressed: _loadMore,
+                  child: const Text('Load more'),
+                ),
+              );
+            }
+            final act = _items[i];
+            return ActivityCard(
+              title: act.title,
+              location: '',
+              price: act.basePrice,
+              rating: 0,
+              reviews: 0,
+              asset: act.imageUrl ?? act.image,
+              isFavorite: favIds.contains(act.id),
+              onFavorite: () async {
+                if (ref.read(authNotifierProvider) != AuthStatus.authenticated) {
+                  showAuthSheet(context);
+                  return;
+                }
+                await ref
+                    .read(favoriteIdsProvider.notifier)
+                    .toggle(context, act.id);
+              },
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => ActivityDetailPage(activity: act),
+                  ),
+                );
+              },
+            );
+          },
+        );
+      },
+    );
+
+    final suggestions = suggestionsAsync.maybeWhen(
+      data: (list) => list,
+      orElse: () => <String>[],
+    );
+
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          controller: _controller,
+          autofocus: true,
+          decoration: const InputDecoration(
+            hintText: 'Search activities',
+            border: InputBorder.none,
+          ),
+          onChanged: (v) =>
+              ref.read(searchQueryProvider.notifier).state = v,
+        ),
+        actions: [
+          if (query.isNotEmpty)
+            IconButton(
+              icon: const Icon(Icons.clear),
+              onPressed: () {
+                _controller.clear();
+                ref.read(searchQueryProvider.notifier).state = '';
+              },
+            ),
+        ],
+      ),
+      body: Column(
+        children: [
+          if (suggestions.isNotEmpty && query.isNotEmpty)
+            Container(
+              color: Colors.white,
+              child: ListView.separated(
+                shrinkWrap: true,
+                itemCount: suggestions.length,
+                separatorBuilder: (_, __) => const Divider(height: 1),
+                itemBuilder: (_, i) => ListTile(
+                  title: Text(suggestions[i]),
+                  onTap: () {
+                    _controller.text = suggestions[i];
+                    ref.read(searchQueryProvider.notifier).state = suggestions[i];
+                  },
+                ),
+              ),
+            ),
+          Expanded(child: body),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -42,6 +42,29 @@ class ActivityService {
     });
   }
 
+  Future<Paginated<Activity>> searchActivities({
+    required String query,
+    int page = 1,
+    int pageSize = 20,
+    CancelToken? cancelToken,
+  }) async {
+    final res = await apiClient.get(
+      '/activities/',
+      queryParameters: {
+        'search': query,
+        'page': page,
+        'page_size': pageSize,
+      },
+      cancelToken: cancelToken,
+    );
+    return _parsePage(res.data);
+  }
+
+  Future<List<String>> suggestActivities(String q) async {
+    final res = await apiClient.get('/search/suggest/', queryParameters: {'q': q});
+    return (res.data as List).cast<String>();
+  }
+
   Future<Activity> fetchById(int id) async {
     final Response res = await apiClient.get('/activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);


### PR DESCRIPTION
## Summary
- enable search & ordering filters for activities API and add suggestion endpoint
- add search service methods on Flutter side
- create search providers with debouncing and request cancellation
- add SearchPage UI with pagination, favorites and optional suggestions
- hook search page from home

## Testing
- `python backend/manage.py check` *(fails: GDAL library missing)*
- `python backend/manage.py test` *(fails: GDAL library missing)*
- `flutter analyze` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6888ebf30b048326bbe663f692b1b2d5