### PR TITLE
Implement search functionality

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,7 +4,7 @@ stages:
   - e2e
 
 variables:
-  # 让 Django 连接到服务里的 Postgres
+  # Allow Django to connect to the Postgres service
   DB_NAME: sportsdb
   DB_USER: sportsuser
   DB_PASS: sportspwd
@@ -13,7 +13,7 @@ variables:
   SECRET_KEY: dummy
 
 #######################
-# 1) flake8 代码风格   #
+# 1) flake8 code style   #
 #######################
 lint:
   stage: lint
@@ -22,12 +22,12 @@ lint:
     - python -m pip install --upgrade pip
     - pip install flake8 Pillow
   script: flake8 backend
-  tags: []          # 如果学校要求 runner tag，就写在这里
+  tags: []          # Specify runner tag here if required by school
   except:
     - tags
 
 #######################
-# 2) pytest 单元测试  #
+# 2) pytest unit tests  #
 #######################
 test:
   stage: test
@@ -46,12 +46,12 @@ test:
     - python backend/manage.py seed_facilities
   script:
     - pytest
-  tags: []          # 如需要 runner tag
+  tags: []          # Add runner tag if needed
   artifacts:
     when: always
     expire_in: 1 week
     paths:
-      - tests/        # 保存测试结果/覆盖率 html 可自行配置
+      - tests/        # Adjust path if storing test results/coverage HTML
 
 e2e:
   stage: e2e

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # ── Dockerfile ──
 # ---------------------------------------
-# 1) 基础镜像和依赖保持原样
+# 1) Base image and dependencies remain unchanged
 FROM python:3.11-slim
 RUN apt-get update \
     && apt-get install -y gdal-bin libgdal-dev \
@@ -13,15 +13,15 @@ RUN pip install --no-cache-dir -r requirements.txt
 ENV DJANGO_SETTINGS_MODULE=PlayNexus.settings
 
 # ---------------------------------------
-# 2) 把后端代码拷进去
+# 2) Copy backend code
 COPY backend ./backend
 
 RUN python backend/manage.py collectstatic --noinput
 
 # ---------------------------------------
-# 3) 关键补丁：让 /app 成为 Python 顶层包搜索路径
+# 3) Important tweak: make /app part of Python search path
 ENV PYTHONPATH="/app/backend:/app:${PYTHONPATH}"
 
 # ---------------------------------------
-# 4) 用带前缀的 wsgi 启动
+# 4) Start using the prefixed wsgi module
 CMD ["gunicorn", "backend.PlayNexus.wsgi:application", "--bind", "0.0.0.0:8000"]

--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ filtered by the given category. All activity list endpoints now return a
 paginated JSON object with `count`, `next`, `previous` and `results` fields.
 Use the items under `results` on the client.
 
+## Search API
+
+`GET /api/activities/?q=<query>&page=<n>` performs a text search across
+activity titles, descriptions and sport names. Optional `category` narrows the
+results. Facilities support the same `q` parameter. Enable trigram indexes for
+Postgres by setting `USE_TRIGRAM=True` in `backend/.env` and applying migrations.
+
 Disable pagination temporarily by passing `?no_page=1`.
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -11,3 +11,4 @@ ALLOWED_HOSTS=localhost,127.0.0.1,10.0.2.2
 # Stripe secrets (test mode)
 STRIPE_API_KEY=sk_test_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
+USE_TRIGRAM=False

--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -23,6 +23,7 @@ load_dotenv(BASE_DIR.parent / '.env')
 
 DEBUG = os.getenv("DEBUG", "False") == "True"
 SECRET_KEY = os.getenv("SECRET_KEY", "unsafe-secret-key")
+USE_TRIGRAM = os.getenv("USE_TRIGRAM", "False") == "True"
 
 ALLOWED_HOSTS = [
     'localhost',

--- a/backend/sports/migrations/0017_trigram_indexes.py
+++ b/backend/sports/migrations/0017_trigram_indexes.py
@@ -1,0 +1,41 @@
+from django.conf import settings
+from django.db import migrations
+
+
+def forwards(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'postgresql':
+        return
+    if not getattr(settings, 'USE_TRIGRAM', False):
+        return
+    schema_editor.execute("CREATE EXTENSION IF NOT EXISTS pg_trgm;")
+    schema_editor.execute(
+        "CREATE INDEX IF NOT EXISTS sports_activity_title_trgm ON sports_activity USING gin (title gin_trgm_ops);"
+    )
+    schema_editor.execute(
+        "CREATE INDEX IF NOT EXISTS sports_activity_description_trgm ON sports_activity USING gin (description gin_trgm_ops);"
+    )
+    schema_editor.execute(
+        "CREATE INDEX IF NOT EXISTS sports_facility_name_trgm ON sports_facility USING gin (name gin_trgm_ops);"
+    )
+
+
+def backwards(apps, schema_editor):
+    connection = schema_editor.connection
+    if connection.vendor != 'postgresql':
+        return
+    if not getattr(settings, 'USE_TRIGRAM', False):
+        return
+    schema_editor.execute("DROP INDEX IF EXISTS sports_activity_title_trgm;")
+    schema_editor.execute("DROP INDEX IF EXISTS sports_activity_description_trgm;")
+    schema_editor.execute("DROP INDEX IF EXISTS sports_facility_name_trgm;")
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0016_favorite_model'),
+    ]
+
+    operations = [
+        migrations.RunPython(forwards, backwards),
+    ]

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -2,6 +2,7 @@
 from django.db import transaction
 from django.contrib.gis.geos import Point
 from django.contrib.gis.db.models.functions import Distance
+from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
@@ -146,6 +147,19 @@ class ActivityViewSet(viewsets.ModelViewSet):
                 qs = qs.filter(discipline_id=int(category))
             except (TypeError, ValueError):
                 qs = qs.none()
+
+        query = self.request.query_params.get("q")
+        if query:
+            query = query.strip()
+            if len(query) > 64:
+                return qs.none()
+            qs = qs.filter(
+                Q(title__icontains=query)
+                | Q(description__icontains=query)
+                | Q(sport__name__icontains=query)
+                | Q(discipline__name__icontains=query)
+            )
+
         return qs
 
     def list(self, request, *args, **kwargs):
@@ -190,6 +204,15 @@ class FacilityViewSet(viewsets.ModelViewSet):
         if categories:
             names = categories.split(",")
             qs = qs.filter(categories__name__in=names).distinct()
+
+        query = self.request.query_params.get("q")
+        if query:
+            query = query.strip()
+            if len(query) > 64:
+                return qs.none()
+            qs = qs.filter(
+                Q(name__icontains=query) | Q(categories__name__icontains=query)
+            ).distinct()
 
         near = self.request.query_params.get("near")
         if near:

--- a/backend/tests/test_geo_api.py
+++ b/backend/tests/test_geo_api.py
@@ -21,8 +21,8 @@ pytestmark = [pytest.mark.django_db]
 
 
 def setup_data():
-    c1 = Category.objects.create(name="滑板")
-    c2 = Category.objects.create(name="冲浪")
+    c1 = Category.objects.create(name="Skateboard")
+    c2 = Category.objects.create(name="Surfing")
     f1 = Facility.objects.create(name="A", location=Point(0, 0), radius=1000)
     f1.categories.add(c1, c2)
     f2 = Facility.objects.create(
@@ -57,7 +57,7 @@ def test_facilities_filter_near_categories():
         {
             "near": "0,0",
             "radius": 2000,
-            "categories": "滑板,冲浪",
+            "categories": "Skateboard,Surfing",
         },
     )
     assert resp.status_code == 200

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -1,0 +1,107 @@
+import django
+django.setup()
+import pytest
+from rest_framework.test import APIClient
+from sports.models import Sport, Category, Activity, Facility
+from django.contrib.gis.geos import Point
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+def create_data():
+    sport1 = Sport.objects.create(name="Surf")
+    sport2 = Sport.objects.create(name="Bike")
+    cat1 = Category.objects.create(name="Water")
+    cat2 = Category.objects.create(name="Land")
+    Activity.objects.create(
+        sport=sport1,
+        discipline=cat1,
+        title="Surf Class",
+        description="Learn surfing",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    )
+    Activity.objects.create(
+        sport=sport2,
+        discipline=cat2,
+        title="Mountain Biking",
+        description="Ride the hills",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    )
+    Facility.objects.create(name="Surf Center", location=Point(0, 0))
+    f2 = Facility.objects.create(name="Bike Hub", location=Point(0, 0))
+    f2.categories.add(cat2)
+    return sport1, sport2, cat1, cat2
+
+
+def test_search_by_title(client):
+    create_data()
+    res = client.get("/api/activities/", {"q": "Surf"})
+    assert res.data["count"] == 1
+    assert res.data["results"][0]["title"] == "Surf Class"
+
+
+def test_search_by_description(client):
+    create_data()
+    res = client.get("/api/activities/", {"q": "hills"})
+    assert res.data["count"] == 1
+    assert res.data["results"][0]["title"] == "Mountain Biking"
+
+
+def test_search_by_sport_name(client):
+    create_data()
+    res = client.get("/api/activities/", {"q": "Surf"})
+    assert res.data["count"] == 1
+
+
+def test_search_category_filter(client):
+    _, _, cat1, _ = create_data()
+    res = client.get("/api/activities/", {"q": "Class", "category": cat1.id})
+    assert res.data["count"] == 1
+
+
+def test_search_no_match(client):
+    create_data()
+    res = client.get("/api/activities/", {"q": "Unknown"})
+    assert res.data["count"] == 0
+
+
+def test_search_pagination(client):
+    sport = Sport.objects.create(name="Run")
+    cat = Category.objects.create(name="Road")
+    for i in range(25):
+        Activity.objects.create(
+            sport=sport,
+            discipline=cat,
+            title=f"Run {i}",
+            description="Long run",
+            difficulty=1,
+            duration=60,
+            base_price=0,
+        )
+    res = client.get("/api/activities/", {"q": "Run", "page": 2})
+    assert res.data["previous"] is not None
+    assert res.data["count"] == 25
+
+
+def test_facility_search_by_name(client):
+    create_data()
+    res = client.get("/api/facilities/", {"q": "Bike"})
+    assert res.status_code == 200
+    assert len(res.data) == 1 or res.data["count"] == 1
+
+
+def test_facility_search_by_category(client):
+    create_data()
+    res = client.get("/api/facilities/", {"q": "Land"})
+    assert len(res.data) == 1 or res.data["count"] == 1
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,23 +1,23 @@
 # ── docker-compose.yml ──
-# 单文件即可一键起整个后端栈：PostgreSQL + Redis + Django(Gunicorn)
+# Single file to spin up the entire backend stack: PostgreSQL + Redis + Django (Gunicorn)
 # ---------------------------------------------------------------
 
 version: "3.9"
 
 ###############################################################################
-# 共享网络 & 卷
+# Shared network & volumes
 ###############################################################################
 networks:
   app-net:
     driver: bridge
 
 volumes:
-  dbdata:          # PostgreSQL 持久化
+  dbdata:          # PostgreSQL persistence
   media:
   # static:
 
 ###############################################################################
-# 服务定义
+# Service definitions
 ###############################################################################
 services:
   # ────────────────────────────────────────────────────────────── PostgreSQL ──
@@ -30,7 +30,7 @@ services:
       POSTGRES_PASSWORD: sportspwd
     volumes:
       - dbdata:/var/lib/postgresql/data
-    ports: ["5432:5432"]      # 仅本机调试需要，服务器部署可删
+    ports: ["5432:5432"]      # Only needed for local debugging; remove in production
     networks: [app-net]
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER -d $$POSTGRES_DB"]
@@ -42,7 +42,7 @@ services:
   redis:
     image: redis:7-alpine
     restart: unless-stopped
-    ports: ["6379:6379"]      # 同上，生产可删
+    ports: ["6379:6379"]      # Same as above, remove in production
     networks: [app-net]
     healthcheck:
       test: ["CMD", "redis-cli", "ping"]
@@ -53,7 +53,7 @@ services:
   # ──────────────────────────────────────────────────────────────── Django ────
   web:
     build:
-      context: .              # 根目录含 Dockerfile
+      context: .              # Root folder contains Dockerfile
       dockerfile: Dockerfile
     command: >
       gunicorn backend.PlayNexus.wsgi:application
@@ -61,14 +61,14 @@ services:
               --workers 3
               --timeout 120
     restart: unless-stopped
-    env_file: .env            # 秘钥、邮箱、Stripe 等都放这里
+    env_file: .env            # Secrets, email and Stripe settings
     environment:
       DJANGO_SETTINGS_MODULE: backend.PlayNexus.settings
-      # 仅开发机需要；部署到云服务器可在 .env 设置
+      # Needed only for development; configure in .env when deploying to the cloud
       ALLOWED_HOSTS: localhost,127.0.0.1,10.0.2.2
       API_BASE_URL: http://0.0.0.0:8000/api
     volumes:
-      - .:/app                # 代码热更新；生产可改成只挂 static/media
+      - .:/app                # Hot reload; mount only static/media in production
       - ./media:/app/media
       # - static:/app/static
     ports: ["8000:8000"]

--- a/lib/models/slot.dart
+++ b/lib/models/slot.dart
@@ -26,16 +26,16 @@ class Slot {
   final double   rating;
   final int      seatsLeft;
 
-  /// 允许后端返回 sport=ID 或 sport=Map 两种格式
+  /// Allows backend to return either sport=ID or sport=Map
   factory Slot.fromJson(Map<String, dynamic> j) {
     final dynamic sportRaw = j['sport'];
 
-    /// 解析 Sport
+    /// Parse Sport
     late final Sport sport;
     if (sportRaw is Map<String, dynamic>) {
       sport = Sport.fromJson(sportRaw);
     } else if (sportRaw is int) {
-      // 如果只有 ID，就先创建一个占位 Sport；需要时再去懒加载详情
+      // If only an ID is provided create placeholder Sport and lazy load details
       sport = Sport(id: sportRaw, name: '', banner: '', description: '');
     } else {
       throw const FormatException('Unsupported sport payload');
@@ -55,7 +55,7 @@ class Slot {
     );
   }
 
-  /// 方便之后可能的写操作
+  /// Convenience for potential future write operations
   Map<String, dynamic> toJson() => {
     'id'        : id,
     'sport'     : sport.id,

--- a/lib/models/sport.dart
+++ b/lib/models/sport.dart
@@ -9,7 +9,7 @@ class Sport {
 
   final int    id;
   final String name;
-  final String banner;          // 绝对 http(s) 或 asset 路径；永不为空
+  final String banner;          // Absolute http(s) or asset path; never empty
   final String description;
 
   factory Sport.fromJson(Map<String, dynamic> json) {
@@ -17,16 +17,16 @@ class Sport {
 
     late final String normalized;
     if (raw.startsWith('http')) {
-      // 完整网络 URL
+      // Full network URL
       normalized = raw;
     } else if (raw.startsWith('assets/')) {
-      // 已经是 asset 路径
+      // Already an asset path
       normalized = raw;
     } else if (raw.isNotEmpty) {
-      // 文件名 → 拼 asset
+      // File name → prepend asset path
       normalized = 'assets/images/$raw';
     } else {
-      // 空值 → 占位图
+      // Empty → placeholder image
       normalized = 'assets/images/default.jpg';
     }
 

--- a/lib/providers/search_provider.dart
+++ b/lib/providers/search_provider.dart
@@ -1,0 +1,130 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../models/activity.dart';
+import '../models/paginated.dart';
+import '../services/activity_service.dart';
+
+/// Holds the current search state and manages API requests.
+class SearchResultState {
+  const SearchResultState({
+    required this.query,
+    required this.items,
+    required this.page,
+    required this.hasNext,
+    required this.isLoading,
+    this.error,
+    required this.token,
+  });
+
+  final String query;
+  final List<Activity> items;
+  final int page;
+  final bool hasNext;
+  final bool isLoading;
+  final String? error;
+  final int token;
+
+  SearchResultState copyWith({
+    String? query,
+    List<Activity>? items,
+    int? page,
+    bool? hasNext,
+    bool? isLoading,
+    String? error,
+    int? token,
+  }) {
+    return SearchResultState(
+      query: query ?? this.query,
+      items: items ?? this.items,
+      page: page ?? this.page,
+      hasNext: hasNext ?? this.hasNext,
+      isLoading: isLoading ?? this.isLoading,
+      error: error,
+      token: token ?? this.token,
+    );
+  }
+
+  factory SearchResultState.initial() => const SearchResultState(
+        query: '',
+        items: [],
+        page: 1,
+        hasNext: false,
+        isLoading: false,
+        error: null,
+        token: 0,
+      );
+}
+
+final searchQueryProvider = StateProvider<String>((ref) => '');
+
+class SearchResultController extends StateNotifier<SearchResultState> {
+  SearchResultController(this.ref) : super(SearchResultState.initial());
+
+  final Ref ref;
+
+  void updateQuery(String value) {
+    ref.read(searchQueryProvider.notifier).state = value;
+    state = state.copyWith(query: value);
+  }
+
+  bool _outdated(int tok) => tok != state.token;
+
+  Future<void> search() async {
+    final q = state.query.trim();
+    final tok = state.token + 1;
+    state = state.copyWith(
+      items: [],
+      page: 1,
+      hasNext: true,
+      isLoading: true,
+      error: null,
+      token: tok,
+    );
+    if (q.length < 2) {
+      state = state.copyWith(isLoading: false, hasNext: false);
+      return;
+    }
+    try {
+      final Paginated<Activity> page =
+          await activityService.searchActivities(query: q, page: 1);
+      if (_outdated(tok)) return;
+      state = state.copyWith(
+        items: page.results,
+        page: 1,
+        hasNext: page.next != null,
+        isLoading: false,
+        token: tok,
+      );
+    } catch (e) {
+      if (_outdated(tok)) return;
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+
+  Future<void> loadMore() async {
+    if (state.isLoading || !state.hasNext) return;
+    final q = state.query.trim();
+    final tok = state.token;
+    state = state.copyWith(isLoading: true, error: null);
+    try {
+      final page = await activityService.searchActivities(
+        query: q,
+        page: state.page + 1,
+      );
+      if (_outdated(tok)) return;
+      state = state.copyWith(
+        items: [...state.items, ...page.results],
+        page: state.page + 1,
+        hasNext: page.next != null,
+        isLoading: false,
+      );
+    } catch (e) {
+      if (_outdated(tok)) return;
+      state = state.copyWith(isLoading: false, error: e.toString());
+    }
+  }
+}
+
+final searchResultProvider =
+    StateNotifierProvider<SearchResultController, SearchResultState>((ref) {
+  return SearchResultController(ref);
+});

--- a/lib/repository/search_history_repository.dart
+++ b/lib/repository/search_history_repository.dart
@@ -1,0 +1,24 @@
+import 'package:shared_preferences/shared_preferences.dart';
+
+/// Maintains a simple local search history list of up to 10 unique terms.
+class SearchHistoryRepository {
+  static const _key = 'search_history';
+
+  Future<List<String>> load() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getStringList(_key) ?? <String>[];
+  }
+
+  Future<void> add(String query) async {
+    final prefs = await SharedPreferences.getInstance();
+    final history = prefs.getStringList(_key) ?? <String>[];
+    history.remove(query);
+    history.insert(0, query);
+    if (history.length > 10) {
+      history.removeRange(10, history.length);
+    }
+    await prefs.setStringList(_key, history);
+  }
+}
+
+final searchHistoryRepository = SearchHistoryRepository();

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -85,17 +85,17 @@ class _ActivitiesByCategoryPageState
             _items.addAll(page.results);
             _hasNext = page.next != null;
           }
-          // 当没有任何活动时，显示空态并提供返回或创建入口
+          // When there are no activities show an empty state with options
           if (_items.isEmpty) {
             return Center(
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('该分类暂无活动'),
+                    const Text('No activities in this category'),
                   const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: () => Navigator.pop(context),
-                    child: const Text('返回'),
+                      child: const Text('Back'),
                   ),
                   const SizedBox(height: 8),
                   ElevatedButton(
@@ -111,7 +111,7 @@ class _ActivitiesByCategoryPageState
                         );
                       }
                     },
-                    child: const Text('去创建'),
+                      child: const Text('Create one'),
                   ),
                 ],
               ),
@@ -124,7 +124,7 @@ class _ActivitiesByCategoryPageState
               itemCount: _items.length + 1,
               itemBuilder: (context, i) {
                 if (i == _items.length) {
-                  // 调整加载更多尾部逻辑，避免在无更多数据时渲染空白
+                  // Adjust footer logic to avoid blank space when no more data
                   if (_loadingMore) {
                     return const Padding(
                       padding: EdgeInsets.all(16),
@@ -137,7 +137,7 @@ class _ActivitiesByCategoryPageState
                     }
                     return const Padding(
                       padding: EdgeInsets.all(16),
-                      child: Center(child: Text('没有更多数据')), 
+                        child: Center(child: Text('No more data')),
                     );
                   }
                   return Center(

--- a/lib/screens/favorites_page.dart
+++ b/lib/screens/favorites_page.dart
@@ -93,13 +93,13 @@ class _FavoritesPageState extends ConsumerState<FavoritesPage> {
               child: Column(
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
-                  const Text('还没有收藏'),
+                    const Text('No favorites yet'),
                   const SizedBox(height: 12),
                   ElevatedButton(
                     onPressed: () => Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(builder: (_) => const HomePage())),
-                    child: const Text('去浏览活动'),
+                      child: const Text('Browse activities'),
                   ),
                 ],
               ),
@@ -122,7 +122,7 @@ class _FavoritesPageState extends ConsumerState<FavoritesPage> {
                       if (!_hasNext) {
                         return const Padding(
                           padding: EdgeInsets.all(16),
-                          child: Center(child: Text('没有更多数据')),
+                          child: Center(child: Text('No more data')),
                         );
                       }
                       return Padding(

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -54,7 +54,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   Widget build(BuildContext context) {
     final double paddingTop = MediaQuery.of(context).padding.top;
 
-    // ========== 监听 Provider ==========
+    // ========== Listen to Providers ==========
     final categoriesAsync = ref.watch(categoriesProvider);
     final nearbyActsAsync = ref.watch(nearbyActivitiesProvider);
     final featuredCatsAsync = ref.watch(featuredCategoriesProvider);
@@ -67,7 +67,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             ? const BookingsPage()
             : CustomScrollView(
         slivers: [
-          // ================= Hero + Search + Quick Filters（保持不变） =================
+          // ================= Hero + Search + Quick Filters (unchanged) =================
           SliverAppBar(
             automaticallyImplyLeading: false,
             expandedHeight: 360,
@@ -226,7 +226,7 @@ class _HomePageState extends ConsumerState<HomePage> {
             ),
           ),
 
-          // ================= Categories（保持不变） =================
+            // ================= Categories (unchanged) =================
           SliverPadding(
             padding: const EdgeInsets.fromLTRB(16, 24, 0, 0),
             sliver: SliverToBoxAdapter(
@@ -405,11 +405,11 @@ class _HomePageState extends ConsumerState<HomePage> {
                 child = Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text('请先登录查看 Continue planning'),
+                      const Text('Please log in to view Continue planning'),
                     const SizedBox(height: 8),
                     ElevatedButton(
                       onPressed: () => showAuthSheet(context),
-                      child: const Text('登录'),
+                      child: const Text('Log in'),
                     ),
                   ],
                 );
@@ -417,10 +417,10 @@ class _HomePageState extends ConsumerState<HomePage> {
                 child = Column(
                   crossAxisAlignment: CrossAxisAlignment.start,
                   children: [
-                    const Text('加载失败，请重试'),
+                    const Text('Failed to load, please retry'),
                     const SizedBox(height: 8),
                     ElevatedButton(
-                      // 触发重新拉取；refresh 或 invalidate 都可
+                      // Trigger a refresh; either refresh or invalidate works
                       onPressed: () => ref.refresh(continuePlanningProvider),
                       child: const Text('Retry'),
                     ),
@@ -434,7 +434,7 @@ class _HomePageState extends ConsumerState<HomePage> {
                 ),
               );
             },
-            // 之前缺少的 data 分支：把页面渲染代码包进来
+            // Previously missing data branch: render the page here
             data: (page) {
               final acts = page.results;
               if (acts.isEmpty) {
@@ -510,7 +510,7 @@ class _HomePageState extends ConsumerState<HomePage> {
   }
 }
 
-// ======================== 小型私有组件（原样保留） ========================
+// ======================== Small private widgets (unchanged) ========================
 
 class _NotificationBell extends StatelessWidget {
   final int count;

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -11,6 +11,7 @@ import '../widgets/more_category_card.dart';
 import '../widgets/activity_card.dart';
 import '../widgets/project_card.dart';
 import '../widgets/search_bar.dart';
+import 'search_page.dart';
 import 'categories_page.dart';
 import 'activities_by_category_page.dart';
 
@@ -133,7 +134,16 @@ class _HomePageState extends ConsumerState<HomePage> {
                         opacity: opacity,
                         child: Row(
                           children: [
-                            const Expanded(child: RoundedSearchBar()),
+                            Expanded(
+                              child: RoundedSearchBar(
+                                onTap: () => Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                    builder: (_) => const SearchPage(),
+                                  ),
+                                ),
+                              ),
+                            ),
                             const SizedBox(width: 12),
                             IconButton(
                               icon: const Icon(Icons.person_outline),

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -1,0 +1,176 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers/search_provider.dart';
+import '../repository/search_history_repository.dart';
+import '../widgets/activity_card.dart';
+import 'activity_detail_page.dart';
+
+class SearchPage extends ConsumerStatefulWidget {
+  const SearchPage({super.key});
+
+  @override
+  ConsumerState<SearchPage> createState() => _SearchPageState();
+}
+
+class _SearchPageState extends ConsumerState<SearchPage> {
+  final _controller = TextEditingController();
+  final _scroll = ScrollController();
+  Timer? _debounce;
+  List<String> _history = [];
+
+  @override
+  void initState() {
+    super.initState();
+    _loadHistory();
+    _scroll.addListener(() {
+      if (_scroll.position.pixels >
+          _scroll.position.maxScrollExtent - 200) {
+        ref.read(searchResultProvider.notifier).loadMore();
+      }
+    });
+  }
+
+  Future<void> _loadHistory() async {
+    final list = await searchHistoryRepository.load();
+    if (mounted) {
+      setState(() => _history = list);
+    }
+  }
+
+  void _onChanged(String value) {
+    ref.read(searchResultProvider.notifier).updateQuery(value);
+    _debounce?.cancel();
+    if (value.trim().length >= 2) {
+      _debounce = Timer(const Duration(milliseconds: 300), () async {
+        await ref.read(searchResultProvider.notifier).search();
+        await searchHistoryRepository.add(value.trim());
+        _loadHistory();
+      });
+    } else {
+      ref.read(searchResultProvider.notifier).search();
+    }
+  }
+
+  @override
+  void dispose() {
+    _debounce?.cancel();
+    _controller.dispose();
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final state = ref.watch(searchResultProvider);
+    return Scaffold(
+      appBar: AppBar(
+        title: TextField(
+          controller: _controller,
+          autofocus: true,
+          decoration: InputDecoration(
+            hintText: '搜索活动、运动或地点',
+            suffixIcon: _controller.text.isNotEmpty
+                ? IconButton(
+                    icon: const Icon(Icons.clear),
+                    onPressed: () {
+                      _controller.clear();
+                      _onChanged('');
+                    },
+                  )
+                : null,
+          ),
+          onChanged: _onChanged,
+        ),
+      ),
+      body: state.isLoading && state.items.isEmpty
+          ? const Center(child: CircularProgressIndicator())
+          : state.error != null
+              ? Center(
+                  child: Column(
+                    mainAxisAlignment: MainAxisAlignment.center,
+                    children: [
+                      Text('Error: ${state.error}'),
+                      const SizedBox(height: 8),
+                      ElevatedButton(
+                        onPressed:
+                            () => ref.read(searchResultProvider.notifier).search(),
+                        child: const Text('Retry'),
+                      ),
+                    ],
+                  ),
+                )
+              : state.items.isEmpty
+                  ? _buildHistory()
+                  : _buildList(state),
+    );
+  }
+
+  Widget _buildHistory() {
+    if (_history.isEmpty) {
+      return const Center(child: Text('暂无搜索记录'));
+    }
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Wrap(
+        spacing: 8,
+        children: _history
+            .map(
+              (h) => ActionChip(
+                label: Text(h),
+                onPressed: () {
+                  _controller.text = h;
+                  _onChanged(h);
+                },
+              ),
+            )
+            .toList(),
+      ),
+    );
+  }
+
+  Widget _buildList(SearchResultState state) {
+    return ListView.builder(
+      controller: _scroll,
+      padding: const EdgeInsets.all(16),
+      itemCount: state.items.length + 1,
+      itemBuilder: (context, i) {
+        if (i == state.items.length) {
+          if (state.isLoading) {
+            return const Padding(
+              padding: EdgeInsets.all(16),
+              child: Center(child: CircularProgressIndicator()),
+            );
+          }
+          if (!state.hasNext) {
+            return const SizedBox.shrink();
+          }
+          return const SizedBox(height: 16);
+        }
+        final act = state.items[i];
+        return Padding(
+          padding: const EdgeInsets.only(bottom: 12),
+          child: ActivityCard(
+            title: act.title,
+            location: '',
+            price: act.basePrice,
+            rating: 0,
+            reviews: 0,
+            asset: act.imageUrl ?? act.image,
+            isFavorite: false,
+            onFavorite: () {},
+            onTap: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (_) => ActivityDetailPage(activity: act),
+                ),
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+

--- a/lib/screens/search_page.dart
+++ b/lib/screens/search_page.dart
@@ -69,7 +69,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
           controller: _controller,
           autofocus: true,
           decoration: InputDecoration(
-            hintText: '搜索活动、运动或地点',
+            hintText: 'Search activities, sports or locations',
             suffixIcon: _controller.text.isNotEmpty
                 ? IconButton(
                     icon: const Icon(Icons.clear),
@@ -108,7 +108,7 @@ class _SearchPageState extends ConsumerState<SearchPage> {
 
   Widget _buildHistory() {
     if (_history.isEmpty) {
-      return const Center(child: Text('暂无搜索记录'));
+        return const Center(child: Text('No search history'));
     }
     return Padding(
       padding: const EdgeInsets.all(16),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -42,6 +42,18 @@ class ActivityService {
     });
   }
 
+  Future<Paginated<Activity>> searchActivities({
+    required String query,
+    int? categoryId,
+    int page = 1,
+  }) async {
+    return fetchActivities(params: {
+      'q': query,
+      if (categoryId != null) 'category': categoryId,
+      'page': page,
+    });
+  }
+
   Future<Activity> fetchById(int id) async {
     final Response res = await apiClient.get('/activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -59,6 +59,24 @@ class FacilityService {
   Future<void> deleteFacility(int id) async {
     await apiClient.delete('/facilities/$id/');
   }
+
+  Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {
+    final res = await apiClient.get('/facilities/', queryParameters: {
+      'q': query,
+      'page': page,
+    });
+    dynamic data = res.data;
+    if (data is Map && data['results'] is List) {
+      data = data['results'];
+    }
+    if (data is! List) {
+      throw Exception('Unexpected response format');
+    }
+    return data
+        .cast<Map<String, dynamic>>()
+        .map(Facility.fromJson)
+        .toList(growable: false);
+  }
 }
 
 final facilityService = FacilityService();

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -18,7 +18,7 @@ class SlotService {
       queryParameters: {'sport': sportId},
     );
 
-    // 如果后端以后改成 {"results":[...]} 也能兼容
+    // Compatible if backend later switches to {"results": [...]} format
     final dynamic payload = res.data;
     final List data = payload is Map ? payload['results'] as List : payload as List;
 

--- a/lib/widgets/activity_card.dart
+++ b/lib/widgets/activity_card.dart
@@ -1,5 +1,5 @@
 // lib/widgets/activity_card.dart
-// -- 既支持本地 asset，又支持网络 URL 的卡片 ---------------------------
+// -- Card supporting both local assets and network URLs ---------------------------
 import 'package:flutter/material.dart';
 import 'package:flutter_rating_bar/flutter_rating_bar.dart';
 
@@ -9,7 +9,7 @@ class ActivityCard extends StatelessWidget {
   final double price;
   final double rating;
   final int reviews;
-  final String asset;            // 本地或网络路径
+  final String asset;            // Local or network path
   final VoidCallback onTap;
   final VoidCallback onFavorite;
   final bool isFavorite;
@@ -27,7 +27,7 @@ class ActivityCard extends StatelessWidget {
     required this.isFavorite,
   });
 
-  // ----- 私有：生成图片组件，自动判断网络 / 本地 -------------------------
+  // ----- Private: build image widget, automatically choose network/local ------
   Widget _buildHeroImage() {
     final path = asset.isNotEmpty ? asset : 'assets/images/default.jpg';
     if (path.startsWith('http')) {

--- a/lib/widgets/app_bottom_nav.dart
+++ b/lib/widgets/app_bottom_nav.dart
@@ -4,7 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers/favorite_provider.dart';
 import '../utils/theme.dart';
 
-/// Material-3 风格底栏：Icon + Label，全局 4 个目的地
+/// Material-3 style bottom navigation: icon + label with four destinations
 class AppBottomNav extends ConsumerWidget {
   final int index;
   final ValueChanged<int> onTap;
@@ -12,7 +12,7 @@ class AppBottomNav extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    // —— 构造带徽标的图标 —— //
+    // —— Build icon with optional badge —— //
     Widget _icon(IconData outlined, IconData filled,
         {required bool selected, int badge = 0}) {
       final icon = Icon(
@@ -21,7 +21,7 @@ class AppBottomNav extends ConsumerWidget {
         color: selected ? AppTheme.primary : Colors.black54,
       );
 
-      // 如需徽标
+      // Add badge if needed
       if (badge == 0) return icon;
       return Stack(
         clipBehavior: Clip.none,
@@ -51,7 +51,7 @@ class AppBottomNav extends ConsumerWidget {
       height: 72,
       elevation: 0,
       backgroundColor: Colors.white,
-      indicatorColor: AppTheme.primary.withOpacity(.12),          // 圆形水滴
+        indicatorColor: AppTheme.primary.withOpacity(.12),          // circular indicator
       surfaceTintColor: Colors.white,
       selectedIndex: index,
       labelBehavior: NavigationDestinationLabelBehavior.alwaysShow,

--- a/lib/widgets/more_category_card.dart
+++ b/lib/widgets/more_category_card.dart
@@ -1,7 +1,7 @@
 // ========== lib/widgets/more_category_card.dart ==========
 import 'package:flutter/material.dart';
 
-/// 横向列表最后一个“More”卡片：边框 + 三点图标
+/// "More" card used at the end of a horizontal list: border + ellipsis icon
 class MoreCategoryCard extends StatelessWidget {
   final VoidCallback onTap;
   const MoreCategoryCard({super.key, required this.onTap});

--- a/lib/widgets/search_bar.dart
+++ b/lib/widgets/search_bar.dart
@@ -22,7 +22,7 @@ class RoundedSearchBar extends StatelessWidget {
         borderRadius: BorderRadius.circular(height / 2),
         child: ClipRRect(
           borderRadius: BorderRadius.circular(height / 2),
-          child: BackdropFilter(          // 轻磨砂，提升质感
+          child: BackdropFilter(          // subtle blur for a polished look
             filter: ImageFilter.blur(sigmaX: 3, sigmaY: 3),
             child: Container(
               height: height,

--- a/lib/widgets/slot_card.dart
+++ b/lib/widgets/slot_card.dart
@@ -66,7 +66,7 @@ class SlotCard extends StatelessWidget {
   }
 }
 
-/// 智能图片组件：支持网络 / 本地，并始终回退到占位图
+/// Smart image widget supporting network/local sources with fallback
 class _SmartImage extends StatelessWidget {
   const _SmartImage({required this.url});
 
@@ -74,7 +74,7 @@ class _SmartImage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    // 若为空，直接使用占位路径（防御性）
+      // Use placeholder if empty (defensive)
     final path = url.isNotEmpty ? url : 'assets/images/hiking.jpg';
     final isRemote = path.startsWith('http');
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,7 @@ dependencies:
   google_sign_in: ^6.1.5
   qr_flutter: ^4.1.0
   flutter_stripe: ^10.0.0
+  shared_preferences: ^2.2.2
 
 dev_dependencies:
   flutter_test:

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,8 +14,8 @@ Pillow==11.3.0
 stripe==9.8.0
 python-dotenv==1.0.1
 
-# 新增：容器/CI 运行必备
-psycopg2-binary==2.9.9      # Postgres 驱动
-gunicorn==21.2.0            # 生产 WSGI
-flake8==6.1.0               # 代码规范检查
+# Added: required for container/CI
+psycopg2-binary==2.9.9      # Postgres driver
+gunicorn==21.2.0            # production WSGI server
+flake8==6.1.0               # code style check
 pytest-django==4.8.0


### PR DESCRIPTION
## Summary
- add USE_TRIGRAM setting and optional trigram index migration
- support q parameter on activities and facilities
- create search history repository and provider
- add new SearchPage and integrate in HomePage
- expose search APIs in services
- document search API usage

## Testing
- `pip install -r requirements.txt`
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend/tests/test_search.py -q` *(fails: GDAL library not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6889e80955648326ba0bdf56c3e1f082