### PR TITLE
Fix notification loading and API paths

### DIFF
--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -72,7 +72,9 @@ String _errMsg(Object e) {
     final data = e.response?.data;
     if (data is Map && data['detail'] != null) return data['detail'].toString();
     if (data is String && data.isNotEmpty) return data;
-    return 'HTTP ${e.response?.statusCode ?? ''} ${e.message}';
+    final code = e.response?.statusCode ?? '';
+    final msg = e.message ?? e.error?.toString() ?? '';
+    return 'HTTP $code $msg'.trim();
   }
   return e.toString();
 }

--- a/lib/providers/notification_provider.dart
+++ b/lib/providers/notification_provider.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'package:dio/dio.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/app_notification.dart';
 import '../services/notification_service.dart';
@@ -66,6 +67,16 @@ class NotificationListState {
   factory NotificationListState.initial() => const NotificationListState();
 }
 
+String _errMsg(Object e) {
+  if (e is DioException) {
+    final data = e.response?.data;
+    if (data is Map && data['detail'] != null) return data['detail'].toString();
+    if (data is String && data.isNotEmpty) return data;
+    return 'HTTP ${e.response?.statusCode ?? ''} ${e.message}';
+  }
+  return e.toString();
+}
+
 class NotificationListController extends StateNotifier<NotificationListState> {
   NotificationListController(this.ref) : super(NotificationListState.initial());
 
@@ -85,7 +96,7 @@ class NotificationListController extends StateNotifier<NotificationListState> {
       );
       ref.read(unreadCountProvider.notifier).refresh();
     } catch (e) {
-      state = state.copyWith(isLoading: false, error: e.toString());
+      state = state.copyWith(isLoading: false, error: _errMsg(e));
     } finally {
       _inFlightPage = null;
     }
@@ -107,7 +118,7 @@ class NotificationListController extends StateNotifier<NotificationListState> {
         isLoading: false,
       );
     } catch (e) {
-      state = state.copyWith(isLoading: false, error: e.toString());
+      state = state.copyWith(isLoading: false, error: _errMsg(e));
     } finally {
       _inFlightPage = null;
     }
@@ -134,7 +145,7 @@ class NotificationListController extends StateNotifier<NotificationListState> {
       );
       ref.read(unreadCountProvider.notifier).refresh();
     } catch (e) {
-      state = state.copyWith(error: e.toString());
+      state = state.copyWith(error: _errMsg(e));
     }
   }
 
@@ -161,7 +172,7 @@ class NotificationListController extends StateNotifier<NotificationListState> {
       state = state.copyWith(items: updated, error: null);
       ref.read(unreadCountProvider.notifier).refresh();
     } catch (e) {
-      state = state.copyWith(error: e.toString());
+      state = state.copyWith(error: _errMsg(e));
     }
   }
 }

--- a/lib/screens/notifications_page.dart
+++ b/lib/screens/notifications_page.dart
@@ -49,7 +49,7 @@ class _NotificationsPageState extends ConsumerState<NotificationsPage> {
             child: Column(
               mainAxisSize: MainAxisSize.min,
               children: [
-                const Text('加载失败'),
+                Text(state.error!.split('\n').first),
                 const SizedBox(height: 8),
                 ElevatedButton(
                   onPressed: () =>

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -18,7 +18,7 @@ class ActivityService {
   }
 
   Future<Paginated<Activity>> fetchActivities({Map<String, dynamic>? params}) async {
-    final res = await apiClient.get('/activities/', queryParameters: params);
+    final res = await apiClient.get('activities/', queryParameters: params);
     return _parsePage(res.data);
   }
 
@@ -55,7 +55,7 @@ class ActivityService {
   }
 
   Future<Activity> fetchById(int id) async {
-    final Response res = await apiClient.get('/activities/$id/');
+    final Response res = await apiClient.get('activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
@@ -69,7 +69,7 @@ class ActivityService {
     int duration,
     double basePrice,
   ) async {
-    await apiClient.post('/activities/', data: {
+    await apiClient.post('activities/', data: {
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
@@ -92,7 +92,7 @@ class ActivityService {
     int duration,
     double basePrice,
   ) async {
-    await apiClient.patch('/activities/' + id.toString() + '/', data: {
+    await apiClient.patch('activities/' + id.toString() + '/', data: {
       'sport': sport,
       'discipline': discipline,
       'variant': variant,

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -10,11 +10,11 @@ late Dio apiClient;
 
 /// Call after dotenv.load to construct the client with the base URL.
 void initApiClient() {
-  var base = dotenv.env['API_BASE_URL']!; // e.g. http://10.0.2.2:8000/api
-  if (!base.endsWith('/')) base += '/';
+  var base = dotenv.env['API_BASE_URL'] ?? '';
+  base = base.replaceAll(RegExp(r'/+\$'), '');
   apiClient = Dio(
     BaseOptions(
-      baseUrl: base,
+      baseUrl: '$base/',
       connectTimeout: const Duration(seconds: 15),
       receiveTimeout: const Duration(seconds: 15),
       responseType: ResponseType.json,
@@ -26,6 +26,7 @@ void initApiClient() {
 }
 
 final _storage = const FlutterSecureStorage();
+bool _refreshing = false;
 
 /// Attach Authorization header if token is stored.
 void initAuthInterceptor() {
@@ -39,17 +40,24 @@ void initAuthInterceptor() {
         handler.next(options);
       },
       onError: (err, handler) async {
-        if (err.response?.statusCode == 401) {
+        if (err.response?.statusCode == 401 && !_refreshing) {
           final refresh = await _storage.read(key: 'refresh');
           if (refresh != null) {
+            _refreshing = true;
             try {
-              final res = await apiClient.post('/auth/token/refresh/', data: {'refresh': refresh});
+              final res = await apiClient.post('auth/token/refresh/', data: {'refresh': refresh});
               final access = res.data['access'];
               await _storage.write(key: 'access', value: access);
+              apiClient.options.headers['Authorization'] = 'Bearer $access';
               err.requestOptions.headers['Authorization'] = 'Bearer $access';
               final cloneReq = await apiClient.fetch(err.requestOptions);
+              _refreshing = false;
               return handler.resolve(cloneReq);
-            } catch (_) {}
+            } catch (_) {
+              await _storage.delete(key: 'access');
+              await _storage.delete(key: 'refresh');
+              _refreshing = false;
+            }
           }
         }
         handler.next(err);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -10,7 +10,7 @@ class AuthService {
 
   Future<void> login(String email, String password) async {
     final Response res = await apiClient.post(
-      '/auth/login/',
+      'auth/login/',
       data: {'email': email, 'password': password},
     );
     final access = res.data['access'];
@@ -22,7 +22,7 @@ class AuthService {
 
   Future<void> register(String email, String password1, String password2) async {
     final Response res = await apiClient.post(
-      '/auth/registration/',
+      'auth/registration/',
       data: {
         'email': email,
         'password1': password1,
@@ -38,7 +38,7 @@ class AuthService {
 
   Future<void> registerProvider(String email, String p1, String p2, String name, String phone, String address) async {
     final Response res = await apiClient.post(
-      '/provider/register/',
+      'provider/register/',
       data: {
         'email': email,
         'password1': p1,
@@ -60,7 +60,7 @@ class AuthService {
     if (account == null) return;
     final auth = await account.authentication;
     final Response res = await apiClient.post(
-      '/auth/google/',
+      'auth/google/',
       data: {'id_token': auth.idToken},
     );
     final access = res.data['access'];
@@ -73,7 +73,7 @@ class AuthService {
   Future<void> logout() async {
     try {
       final refresh = await _storage.read(key: 'refresh');
-      await apiClient.post('/auth/logout/', data: {'refresh': refresh});
+      await apiClient.post('auth/logout/', data: {'refresh': refresh});
     } finally {
       await _storage.delete(key: 'access');
       await _storage.delete(key: 'refresh');
@@ -82,14 +82,14 @@ class AuthService {
   }
 
   Future<void> requestPasswordReset(String email) async {
-    await apiClient.post('/auth/password/reset/', data: {'email': email});
+    await apiClient.post('auth/password/reset/', data: {'email': email});
   }
 
   Future<void> refresh() async {
     final refresh = await _storage.read(key: 'refresh');
     if (refresh == null) return;
     final Response res = await apiClient.post(
-      '/auth/token/refresh/',
+      'auth/token/refresh/',
       data: {'refresh': refresh},
     );
     final access = res.data['access'];

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -6,7 +6,7 @@ import 'api_client.dart';
 
 class BookingService {
   Future<List<Booking>> fetchMine() async {
-    final res = await apiClient.get('/bookings/');
+    final res = await apiClient.get('bookings/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Booking.fromJson)
@@ -15,7 +15,7 @@ class BookingService {
 
   Future<Booking> create(int slotId, {int pax = 1}) async {
     final res = await apiClient.post(
-      '/bookings/',
+      'bookings/',
       data: {'slot_id': slotId, 'pax': pax},
       options: Options(contentType: Headers.formUrlEncodedContentType),
     );
@@ -23,7 +23,7 @@ class BookingService {
   }
 
   Future<Booking> fetchById(int id) async {
-    final res = await apiClient.get('/bookings/' + id.toString() + '/');
+    final res = await apiClient.get('bookings/' + id.toString() + '/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -6,7 +6,7 @@ class FacilityService {
   Future<List<Facility>> fetchFacilities(
       List<String> categories, double radius, double lat, double lng,
       {bool mine = false}) async {
-    final res = await apiClient.get('/facilities/', queryParameters: {
+    final res = await apiClient.get('facilities/', queryParameters: {
       'categories': categories.join(','),
       if (radius > 0) 'radius': radius.toInt(),
       if (lat != 0 || lng != 0) 'near': '$lat,$lng',
@@ -31,7 +31,7 @@ class FacilityService {
   Future<void> createFacility(
       String name, double lat, double lng, List<String> categories,
       {double radius = 1000}) async {
-    await apiClient.post('/facilities/', data: {
+    await apiClient.post('facilities/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
@@ -47,7 +47,7 @@ class FacilityService {
   Future<void> updateFacility(
       int id, String name, double lat, double lng, List<String> categories,
       {double radius = 1000}) async {
-    await apiClient.patch('/facilities/$id/', data: {
+    await apiClient.patch('facilities/$id/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
@@ -57,11 +57,11 @@ class FacilityService {
   }
 
   Future<void> deleteFacility(int id) async {
-    await apiClient.delete('/facilities/$id/');
+    await apiClient.delete('facilities/$id/');
   }
 
   Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {
-    final res = await apiClient.get('/facilities/', queryParameters: {
+    final res = await apiClient.get('facilities/', queryParameters: {
       'q': query,
       'page': page,
     });

--- a/lib/services/favorite_service.dart
+++ b/lib/services/favorite_service.dart
@@ -14,12 +14,12 @@ class FriendlyError implements Exception {
 
 class FavoriteService {
   Future<Set<int>> fetchFavoriteIds() async {
-    final Response res = await apiClient.get('/favorites/ids/');
+    final Response res = await apiClient.get('favorites/ids/');
     return (res.data as List).cast<int>().toSet();
   }
 
   Future<Paginated<Activity>> listFavorites({int page = 1, int pageSize = 20}) async {
-    final Response res = await apiClient.get('/favorites/', queryParameters: {
+    final Response res = await apiClient.get('favorites/', queryParameters: {
       'page': page,
       'page_size': pageSize,
     });
@@ -29,7 +29,7 @@ class FavoriteService {
 
   Future<bool> toggle(int activityId) async {
     try {
-      final Response res = await apiClient.post('/activities/$activityId/favorite/toggle/');
+      final Response res = await apiClient.post('activities/$activityId/favorite/toggle/');
       return res.data['favorited'] as bool? ?? true;
     } on DioException catch (e) {
       if (e.response?.statusCode == 401) throw UnauthorizedError();

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -6,7 +6,7 @@ import 'api_client.dart';
 
 class HomeService {
   Future<List<FeaturedCategory>> fetchFeaturedCategories() async {
-    final res = await apiClient.get('/featured-categories/');
+    final res = await apiClient.get('featured-categories/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(FeaturedCategory.fromJson)
@@ -14,7 +14,7 @@ class HomeService {
   }
 
   Future<List<FeaturedActivity>> fetchFeaturedActivities() async {
-    final res = await apiClient.get('/featured-activities/');
+    final res = await apiClient.get('featured-activities/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(FeaturedActivity.fromJson)
@@ -35,7 +35,7 @@ class HomeService {
   }
 
   Future<Paginated<Activity>> fetchContinuePlanning() async {
-    final res = await apiClient.get('/home/continue-planning/');
+    final res = await apiClient.get('home/continue-planning/');
     final data = res.data;
     if (data is List) {
       return Paginated.fromList(

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -5,7 +5,7 @@ import 'api_client.dart';
 class PaymentService {
   Future<Map<String, dynamic>> createIntent(int slotId) async {
     try {
-      final res = await apiClient.post('/payments/checkout/', data: {'slot': slotId});
+      final res = await apiClient.post('payments/checkout/', data: {'slot': slotId});
       return res.data as Map<String, dynamic>;
     } on DioException catch (e) {
       if (e.response?.data is Map && e.response?.data['detail'] != null) {
@@ -16,12 +16,12 @@ class PaymentService {
   }
 
   Future<Booking> confirmIntent(String intentId) async {
-    final res = await apiClient.get('/payments/confirm/$intentId/');
+    final res = await apiClient.get('payments/confirm/$intentId/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 
   Future<Booking> fetchBooking(int bookingId) async {
-    final res = await apiClient.get('/bookings/' + bookingId.toString() + '/');
+    final res = await apiClient.get('bookings/' + bookingId.toString() + '/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/profile_service.dart
+++ b/lib/services/profile_service.dart
@@ -5,12 +5,12 @@ import 'api_client.dart';
 
 class ProfileService {
   Future<Profile> fetch() async {
-    final Response res = await apiClient.get('/profile/');
+    final Response res = await apiClient.get('profile/');
     return Profile.fromJson(res.data as Map<String, dynamic>);
   }
 
   Future<Profile> update(Map<String, dynamic> data) async {
-    final Response res = await apiClient.put('/provider/profile/', data: data);
+    final Response res = await apiClient.put('provider/profile/', data: data);
     return Profile.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -5,7 +5,7 @@ import 'api_client.dart';
 class ReviewService {
   Future<List<Review>> fetchReviews(int activityId, {int? limit}) async {
     final Response res = await apiClient.get(
-      '/activities/$activityId/reviews/',
+      'activities/$activityId/reviews/',
       queryParameters: limit != null ? {'limit': limit} : null,
     );
     return (res.data as List)
@@ -17,7 +17,7 @@ class ReviewService {
   Future<Review> createReview(
       int activityId, int rating, String comment) async {
     final Response res = await apiClient.post(
-      '/activities/$activityId/reviews/',
+      'activities/$activityId/reviews/',
       data: {'rating': rating, 'comment': comment},
     );
     return Review.fromJson(res.data as Map<String, dynamic>);

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -14,7 +14,7 @@ class SlotService {
   /// GET /api/slots/?sport=<sportId>
   Future<List<Slot>> fetchBySport(int sportId) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {'sport': sportId},
     );
 
@@ -32,7 +32,7 @@ class SlotService {
   /// only return slots from now onwards.
   Future<List<Slot>> fetchByActivity(int activityId) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'activity': activityId,
         'after': _iso(DateTime.now()),
@@ -50,7 +50,7 @@ class SlotService {
 
   Future<List<Slot>> fetchBySportDate(int sportId, DateTime after) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'sport': sportId,
         'after': _iso(after),
@@ -70,7 +70,7 @@ class SlotService {
     final start = DateTime.utc(date.year, date.month, date.day);
     final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'activity': activityId,
         'after': _iso(start),
@@ -95,7 +95,7 @@ class SlotService {
       double price,
       String title,
       String location,) async {
-    await apiClient.post('/merchant/slots/', data: {
+    await apiClient.post('merchant/slots/', data: {
       'activity': activityId,
       'begins_at': start.toIso8601String(),
       'ends_at': end.toIso8601String(),

--- a/lib/services/sport_category_service.dart
+++ b/lib/services/sport_category_service.dart
@@ -3,7 +3,7 @@ import 'api_client.dart';
 
 class SportCategoryService {
   Future<List<SportCategory>> fetchCategories() async {
-    final res = await apiClient.get('/sport-categories/');
+    final res = await apiClient.get('sport-categories/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(SportCategory.fromJson)
@@ -12,21 +12,21 @@ class SportCategoryService {
   }
 
   Future<void> createCategory(String name, int? parent) async {
-    await apiClient.post('/sport-categories/', data: {
+    await apiClient.post('sport-categories/', data: {
       'name': name,
       'parent': parent,
     });
   }
 
   Future<void> updateCategory(int id, String name, int? parent) async {
-    await apiClient.patch('/sport-categories/' + id.toString() + '/', data: {
+    await apiClient.patch('sport-categories/' + id.toString() + '/', data: {
       'name': name,
       'parent': parent,
     });
   }
 
   Future<void> deleteCategory(int id) async {
-    await apiClient.delete('/sport-categories/' + id.toString() + '/');
+    await apiClient.delete('sport-categories/' + id.toString() + '/');
   }
 }
 

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -15,7 +15,7 @@ import 'api_client.dart';
 class SportsService {
   /// GET /api/sports/
   Future<List<Sport>> fetchSports() async {
-    final res = await apiClient.get('/sports/');
+    final res = await apiClient.get('sports/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Sport.fromJson)
@@ -28,7 +28,7 @@ class SportsService {
   /// The backend returns ALL upcoming slots (future dates only).
   /// You can add query-string filters on the API later as needed.
   Future<List<Slot>> fetchSlots() async {
-    final res = await apiClient.get('/slots/');
+    final res = await apiClient.get('slots/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Slot.fromJson)
@@ -37,7 +37,7 @@ class SportsService {
   }
 
   Future<List<Category>> fetchCategories() async {
-    final res = await apiClient.get('/categories/');
+    final res = await apiClient.get('categories/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Category.fromJson)
@@ -45,7 +45,7 @@ class SportsService {
   }
 
   Future<List<Variant>> fetchVariants() async {
-    final res = await apiClient.get('/variants/');
+    final res = await apiClient.get('variants/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Variant.fromJson)


### PR DESCRIPTION
## Summary
- use relative API paths across services
- improve token refresh handling
- show readable errors in notification provider
- display error text on notifications page

## Testing
- `dart format lib` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_688b4fce77f0832698ec6e666642ea2c