### PR TITLE
feat: add vendor organizations

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -118,13 +118,21 @@ if os.getenv("DB_HOST"):
         }
     }
 else:
-    DATABASES = {
-        "default": {
-            "ENGINE": "django.contrib.gis.db.backends.spatialite",
-            "NAME": BASE_DIR / "db.sqlite3",
+    if os.getenv("USE_GIS", "1") == "1":
+        DATABASES = {
+            "default": {
+                "ENGINE": "django.contrib.gis.db.backends.spatialite",
+                "NAME": BASE_DIR / "db.sqlite3",
+            }
         }
-    }
-    SPATIALITE_LIBRARY_PATH = "mod_spatialite"
+        SPATIALITE_LIBRARY_PATH = "mod_spatialite"
+    else:
+        DATABASES = {
+            "default": {
+                "ENGINE": "django.db.backends.sqlite3",
+                "NAME": BASE_DIR / "db.sqlite3",
+            }
+        }
 
 # ──────────────────────────────
 # Password validators

--- a/backend/accounts/migrations/0003_user_is_vendor_organization.py
+++ b/backend/accounts/migrations/0003_user_is_vendor_organization.py
@@ -1,0 +1,61 @@
+from django.db import migrations, models
+from django.conf import settings
+from django.utils.text import slugify
+
+
+def create_org_for_existing_vendors(apps, schema_editor):
+    User = apps.get_model('auth', 'User')
+    Organization = apps.get_model('accounts', 'Organization')
+    OrganizationMember = apps.get_model('accounts', 'OrganizationMember')
+    for user in User.objects.filter(is_staff=True):
+        org = Organization.objects.create(
+            name=user.username,
+            slug=slugify(f'default-{user.pk}')
+        )
+        OrganizationMember.objects.create(
+            organization=org,
+            user=user,
+            role='owner'
+        )
+        user.is_vendor = True
+        user.is_staff = False
+        user.save(update_fields=['is_vendor', 'is_staff'])
+
+
+def noop(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('accounts', '0002_vendor_extra_fields'),
+    ]
+
+    operations = [
+        migrations.RunSQL(
+            'ALTER TABLE auth_user ADD COLUMN is_vendor BOOLEAN NOT NULL DEFAULT FALSE;'
+        ),
+        migrations.RunSQL(
+            'CREATE INDEX auth_user_is_vendor_idx ON auth_user (is_vendor);',
+            'DROP INDEX auth_user_is_vendor_idx;'
+        ),
+        migrations.CreateModel(
+            name='Organization',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('name', models.CharField(max_length=120)),
+                ('slug', models.SlugField(unique=True)),
+                ('created_at', models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='OrganizationMember',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('role', models.CharField(choices=[('owner', 'Owner'), ('staff', 'Staff')], max_length=10)),
+                ('organization', models.ForeignKey(on_delete=models.CASCADE, related_name='members', to='accounts.organization')),
+                ('user', models.ForeignKey(on_delete=models.CASCADE, related_name='orgs', to=settings.AUTH_USER_MODEL)),
+            ],
+        ),
+        migrations.RunPython(create_org_for_existing_vendors, noop),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -2,6 +2,13 @@ from django.db import models
 from django.contrib.auth.models import User
 
 
+# extend core User with vendor flag
+User.add_to_class(
+    "is_vendor",
+    models.BooleanField(default=False, db_index=True),
+)
+
+
 class VendorProfile(models.Model):
     user = models.OneToOneField(User, on_delete=models.CASCADE)
     company_name = models.CharField(max_length=100, blank=True)
@@ -25,6 +32,27 @@ class CustomerProfile(models.Model):
 
     def __str__(self) -> str:
         return self.user.username
+
+
+class Organization(models.Model):
+    name = models.CharField(max_length=120)
+    slug = models.SlugField(unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+
+class OrganizationMember(models.Model):
+    ORGANIZATION_ROLES = (("owner", "Owner"), ("staff", "Staff"))
+    organization = models.ForeignKey(
+        Organization,
+        on_delete=models.CASCADE,
+        related_name="members",
+    )
+    user = models.ForeignKey(
+        User,
+        on_delete=models.CASCADE,
+        related_name="orgs",
+    )
+    role = models.CharField(max_length=10, choices=ORGANIZATION_ROLES)
 
 
 # expose a convenience property on Django's User

--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -1,8 +1,12 @@
 from rest_framework.permissions import BasePermission
+from .models import OrganizationMember
 
 
 class IsVendor(BasePermission):
-    """Allows access only to users with a VendorProfile."""
+    """Allow access to vendor users who belong to an organization."""
 
     def has_permission(self, request, view):
-        return request.user and hasattr(request.user, "vendorprofile")
+        user = request.user
+        if not getattr(user, "is_vendor", False):
+            return False
+        return OrganizationMember.objects.filter(user=user).exists()

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,6 +1,11 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
-from .models import VendorProfile
+from .models import (
+    VendorProfile,
+    Organization,
+    OrganizationMember,
+    CustomerProfile,
+)
 
 
 class ProfileSerializer(serializers.Serializer):
@@ -58,7 +63,7 @@ class ProfileSerializer(serializers.Serializer):
         return instance
 
 
-class ProviderRegisterSerializer(serializers.Serializer):
+class MerchantSignupSerializer(serializers.Serializer):
     email = serializers.EmailField()
     password1 = serializers.CharField(write_only=True)
     password2 = serializers.CharField(write_only=True)
@@ -81,12 +86,19 @@ class ProviderRegisterSerializer(serializers.Serializer):
             email=validated_data["email"],
             password=validated_data["password1"],
         )
-        user.is_staff = True
-        user.save()
+        user.is_vendor = True
+        user.save(update_fields=["is_vendor"])
         VendorProfile.objects.create(
             user=user,
             company_name=company,
             phone=phone,
             address=address,
+        )
+        org = Organization.objects.create(
+            name=company or user.username,
+            slug=f"org-{user.pk}",
+        )
+        OrganizationMember.objects.create(
+            organization=org, user=user, role="owner"
         )
         return user

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -4,8 +4,9 @@ from .views import (
     ProfileView,
     VendorArea,
     GoogleLoginView,
-    ProviderRegisterView,
+    MerchantSignupView,
     ProviderProfileView,
+    OrganizationMemberView,
 )
 
 urlpatterns = [
@@ -13,6 +14,10 @@ urlpatterns = [
     path("me/", ProfileView.as_view()),
     path("vendor-area/", VendorArea.as_view()),
     path("auth/google/", GoogleLoginView.as_view()),
-    path("provider/register/", ProviderRegisterView.as_view()),
+    path("provider/register/", MerchantSignupView.as_view()),
     path("provider/profile/", ProviderProfileView.as_view()),
+    path(
+        "organization/<slug:slug>/members/",
+        OrganizationMemberView.as_view(),
+    ),
 ]

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -4,9 +4,11 @@ from rest_framework.permissions import IsAuthenticated, AllowAny
 from .permissions import IsVendor
 from rest_framework.response import Response
 
-from .serializers import ProfileSerializer, ProviderRegisterSerializer
+from .serializers import ProfileSerializer, MerchantSignupSerializer
+from .models import Organization, OrganizationMember
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404
 from allauth.socialaccount.models import SocialAccount
 from google.oauth2 import id_token as google_id_token
 from google.auth.transport import requests as google_requests
@@ -66,19 +68,51 @@ class GoogleLoginView(APIView):
         )
 
 
-class ProviderRegisterView(APIView):
-    """Register a new provider account."""
+class MerchantSignupView(APIView):
+    """Register a new vendor account."""
 
     permission_classes = [AllowAny]
 
     def post(self, request):
-        ser = ProviderRegisterSerializer(data=request.data)
+        ser = MerchantSignupSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         user = ser.save()
         refresh = RefreshToken.for_user(user)
         return Response(
             {"access": str(refresh.access_token), "refresh": str(refresh)}
         )
+
+
+class OrganizationMemberView(APIView):
+    permission_classes = [IsAuthenticated, IsVendor]
+
+    def post(self, request, slug):
+        org = get_object_or_404(Organization, slug=slug)
+        if not OrganizationMember.objects.filter(
+            organization=org, user=request.user, role="owner"
+        ).exists():
+            return Response(status=403)
+        email = request.data.get("email")
+        user = get_object_or_404(User, email=email)
+        OrganizationMember.objects.get_or_create(
+            organization=org, user=user, defaults={"role": "staff"}
+        )
+        if not user.is_vendor:
+            user.is_vendor = True
+            user.save(update_fields=["is_vendor"])
+        return Response(status=201)
+
+    def delete(self, request, slug):
+        org = get_object_or_404(Organization, slug=slug)
+        if not OrganizationMember.objects.filter(
+            organization=org, user=request.user, role="owner"
+        ).exists():
+            return Response(status=403)
+        target = request.data.get("user")
+        OrganizationMember.objects.filter(
+            organization=org, user_id=target
+        ).delete()
+        return Response(status=204)
 
 
 class ProviderProfileView(APIView):

--- a/backend/tests/test_accounts_vendor.py
+++ b/backend/tests/test_accounts_vendor.py
@@ -1,0 +1,76 @@
+import pytest
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+from rest_framework_simplejwt.tokens import RefreshToken
+
+
+@pytest.mark.django_db
+class TestMerchantSignup:
+    def test_signup_sets_vendor_and_no_admin_access(self):
+        client = APIClient()
+        data = {
+            "email": "vendor@example.com",
+            "password1": "pass1234",
+            "password2": "pass1234",
+            "company_name": "Vend Co",
+        }
+        resp = client.post("/api/provider/register/", data, format="json")
+        assert resp.status_code == 200
+        user = User.objects.get(email="vendor@example.com")
+        assert user.is_vendor is True
+        assert user.is_staff is False
+        token = resp.data["access"]
+        resp_admin = client.get(
+            "/admin/", HTTP_AUTHORIZATION=f"Bearer {token}", follow=False
+        )
+        assert resp_admin.status_code == 302
+        assert "/admin/login" in resp_admin.headers["Location"]
+
+
+@pytest.mark.django_db
+class TestOrganizationMembers:
+    def setup_owner(self):
+        client = APIClient()
+        data = {
+            "email": "owner@example.com",
+            "password1": "pass1234",
+            "password2": "pass1234",
+            "company_name": "Owner Co",
+        }
+        resp = client.post("/api/provider/register/", data, format="json")
+        token = resp.data["access"]
+        user = User.objects.get(email="owner@example.com")
+        org = user.orgs.first().organization
+        return client, user, org, token
+
+    def test_owner_and_staff_permissions(self):
+        client, owner, org, token = self.setup_owner()
+        staff_user = User.objects.create_user(
+            username="staff@example.com",
+            email="staff@example.com",
+            password="pass1234",
+        )
+        resp = client.post(
+            f"/api/organization/{org.slug}/members/",
+            {"email": staff_user.email},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert resp.status_code == 201
+        # staff member token
+        refresh = RefreshToken.for_user(staff_user)
+        staff_token = str(refresh.access_token)
+        resp2 = client.post(
+            f"/api/organization/{org.slug}/members/",
+            {"email": "another@example.com"},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {staff_token}",
+        )
+        assert resp2.status_code == 403
+        resp3 = client.delete(
+            f"/api/organization/{org.slug}/members/",
+            {"user": staff_user.id},
+            format="json",
+            HTTP_AUTHORIZATION=f"Bearer {token}",
+        )
+        assert resp3.status_code == 204


### PR DESCRIPTION
## Summary
- extend core User with is_vendor flag
- add Organization and membership models with signup flow
- secure vendor endpoints with organization-aware permission

## Testing
- `flake8 backend/accounts/models.py backend/accounts/permissions.py backend/accounts/serializers.py backend/accounts/urls.py backend/accounts/views.py backend/tests/test_accounts_vendor.py backend/PlayNexus/settings.py`
- `DJANGO_SETTINGS_MODULE=PlayNexus.settings USE_GIS=0 pytest backend/tests/test_accounts_vendor.py` *(fails: AttributeError: 'DatabaseOperations' object has no attribute 'geo_db_type')*


------
https://chatgpt.com/codex/tasks/task_e_6895e186fa28832698677eaef6795838