### PR TITLE
Skip auth header on token refresh

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -9,6 +9,7 @@ https://docs.djangoproject.com/en/5.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
+
 import os
 from pathlib import Path
 from dotenv import load_dotenv
@@ -19,17 +20,17 @@ from datetime import timedelta
 # ──────────────────────────────
 BASE_DIR: Path = Path(__file__).resolve().parent.parent
 # Load environment variables for local runs (project root .env)
-load_dotenv(BASE_DIR.parent / '.env')
+load_dotenv(BASE_DIR.parent / ".env")
 
 DEBUG = os.getenv("DEBUG", "False") == "True"
 SECRET_KEY = os.getenv("SECRET_KEY", "unsafe-secret-key")
 USE_TRIGRAM = os.getenv("USE_TRIGRAM", "False") == "True"
 
 ALLOWED_HOSTS = [
-    'localhost',
-    '127.0.0.1',
-    '10.0.2.2',       # Android Emulator
-    'testserver',
+    "localhost",
+    "127.0.0.1",
+    "10.0.2.2",  # Android Emulator
+    "testserver",
 ]
 SITE_ID = 1
 
@@ -44,7 +45,6 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
-
     # 3rd-party
     "rest_framework",
     "corsheaders",
@@ -58,7 +58,6 @@ INSTALLED_APPS = [
     "allauth.account",
     "allauth.socialaccount",
     "allauth.socialaccount.providers.google",
-
     # Local apps
     # use absolute path so management commands work from any cwd
     "sports.apps.SportsConfig",
@@ -72,7 +71,7 @@ AUTHENTICATION_BACKENDS = [
 ]
 
 MIDDLEWARE = [
-    "corsheaders.middleware.CorsMiddleware",       # must be first
+    "corsheaders.middleware.CorsMiddleware",  # must be first
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -136,21 +135,9 @@ AUTH_PASSWORD_VALIDATORS = [
             "UserAttributeSimilarityValidator"
         )
     },
-    {
-        "NAME": (
-            "django.contrib.auth.password_validation.MinimumLengthValidator"
-        )
-    },
-    {
-        "NAME": (
-            "django.contrib.auth.password_validation.CommonPasswordValidator"
-        )
-    },
-    {
-        "NAME": (
-            "django.contrib.auth.password_validation.NumericPasswordValidator"
-        )
-    },
+    {"NAME": ("django.contrib.auth.password_validation.MinimumLengthValidator")},
+    {"NAME": ("django.contrib.auth.password_validation.CommonPasswordValidator")},
+    {"NAME": ("django.contrib.auth.password_validation.NumericPasswordValidator")},
 ]
 
 # ──────────────────────────────
@@ -175,7 +162,7 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 # ──────────────────────────────
 # CORS (allow everything in dev)
 # ──────────────────────────────
-CORS_ALLOW_ALL_ORIGINS = True      # ⚠ tighten in production
+CORS_ALLOW_ALL_ORIGINS = True  # ⚠ tighten in production
 
 # ──────────────────────────────
 # Django REST framework + JWT
@@ -191,12 +178,10 @@ REST_FRAMEWORK = {
     # "DEFAULT_PAGINATION_CLASS":
     #     "rest_framework.pagination.PageNumberPagination",
     # "PAGE_SIZE": 20,
-
     # enable query-parameter filtering on all ViewSets
     "DEFAULT_FILTER_BACKENDS": [
         "django_filters.rest_framework.DjangoFilterBackend",
     ],
-
     "COERCE_DECIMAL_TO_STRING": False,
     # return numbers instead of strings
 }
@@ -204,8 +189,8 @@ REST_FRAMEWORK = {
 # SimpleJWT configuration
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
-    "ROTATE_REFRESH_TOKENS": False,
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
+    "ROTATE_REFRESH_TOKENS": True,
     "BLACKLIST_AFTER_ROTATION": True,
     "AUTH_HEADER_TYPES": ("Bearer",),
 }

--- a/backend/PlayNexus/urls.py
+++ b/backend/PlayNexus/urls.py
@@ -14,6 +14,7 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path, include
 from django.http import JsonResponse
@@ -29,8 +30,8 @@ from django.conf.urls.static import static
 urlpatterns = [
     path("healthz", lambda r: JsonResponse({"status": "ok"})),
     path("admin/", admin.site.urls),
-    path("api/", include("sports.urls")),          # ← REST entrance
-    path("api/", include("accounts.urls")),        # profile endpoint
+    path("api/", include("sports.urls")),  # ← REST entrance
+    path("api/", include("accounts.urls")),  # profile endpoint
     path("api/", include("payments.urls")),
     path("api/auth/", include("dj_rest_auth.urls")),
     path("api/auth/register/", RegisterView.as_view()),
@@ -44,13 +45,9 @@ urlpatterns = [
         name="token_obtain_pair",
     ),
     path(
-        "api/token/refresh/",
-        TokenRefreshView.as_view(),
-        name="token_refresh",
-    ),
-    path(
         "api/auth/token/refresh/",
         TokenRefreshView.as_view(),
+        name="token_refresh",
     ),
     path(
         "password-reset-confirm/<uidb64>/<token>/",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,7 +43,11 @@ class SportsBookingApp extends StatelessWidget {
       title: 'Sports Booking',
       theme: AppTheme.light,                    // centralised light theme
       debugShowCheckedModeBanner: false,
+      navigatorKey: navigatorKey,
       home: const HomePage(),             // first screen
+      routes: {
+        '/login': (context) => const LoginPage(),
+      },
     );
   }
 }

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -3,10 +3,13 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 late Dio apiClient;
+const _refreshUrl = '/auth/token/refresh/';
+final navigatorKey = GlobalKey<NavigatorState>();
 
 /// Call after dotenv.load to construct the client with the base URL.
 void initApiClient() {
@@ -33,25 +36,40 @@ void initAuthInterceptor() {
     InterceptorsWrapper(
       onRequest: (options, handler) async {
         final token = await _storage.read(key: 'access');
-        final refreshUrl = '/auth/token/refresh/';
-        final isRefreshCall = options.uri.path.endsWith(refreshUrl);
+        final isRefreshCall = options.uri.path.endsWith(_refreshUrl);
         if (token != null && !isRefreshCall) {
           options.headers['Authorization'] = 'Bearer $token';
         }
         handler.next(options);
       },
       onError: (err, handler) async {
-        if (err.response?.statusCode == 401) {
+        if (err.response?.statusCode == 401 &&
+            !err.requestOptions.path.endsWith(_refreshUrl) &&
+            err.requestOptions.extra['__retry'] != true) {
           final refresh = await _storage.read(key: 'refresh');
           if (refresh != null) {
             try {
-              final res = await apiClient.post('/auth/token/refresh/', data: {'refresh': refresh});
+              final refreshClient = Dio(BaseOptions(baseUrl: apiClient.options.baseUrl));
+              final res = await refreshClient.post(_refreshUrl, data: {'refresh': refresh});
               final access = res.data['access'];
               await _storage.write(key: 'access', value: access);
-              err.requestOptions.headers['Authorization'] = 'Bearer $access';
-              final cloneReq = await apiClient.fetch(err.requestOptions);
+              if (res.data['refresh'] != null) {
+                await _storage.write(key: 'refresh', value: res.data['refresh']);
+              }
+              final opts = err.requestOptions;
+              opts.headers['Authorization'] = 'Bearer $access';
+              opts.extra['__retry'] = true;
+              final cloneReq = await apiClient.fetch(opts);
               return handler.resolve(cloneReq);
-            } catch (_) {}
+            } catch (_) {
+              await _storage.deleteAll();
+              apiClient.options.headers.remove('Authorization');
+              navigatorKey.currentState?.pushReplacementNamed('/login');
+            }
+          } else {
+            await _storage.deleteAll();
+            apiClient.options.headers.remove('Authorization');
+            navigatorKey.currentState?.pushReplacementNamed('/login');
           }
         }
         handler.next(err);

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -33,7 +33,9 @@ void initAuthInterceptor() {
     InterceptorsWrapper(
       onRequest: (options, handler) async {
         final token = await _storage.read(key: 'access');
-        if (token != null) {
+        final refreshUrl = '/auth/token/refresh/';
+        final isRefreshCall = options.uri.path.endsWith(refreshUrl);
+        if (token != null && !isRefreshCall) {
           options.headers['Authorization'] = 'Bearer $token';
         }
         handler.next(options);

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -66,10 +66,6 @@ void initAuthInterceptor() {
               apiClient.options.headers.remove('Authorization');
               navigatorKey.currentState?.pushReplacementNamed('/login');
             }
-          } else {
-            await _storage.deleteAll();
-            apiClient.options.headers.remove('Authorization');
-            navigatorKey.currentState?.pushReplacementNamed('/login');
           }
         }
         handler.next(err);

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -94,6 +94,9 @@ class AuthService {
     );
     final access = res.data['access'];
     await _storage.write(key: 'access', value: access);
+    if (res.data['refresh'] != null) {
+      await _storage.write(key: 'refresh', value: res.data['refresh']);
+    }
     apiClient.options.headers['Authorization'] = 'Bearer $access';
   }
 


### PR DESCRIPTION
## Summary
- Detect refresh token request via `options.uri.path` to skip injecting Authorization header

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y flutter` *(fails: unable to locate package)*

------
https://chatgpt.com/codex/tasks/task_e_68962c1b361c8326a569624dfd9ae2f9