### PR TITLE
Fix JWT refresh logic and logout

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -204,8 +204,8 @@ REST_FRAMEWORK = {
 # SimpleJWT configuration
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=60),
-    "REFRESH_TOKEN_LIFETIME": timedelta(days=7),
-    "ROTATE_REFRESH_TOKENS": False,
+    "REFRESH_TOKEN_LIFETIME": timedelta(days=14),
+    "ROTATE_REFRESH_TOKENS": True,
     "BLACKLIST_AFTER_ROTATION": True,
     "AUTH_HEADER_TYPES": ("Bearer",),
 }

--- a/backend/PlayNexus/urls.py
+++ b/backend/PlayNexus/urls.py
@@ -49,10 +49,6 @@ urlpatterns = [
         name="token_refresh",
     ),
     path(
-        "api/auth/token/refresh/",
-        TokenRefreshView.as_view(),
-    ),
-    path(
         "password-reset-confirm/<uidb64>/<token>/",
         lambda r, uidb64, token: HttpResponse(""),
         name="password_reset_confirm",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -43,6 +43,10 @@ class SportsBookingApp extends StatelessWidget {
       title: 'Sports Booking',
       theme: AppTheme.light,                    // centralised light theme
       debugShowCheckedModeBanner: false,
+      navigatorKey: navigatorKey,
+      routes: {
+        '/login': (_) => const LoginPage(),
+      },
       home: const HomePage(),             // first screen
     );
   }

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -57,10 +57,10 @@ void initAuthInterceptor() {
               final cloneReq = await apiClient.fetch(err.requestOptions);
               return handler.resolve(cloneReq);
             } catch (_) {}
+            await _storage.deleteAll();
+            apiClient.options.headers.remove('Authorization');
+            navigatorKey.currentState?.pushReplacementNamed('/login');
           }
-          await _storage.deleteAll();
-          apiClient.options.headers.remove('Authorization');
-          navigatorKey.currentState?.pushReplacementNamed('/login');
         }
         handler.next(err);
       },

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -3,10 +3,12 @@
 
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 
 late Dio apiClient;
+final navigatorKey = GlobalKey<NavigatorState>();
 
 /// Call after dotenv.load to construct the client with the base URL.
 void initApiClient() {
@@ -32,25 +34,33 @@ void initAuthInterceptor() {
   apiClient.interceptors.add(
     InterceptorsWrapper(
       onRequest: (options, handler) async {
-        final token = await _storage.read(key: 'access');
-        if (token != null) {
-          options.headers['Authorization'] = 'Bearer $token';
+        if (!options.path.contains('token/refresh')) {
+          final token = await _storage.read(key: 'access');
+          if (token != null) {
+            options.headers['Authorization'] = 'Bearer $token';
+          }
         }
         handler.next(options);
       },
       onError: (err, handler) async {
-        if (err.response?.statusCode == 401) {
+        if (err.response?.statusCode == 401 &&
+            !err.requestOptions.path.contains('token/refresh') &&
+            err.requestOptions.extra['retry'] != true) {
           final refresh = await _storage.read(key: 'refresh');
           if (refresh != null) {
             try {
-              final res = await apiClient.post('/auth/token/refresh/', data: {'refresh': refresh});
+              final res = await apiClient.post('/token/refresh/', data: {'refresh': refresh});
               final access = res.data['access'];
               await _storage.write(key: 'access', value: access);
               err.requestOptions.headers['Authorization'] = 'Bearer $access';
+              err.requestOptions.extra['retry'] = true;
               final cloneReq = await apiClient.fetch(err.requestOptions);
               return handler.resolve(cloneReq);
             } catch (_) {}
           }
+          await _storage.deleteAll();
+          apiClient.options.headers.remove('Authorization');
+          navigatorKey.currentState?.pushReplacementNamed('/login');
         }
         handler.next(err);
       },

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -89,7 +89,7 @@ class AuthService {
     final refresh = await _storage.read(key: 'refresh');
     if (refresh == null) return;
     final Response res = await apiClient.post(
-      '/auth/token/refresh/',
+      '/token/refresh/',
       data: {'refresh': refresh},
     );
     final access = res.data['access'];


### PR DESCRIPTION
## Summary
- rotate and extend refresh tokens for 14 days
- remove duplicate refresh endpoint
- ensure API client skips auth header for refresh, retries once, and logs out on failure
- add navigator key and login route for logout navigation

## Testing
- `python -m compileall backend`

------
https://chatgpt.com/codex/tasks/task_e_6897367a985c83269961e2b52d1b4dc6