### PR TITLE
feat: introduce merchant organizations and permissions

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
     "rest_framework_gis",
     "rest_framework.authtoken",
     "rest_framework_simplejwt.token_blacklist",
+    "drf_spectacular",
     "dj_rest_auth",
     "dj_rest_auth.registration",
     "allauth",
@@ -199,6 +200,7 @@ REST_FRAMEWORK = {
 
     "COERCE_DECIMAL_TO_STRING": False,
     # return numbers instead of strings
+    "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
 }
 
 # SimpleJWT configuration

--- a/backend/accounts/management/commands/audit_vendor_staff.py
+++ b/backend/accounts/management/commands/audit_vendor_staff.py
@@ -1,0 +1,17 @@
+from django.core.management.base import BaseCommand
+from django.contrib.auth import get_user_model
+
+
+class Command(BaseCommand):
+    help = (
+        "List users who have a VendorProfile and are marked as staff "
+        "but are not superusers."
+    )
+
+    def handle(self, *args, **options):
+        User = get_user_model()
+        qs = User.objects.filter(
+            vendorprofile__isnull=False, is_staff=True, is_superuser=False
+        )
+        for u in qs:
+            self.stdout.write(f"{u.username}\t{u.email}\t{u.id}")

--- a/backend/accounts/migrations/0003_organization.py
+++ b/backend/accounts/migrations/0003_organization.py
@@ -1,0 +1,72 @@
+from django.db import migrations, models
+import django.db.models.deletion
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0002_vendor_extra_fields"),
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="Organization",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("name", models.CharField(max_length=120)),
+                ("slug", models.SlugField(unique=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name="OrganizationMember",
+            fields=[
+                (
+                    "id",
+                    models.BigAutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                (
+                    "role",
+                    models.CharField(
+                        choices=[("owner", "Owner"), ("staff", "Staff")],
+                        max_length=10,
+                    ),
+                ),
+                (
+                    "organization",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="members",
+                        to="accounts.organization",
+                    ),
+                ),
+                (
+                    "user",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="org_memberships",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={
+                "unique_together": {("organization", "user")},
+            },
+        ),
+    ]
+

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -1,5 +1,6 @@
 from django.db import models
 from django.contrib.auth.models import User
+from django.conf import settings
 
 
 class VendorProfile(models.Model):
@@ -33,3 +34,33 @@ def _user_is_provider(self) -> bool:
 
 
 User.add_to_class("is_provider", property(_user_is_provider))
+
+
+class Organization(models.Model):
+    name = models.CharField(max_length=120)
+    slug = models.SlugField(unique=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    def __str__(self) -> str:  # pragma: no cover
+        return self.name
+
+
+class OrganizationMember(models.Model):
+    ROLE_OWNER = "owner"
+    ROLE_STAFF = "staff"
+    ROLE_CHOICES = [(ROLE_OWNER, "Owner"), (ROLE_STAFF, "Staff")]
+    organization = models.ForeignKey(
+        Organization, related_name="members", on_delete=models.CASCADE
+    )
+    user = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        related_name="org_memberships",
+        on_delete=models.CASCADE,
+    )
+    role = models.CharField(max_length=10, choices=ROLE_CHOICES)
+
+    class Meta:
+        unique_together = ("organization", "user")
+
+    def __str__(self) -> str:  # pragma: no cover
+        return f"{self.organization} - {self.user} ({self.role})"

--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -1,4 +1,5 @@
 from rest_framework.permissions import BasePermission
+from .models import OrganizationMember
 
 
 class IsVendor(BasePermission):
@@ -6,3 +7,23 @@ class IsVendor(BasePermission):
 
     def has_permission(self, request, view):
         return request.user and hasattr(request.user, "vendorprofile")
+
+
+class IsOrgMember(BasePermission):
+    """Allow access if user belongs to object's organization."""
+
+    def has_object_permission(self, request, view, obj):
+        org = getattr(obj, "organization", obj)
+        return OrganizationMember.objects.filter(
+            organization=org, user=request.user
+        ).exists()
+
+
+class IsOrgOwner(BasePermission):
+    """Allow access only to organization owners."""
+
+    def has_object_permission(self, request, view, obj):
+        org = getattr(obj, "organization", obj)
+        return OrganizationMember.objects.filter(
+            organization=org, user=request.user, role="owner"
+        ).exists()

--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -81,12 +81,19 @@ class ProviderRegisterSerializer(serializers.Serializer):
             email=validated_data["email"],
             password=validated_data["password1"],
         )
-        user.is_staff = True
-        user.save()
-        VendorProfile.objects.create(
-            user=user,
-            company_name=company,
-            phone=phone,
-            address=address,
+        vendor, _ = VendorProfile.objects.get_or_create(user=user)
+        vendor.company_name = company
+        vendor.phone = phone
+        vendor.address = address
+        vendor.save()
+        from .models import Organization, OrganizationMember
+        import shortuuid
+
+        org = Organization.objects.create(
+            name=company or user.username,
+            slug=f"{user.username}-{shortuuid.uuid()[:8]}",
+        )
+        OrganizationMember.objects.create(
+            organization=org, user=user, role="owner"
         )
         return user

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from rest_framework.routers import DefaultRouter
 
 from .views import (
     ProfileView,
@@ -6,6 +7,15 @@ from .views import (
     GoogleLoginView,
     ProviderRegisterView,
     ProviderProfileView,
+    OrganizationMemberViewSet,
+    MyOrganizationsView,
+)
+
+router = DefaultRouter()
+router.register(
+    r"merchant/orgs/(?P<org_id>\d+)/members",
+    OrganizationMemberViewSet,
+    basename="org-members",
 )
 
 urlpatterns = [
@@ -15,4 +25,7 @@ urlpatterns = [
     path("auth/google/", GoogleLoginView.as_view()),
     path("provider/register/", ProviderRegisterView.as_view()),
     path("provider/profile/", ProviderProfileView.as_view()),
+    path("merchant/orgs/me/", MyOrganizationsView.as_view()),
 ]
+
+urlpatterns += router.urls

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -1,10 +1,14 @@
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
+from rest_framework import viewsets, status
+from django.shortcuts import get_object_or_404
 
-from .permissions import IsVendor
+from .permissions import IsVendor, IsOrgMember, IsOrgOwner
 from rest_framework.response import Response
 
 from .serializers import ProfileSerializer, ProviderRegisterSerializer
+from .models import Organization, OrganizationMember
+from drf_spectacular.utils import extend_schema
 from rest_framework_simplejwt.tokens import RefreshToken
 from django.contrib.auth.models import User
 from allauth.socialaccount.models import SocialAccount
@@ -93,3 +97,68 @@ class ProviderProfileView(APIView):
         ser.is_valid(raise_exception=True)
         ser.save()
         return Response(ser.data)
+
+
+class OrganizationMemberViewSet(viewsets.ViewSet):
+    """Manage members within an organization."""
+
+    def get_permissions(self):
+        if self.action in ("create", "destroy"):
+            perms = [IsAuthenticated, IsOrgOwner]
+        else:
+            perms = [IsAuthenticated]
+        return [p() if isinstance(p, type) else p for p in perms]
+
+    @extend_schema(request=None, responses={201: None})
+    def create(self, request, org_id=None):
+        org = get_object_or_404(Organization, pk=org_id)
+        self.check_object_permissions(request, org)
+        user_id = request.data.get("user_id")
+        email = request.data.get("email")
+        role = request.data.get("role")
+        if role not in ("owner", "staff"):
+            return Response({"detail": "invalid role"}, status=400)
+        if not user_id and not email:
+            return Response({"detail": "user_id or email required"}, status=400)
+        user = None
+        if user_id:
+            user = get_object_or_404(User, pk=user_id)
+        else:
+            user = get_object_or_404(User, email=email)
+        if OrganizationMember.objects.filter(organization=org, user=user).exists():
+            return Response({"detail": "member exists"}, status=400)
+        member = OrganizationMember.objects.create(
+            organization=org, user=user, role=role
+        )
+        return Response({"id": member.id}, status=status.HTTP_201_CREATED)
+
+    @extend_schema(request=None, responses={204: None})
+    def destroy(self, request, org_id=None, pk=None):
+        org = get_object_or_404(Organization, pk=org_id)
+        self.check_object_permissions(request, org)
+        try:
+            member = OrganizationMember.objects.get(pk=pk, organization=org)
+        except OrganizationMember.DoesNotExist:
+            return Response({"detail": "no such member"}, status=400)
+        member.delete()
+        return Response(status=status.HTTP_204_NO_CONTENT)
+
+
+class MyOrganizationsView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(responses=None)
+    def get(self, request):
+        memberships = OrganizationMember.objects.filter(
+            user=request.user
+        ).select_related("organization")
+        data = [
+            {
+                "id": m.organization_id,
+                "name": m.organization.name,
+                "slug": m.organization.slug,
+                "role": m.role,
+            }
+            for m in memberships
+        ]
+        return Response(data)

--- a/backend/sports/migrations/0018_activity_organization.py
+++ b/backend/sports/migrations/0018_activity_organization.py
@@ -1,0 +1,69 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+def forwards(apps, schema_editor):
+    Activity = apps.get_model("sports", "Activity")
+    User = apps.get_model("auth", "User")
+    Organization = apps.get_model("accounts", "Organization")
+    OrganizationMember = apps.get_model("accounts", "OrganizationMember")
+    import shortuuid
+
+    users = User.objects.filter(activities__isnull=False).distinct()
+    for user in users:
+        org = Organization.objects.create(
+            name=user.username,
+            slug=f"{user.username}-{shortuuid.uuid()[:8]}",
+        )
+        OrganizationMember.objects.create(
+            organization=org, user=user, role="owner"
+        )
+        Activity.objects.filter(owner=user).update(organization=org)
+
+
+def backwards(apps, schema_editor):
+    Activity = apps.get_model("sports", "Activity")
+    Organization = apps.get_model("accounts", "Organization")
+    OrganizationMember = apps.get_model("accounts", "OrganizationMember")
+    for act in Activity.objects.all():
+        member = OrganizationMember.objects.filter(
+            organization=act.organization, role="owner"
+        ).first()
+        act.owner = member.user if member else None
+        act.save()
+    OrganizationMember.objects.all().delete()
+    Organization.objects.all().delete()
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_organization"),
+        ("sports", "0017_trigram_indexes"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="activity",
+            name="organization",
+            field=models.ForeignKey(
+                blank=True,
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="activities",
+                to="accounts.organization",
+            ),
+        ),
+        migrations.RunPython(forwards, backwards),
+        migrations.RemoveField(model_name="activity", name="owner"),
+        migrations.AlterField(
+            model_name="activity",
+            name="organization",
+            field=models.ForeignKey(
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name="activities",
+                to="accounts.organization",
+            ),
+        ),
+    ]
+

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -119,8 +119,8 @@ class Activity(models.Model):
     )
     image = models.ImageField(upload_to="activity/", blank=True)
     is_nearby = models.BooleanField(default=False)
-    owner = models.ForeignKey(
-        "auth.User",
+    organization = models.ForeignKey(
+        "accounts.Organization",
         on_delete=models.CASCADE,
         related_name="activities",
         null=True,

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -16,6 +16,7 @@ from .models import (
     FeaturedActivity,
     Favorite,
 )
+from accounts.models import Organization, OrganizationMember
 
 
 class SportSerializer(serializers.ModelSerializer):
@@ -105,6 +106,9 @@ class VariantSerializer(serializers.ModelSerializer):
 
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
+    organization = serializers.PrimaryKeyRelatedField(
+        queryset=Organization.objects.all()
+    )
 
     class Meta:
         model = Activity
@@ -115,7 +119,7 @@ class ActivitySerializer(serializers.ModelSerializer):
             "variant",
             "image",
             "image_url",
-            "owner",
+            "organization",
             "title",
             "description",
             "difficulty",
@@ -123,7 +127,7 @@ class ActivitySerializer(serializers.ModelSerializer):
             "base_price",
             "is_nearby",
         )
-        read_only_fields = ("id", "owner", "image")
+        read_only_fields = ("id", "image")
 
     def get_image_url(self, obj):
         if obj.image:
@@ -149,6 +153,17 @@ class ActivitySerializer(serializers.ModelSerializer):
         if len(desc) > 500:
             raise serializers.ValidationError({"description": "Max 500 characters"})
         return attrs
+
+    def validate_organization(self, value):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        if user is None:
+            return value
+        if not OrganizationMember.objects.filter(
+            organization=value, user=user
+        ).exists():
+            raise serializers.ValidationError("Not a member of this organization")
+        return value
 
 
 class ActivitySimpleSerializer(serializers.ModelSerializer):

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -6,6 +6,7 @@ from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
+from accounts.models import OrganizationMember
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
@@ -133,10 +134,12 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return [p() if isinstance(p, type) else p for p in perms]
 
     def get_queryset(self):
-        qs = Activity.objects.select_related("sport", "discipline", "variant")
+        qs = Activity.objects.select_related("sport", "discipline", "variant", "organization")
+        if self.action in ("update", "partial_update", "destroy"):
+            qs = qs.filter(organization__members__user=self.request.user)
         mine = self.request.query_params.get("mine")
         if mine == "1" and self.request.user.is_authenticated:
-            qs = qs.filter(owner=self.request.user)
+            qs = qs.filter(organization__members__user=self.request.user)
         nearby = self.request.query_params.get("nearby")
         if nearby == "1":
             qs = qs.filter(is_nearby=True)
@@ -167,7 +170,7 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        serializer.save(owner=self.request.user)
+        serializer.save()
 
     @action(detail=True, methods=["post"], url_path="favorite/toggle",
             permission_classes=[permissions.IsAuthenticated])
@@ -414,7 +417,9 @@ class MerchantSlotCreateView(APIView):
         ser = SlotCreateSerializer(data=request.data)
         ser.is_valid(raise_exception=True)
         activity: Activity = ser.validated_data["activity"]
-        if activity.owner != request.user:
+        if not OrganizationMember.objects.filter(
+            organization=activity.organization, user=request.user
+        ).exists():
             return Response({"detail": "Not your activity"}, status=403)
         slot = ser.save()
         return Response(SlotSerializer(slot).data, status=201)
@@ -424,10 +429,9 @@ class MerchantBookingList(APIView):
     permission_classes = [permissions.IsAuthenticated, IsVendor]
 
     def get(self, request):
-        qs = (
-            Booking.objects.filter(activity__owner=request.user)
-            .select_related("slot", "user")
-        )
+        qs = Booking.objects.filter(
+            activity__organization__members__user=request.user
+        ).select_related("slot", "user")
         ser = BookingSerializer(qs, many=True)
         return Response(ser.data)
 

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,4 +1,15 @@
 import pytest
+import pytest
+import django
+import os
+import pysqlite3
+import sys
+sys.modules["sqlite3"] = pysqlite3
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PlayNexus.settings")
+os.environ.setdefault("DB_HOST", "")
+os.environ.setdefault("SPATIALITE_LIBRARY_PATH", "/usr/lib/x86_64-linux-gnu/mod_spatialite.so")
+django.setup()
 from django.utils import timezone
 from rest_framework.test import APIClient
 
@@ -32,6 +43,14 @@ def client():
 def provider_user(db):
     from django.contrib.auth.models import User
     user = User.objects.create_user("prov", email="prov@example.com", password="pass")
+    from accounts.models import Organization, OrganizationMember
+    from uuid import uuid4
+
+    org = Organization.objects.create(name="Org", slug=f"org-{uuid4().hex[:8]}")
+    OrganizationMember.objects.create(
+        organization=org, user=user, role="owner"
+    )
+    user.org = org
     return user
 
 

--- a/backend/tests/test_accounts_org_permissions.py
+++ b/backend/tests/test_accounts_org_permissions.py
@@ -1,0 +1,124 @@
+import pytest
+import django
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+from django.db import connection
+from django.db.migrations.executor import MigrationExecutor
+
+django.setup()
+
+
+pytestmark = pytest.mark.django_db
+
+
+def test_vendor_signup_not_staff():
+    client = APIClient()
+    res = client.post(
+        "/api/provider/register/",
+        {
+            "email": "v1@example.com",
+            "password1": "pass1234",
+            "password2": "pass1234",
+        },
+    )
+    assert res.status_code == 200
+    user = User.objects.get(email="v1@example.com")
+    assert not user.is_staff
+    admin_resp = client.get("/admin/")
+    assert admin_resp.status_code == 302
+
+
+def test_org_default_migration():
+    executor = MigrationExecutor(connection)
+    old_target = [
+        ("accounts", "0002_vendor_extra_fields"),
+        ("sports", "0017_trigram_indexes"),
+    ]
+    executor.migrate(old_target)
+    old_apps = executor.loader.project_state(old_target).apps
+    UserModel = old_apps.get_model("auth", "User")
+    Sport = old_apps.get_model("sports", "Sport")
+    Category = old_apps.get_model("sports", "Category")
+    Activity = old_apps.get_model("sports", "Activity")
+    user = UserModel.objects.create_user("old", email="old@example.com", password="pass")
+    sport = Sport.objects.create(name="S")
+    cat = Category.objects.create(name="C")
+    act_id = Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title="A",
+        owner=user,
+        difficulty=1,
+        duration=60,
+        base_price=0,
+    ).id
+    executor = MigrationExecutor(connection)
+    executor.migrate(executor.loader.graph.leaf_nodes())
+    ActivityNew = executor.loader.project_state(None).apps.get_model(
+        "sports", "Activity"
+    )
+    Organization = executor.loader.project_state(None).apps.get_model(
+        "accounts", "Organization"
+    )
+    OrganizationMember = executor.loader.project_state(None).apps.get_model(
+        "accounts", "OrganizationMember"
+    )
+    act = ActivityNew.objects.get(id=act_id)
+    org = Organization.objects.get()
+    member = OrganizationMember.objects.get()
+    assert act.organization_id == org.id
+    assert member.user_id == user.id and member.role == "owner"
+
+
+def test_member_permissions():
+    owner = User.objects.create_user("own", email="own@example.com", password="pass")
+    staff = User.objects.create_user("stf", email="stf@example.com", password="pass")
+    from accounts.models import Organization, OrganizationMember
+    from uuid import uuid4
+
+    org = Organization.objects.create(name="Org", slug=f"o-{uuid4().hex[:8]}")
+    OrganizationMember.objects.create(organization=org, user=owner, role="owner")
+    OrganizationMember.objects.create(organization=org, user=staff, role="staff")
+
+    owner_client = APIClient()
+    owner_client.force_authenticate(owner)
+    staff_client = APIClient()
+    staff_client.force_authenticate(staff)
+
+    res = owner_client.post(
+        f"/api/merchant/orgs/{org.id}/members/",
+        {"user_id": staff.id, "role": "staff"},
+    )
+    assert res.status_code == 400  # duplicate
+
+    res = staff_client.post(
+        f"/api/merchant/orgs/{org.id}/members/",
+        {"user_id": owner.id, "role": "staff"},
+    )
+    assert res.status_code == 403
+
+    from sports.models import Sport, Category, Activity
+
+    sport = Sport.objects.create(name="T")
+    cat = Category.objects.create(name="C")
+    act_res = staff_client.post(
+        "/api/activities/",
+        {
+            "sport": sport.id,
+            "discipline": cat.id,
+            "title": "Test",
+            "organization": org.id,
+        },
+    )
+    assert act_res.status_code == 201
+
+    member_id = OrganizationMember.objects.get(organization=org, user=staff).id
+    res = owner_client.delete(
+        f"/api/merchant/orgs/{org.id}/members/{member_id}/"
+    )
+    assert res.status_code == 204
+
+    res = owner_client.delete(
+        f"/api/merchant/orgs/{org.id}/members/{member_id}/"
+    )
+    assert res.status_code == 400

--- a/backend/tests/test_activity_api.py
+++ b/backend/tests/test_activity_api.py
@@ -21,7 +21,7 @@ def setup_taxonomy():
     return sport, disc, var
 
 
-def test_create_activity_invalid_taxonomy(auth_client):
+def test_create_activity_invalid_taxonomy(auth_client, provider_user):
     sport, disc, var = setup_taxonomy()
     resp = auth_client.post(
         "/api/activities/",
@@ -30,12 +30,13 @@ def test_create_activity_invalid_taxonomy(auth_client):
             "discipline": disc.id + 1,
             "variant": var.id,
             "title": "Surf 101",
+            "organization": provider_user.org.id,
         },
     )
     assert resp.status_code == 400
 
 
-def test_create_activity_success(auth_client):
+def test_create_activity_success(auth_client, provider_user):
     sport, disc, var = setup_taxonomy()
     resp = auth_client.post(
         "/api/activities/",
@@ -47,6 +48,7 @@ def test_create_activity_success(auth_client):
             "difficulty": 3,
             "duration": 90,
             "base_price": "20.00",
+            "organization": provider_user.org.id,
         },
     )
     assert resp.status_code == 201
@@ -79,9 +81,13 @@ def test_filter_activities_by_category(client):
     sport = Sport.objects.create(name="Row")
     cat1 = Category.objects.create(name="Water")
     cat2 = Category.objects.create(name="Land")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     act = Activity.objects.create(
         sport=sport,
         discipline=cat1,
+        organization=org,
         title="Rowing",
         description="",
         difficulty=1,
@@ -91,6 +97,7 @@ def test_filter_activities_by_category(client):
     Activity.objects.create(
         sport=sport,
         discipline=cat2,
+        organization=org,
         title="Biking",
         description="",
         difficulty=1,
@@ -112,10 +119,14 @@ def test_filter_activities_invalid_category(client):
 def test_list_no_pagination(client):
     sport = Sport.objects.create(name="Run")
     cat = Category.objects.create(name="Track")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     for i in range(5):
         Activity.objects.create(
             sport=sport,
             discipline=cat,
+            organization=org,
             title=f"Run {i}",
             description="",
             difficulty=1,

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -117,6 +117,9 @@ def test_concurrent_booking_capacity(db):
 def test_slots_filter_by_activity():
     sport = Sport.objects.create(name="Yoga")
     disc = Category.objects.create(name="Flow")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     activity = Activity.objects.create(
         sport=sport,
         discipline=disc,
@@ -125,6 +128,7 @@ def test_slots_filter_by_activity():
         difficulty=1,
         duration=60,
         base_price=0,
+        organization=org,
     )
     slot = Slot.objects.create(
         sport=sport,
@@ -148,6 +152,9 @@ def test_continue_planning_endpoint():
     user = User.objects.create_user("planu")
     sport = Sport.objects.create(name="Run")
     cat = Category.objects.create(name="Aerobic")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     act = Activity.objects.create(
         sport=sport,
         discipline=cat,
@@ -156,6 +163,7 @@ def test_continue_planning_endpoint():
         difficulty=1,
         duration=30,
         base_price=5,
+        organization=org,
     )
     UserActivityHistory.objects.create(
         user=user, activity=act, action="view"
@@ -172,6 +180,9 @@ def test_continue_planning_endpoint():
 def test_webhook_updates_booking(client=None):
     sport = Sport.objects.create(name="Foot")
     cat = Category.objects.create(name="Play")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     act = Activity.objects.create(
         sport=sport,
         discipline=cat,
@@ -180,6 +191,7 @@ def test_webhook_updates_booking(client=None):
         difficulty=1,
         duration=60,
         base_price=10,
+        organization=org,
     )
     slot = Slot.objects.create(
         sport=sport,

--- a/backend/tests/test_image_upload.py
+++ b/backend/tests/test_image_upload.py
@@ -20,15 +20,21 @@ def test_category_upload():
 def test_is_nearby_filter():
     sport = Sport.objects.create(name='Run')
     cat = Category.objects.create(name='Road')
-    act1 = Activity.objects.create(sport=sport, discipline=cat, title='A', is_nearby=True)
-    Activity.objects.create(sport=sport, discipline=cat, title='B', is_nearby=False)
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name='O', slug=f'o-{uuid4().hex[:8]}')
+    act1 = Activity.objects.create(sport=sport, discipline=cat, title='A', is_nearby=True, organization=org)
+    Activity.objects.create(sport=sport, discipline=cat, title='B', is_nearby=False, organization=org)
     assert Activity.objects.filter(is_nearby=True).count() == 1
 
 def test_api_nearby_filter(client):
     sport = Sport.objects.create(name='Swim')
     cat = Category.objects.create(name='Pool')
-    Activity.objects.create(sport=sport, discipline=cat, title='X', is_nearby=True)
-    Activity.objects.create(sport=sport, discipline=cat, title='Y', is_nearby=False)
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name='O', slug=f'o-{uuid4().hex[:8]}')
+    Activity.objects.create(sport=sport, discipline=cat, title='X', is_nearby=True, organization=org)
+    Activity.objects.create(sport=sport, discipline=cat, title='Y', is_nearby=False, organization=org)
     resp = client.get('/api/activities/', {'nearby': '1'})
     assert resp.status_code == 200
     assert len(resp.data) == 1

--- a/backend/tests/test_payment_checkout.py
+++ b/backend/tests/test_payment_checkout.py
@@ -23,6 +23,9 @@ def auth_client():
 def slot():
     sport = Sport.objects.create(name='X')
     cat = Category.objects.create(name='C')
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name='O', slug=f'o-{uuid4().hex[:8]}')
     act = Activity.objects.create(
         sport=sport,
         discipline=cat,
@@ -31,6 +34,7 @@ def slot():
         difficulty=1,
         duration=60,
         base_price=10,
+        organization=org,
     )
     return Slot.objects.create(
         sport=sport,

--- a/backend/tests/test_payment_webhook.py
+++ b/backend/tests/test_payment_webhook.py
@@ -12,6 +12,9 @@ pytestmark = pytest.mark.django_db
 def test_payment_webhook_updates_booking():
     sport = Sport.objects.create(name="Pay")
     cat = Category.objects.create(name="Cat")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     act = Activity.objects.create(
         sport=sport,
         discipline=cat,
@@ -20,6 +23,7 @@ def test_payment_webhook_updates_booking():
         difficulty=1,
         duration=60,
         base_price=10,
+        organization=org,
     )
     slot = Slot.objects.create(
         sport=sport,

--- a/backend/tests/test_review_api.py
+++ b/backend/tests/test_review_api.py
@@ -11,6 +11,12 @@ def setup_activity(user):
     sport = Sport.objects.create(name="Climb")
     disc = Category.objects.create(name="Rock")
     var = Variant.objects.create(discipline=disc, name="Bouldering")
+    from accounts.models import Organization, OrganizationMember
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
+    OrganizationMember.objects.create(
+        organization=org, user=user, role="owner"
+    )
     client = APIClient()
     client.force_authenticate(user)
     resp = client.post(
@@ -20,6 +26,7 @@ def setup_activity(user):
             "discipline": disc.id,
             "variant": var.id,
             "title": "Climb 101",
+            "organization": org.id,
         },
     )
     return client, resp.data["id"]

--- a/backend/tests/test_search.py
+++ b/backend/tests/test_search.py
@@ -18,9 +18,13 @@ def create_data():
     sport2 = Sport.objects.create(name="Bike")
     cat1 = Category.objects.create(name="Water")
     cat2 = Category.objects.create(name="Land")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     Activity.objects.create(
         sport=sport1,
         discipline=cat1,
+        organization=org,
         title="Surf Class",
         description="Learn surfing",
         difficulty=1,
@@ -30,6 +34,7 @@ def create_data():
     Activity.objects.create(
         sport=sport2,
         discipline=cat2,
+        organization=org,
         title="Mountain Biking",
         description="Ride the hills",
         difficulty=1,
@@ -77,10 +82,14 @@ def test_search_no_match(client):
 def test_search_pagination(client):
     sport = Sport.objects.create(name="Run")
     cat = Category.objects.create(name="Road")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     for i in range(25):
         Activity.objects.create(
             sport=sport,
             discipline=cat,
+            organization=org,
             title=f"Run {i}",
             description="Long run",
             difficulty=1,

--- a/backend/tests/test_slot_filters.py
+++ b/backend/tests/test_slot_filters.py
@@ -11,9 +11,13 @@ pytestmark = pytest.mark.django_db
 def test_slots_filter_by_activity_and_after_utc():
     sport = Sport.objects.create(name="Ping")
     cat = Category.objects.create(name="Gen")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
     act = Activity.objects.create(
         sport=sport,
         discipline=cat,
+        organization=org,
         title="A",
         description="",
         difficulty=1,

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,6 +13,8 @@ whitenoise==6.6.0
 Pillow==11.3.0
 stripe==9.8.0
 python-dotenv==1.0.1
+drf-spectacular==0.27.0
+shortuuid==1.0.11
 
 # Added: required for container/CI
 psycopg2-binary==2.9.9      # Postgres driver


### PR DESCRIPTION
## Summary
- drop staff elevation on vendor registration and audit existing staff vendors
- add Organization & OrganizationMember models with permissions and management APIs
- migrate activities to organizations and update related serializers and views

## Testing
- `python manage.py check --deploy`
- `pytest -q` *(fails: 17 failed, 29 passed, 1 error)*


------
https://chatgpt.com/codex/tasks/task_e_68977c3edb788326ac4fd6f2352daac7