### PR TITLE
Add paged merchant bookings API with cancel/refund and timeout cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,3 +218,17 @@ DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest backend -q
 A helper script `scripts/run_backend_tests.sh` automates the above commands.
 Some tests require SpatiaLite which may not work on every platform. Docker is
 the recommended environment for running the full test suite.
+
+## Booking timeout cleanup
+
+Pending bookings older than 30 minutes can be cleaned up with:
+
+```
+python backend/manage.py bookings_cancel_timeouts
+```
+
+To run it periodically add a cron job such as:
+
+```
+*/10 * * * * python /path/to/backend/manage.py bookings_cancel_timeouts
+```

--- a/backend/payments/services.py
+++ b/backend/payments/services.py
@@ -1,0 +1,17 @@
+import os
+import logging
+import stripe
+
+stripe.api_key = os.getenv('STRIPE_API_KEY', '')
+logger = logging.getLogger(__name__)
+
+
+def refund(booking):
+    """Issue a refund via Stripe for the given booking."""
+    if not booking.payment_intent_id:
+        raise ValueError('booking has no payment intent')
+    try:
+        stripe.Refund.create(payment_intent=booking.payment_intent_id)
+    except stripe.error.StripeError as e:  # pragma: no cover - network call
+        logger.exception('Stripe refund failed')
+        raise

--- a/backend/sports/management/commands/bookings_cancel_timeouts.py
+++ b/backend/sports/management/commands/bookings_cancel_timeouts.py
@@ -1,0 +1,24 @@
+from django.core.management.base import BaseCommand
+from django.utils import timezone
+from datetime import timedelta
+from django.db.models import F
+
+from sports.models import Booking
+
+
+class Command(BaseCommand):
+    help = "Cancel pending bookings older than 30 minutes"
+
+    def handle(self, *args, **options):
+        cutoff = timezone.now() - timedelta(minutes=30)
+        qs = Booking.objects.filter(
+            status=Booking.STATUS_PENDING, booked_at__lt=cutoff
+        ).select_related("slot")
+        count = 0
+        for b in qs:
+            b.slot.current_participants = F("current_participants") - b.pax
+            b.slot.save(update_fields=["current_participants"])
+            b.status = Booking.STATUS_CANCELLED
+            b.save(update_fields=["status"])
+            count += 1
+        self.stdout.write(f"Cancelled {count} bookings")

--- a/backend/sports/merchant_views.py
+++ b/backend/sports/merchant_views.py
@@ -1,11 +1,17 @@
-from rest_framework import viewsets, permissions
+from rest_framework import viewsets, permissions, generics, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
+from rest_framework.pagination import CursorPagination
+from django.utils.dateparse import parse_datetime
+from django.utils import timezone
+from django.shortcuts import get_object_or_404
+from django.db.models import F
+from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse, OpenApiParameter, OpenApiTypes
 
-from .models import Slot
-from .serializers import SlotSerializer, MerchantSlotSerializer
+from .models import Slot, Booking
+from .serializers import SlotSerializer, MerchantSlotSerializer, BookingSerializer
 from accounts.permissions import IsVendor
+from payments.services import refund
 
 
 class MerchantSlotViewSet(viewsets.ModelViewSet):
@@ -84,3 +90,99 @@ class MerchantSlotBulkDeleteView(APIView):
             "forbidden": forbidden,
             "not_found": not_found,
         })
+
+class BookingCursorPagination(CursorPagination):
+    page_size = 50
+    ordering = '-booked_at'
+
+
+class MerchantBookingListPaged(generics.ListAPIView):
+    permission_classes = [permissions.IsAuthenticated, IsVendor]
+    serializer_class = BookingSerializer
+    pagination_class = BookingCursorPagination
+
+    def get_queryset(self):
+        qs = Booking.objects.filter(
+            activity__organization__members__user=self.request.user
+        ).select_related("slot", "user", "slot__activity")
+        params = self.request.query_params
+        status_param = params.get("status")
+        if status_param in dict(Booking.STATUS_CHOICES):
+            qs = qs.filter(status=status_param)
+        paid = params.get("paid")
+        if paid == "true":
+            qs = qs.filter(paid=True)
+        elif paid == "false":
+            qs = qs.filter(paid=False)
+        created_after = params.get("created_after")
+        if created_after:
+            dt = parse_datetime(created_after)
+            if dt:
+                qs = qs.filter(booked_at__gte=dt)
+        created_before = params.get("created_before")
+        if created_before:
+            dt = parse_datetime(created_before)
+            if dt:
+                qs = qs.filter(booked_at__lte=dt)
+        activity_id = params.get("activity_id")
+        if activity_id:
+            qs = qs.filter(activity_id=activity_id)
+        return qs
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter("status", OpenApiTypes.STR, required=False),
+            OpenApiParameter("paid", OpenApiTypes.BOOL, required=False),
+            OpenApiParameter("created_after", OpenApiTypes.DATETIME, required=False),
+            OpenApiParameter("created_before", OpenApiTypes.DATETIME, required=False),
+            OpenApiParameter("activity_id", OpenApiTypes.INT, required=False),
+            OpenApiParameter("cursor", OpenApiTypes.STR, required=False),
+        ],
+        responses={
+            200: OpenApiResponse(
+                response=BookingSerializer(many=True),
+                examples=[
+                    OpenApiExample(
+                        "Example",
+                        value={"next": None, "previous": None, "results": []},
+                    )
+                ],
+            )
+        },
+    )
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+
+
+class MerchantBookingCancelView(APIView):
+    permission_classes = [permissions.IsAuthenticated, IsVendor]
+
+    @extend_schema(
+        responses={
+            200: BookingSerializer,
+            400: OpenApiResponse(description="Invalid state"),
+            502: OpenApiResponse(description="Refund failed"),
+        }
+    )
+    def post(self, request, pk):
+        booking = get_object_or_404(
+            Booking.objects.select_related("slot"),
+            pk=pk,
+            activity__organization__members__user=request.user,
+        )
+        if booking.status not in (Booking.STATUS_PENDING, Booking.STATUS_CONFIRMED):
+            return Response({"detail": "invalid_status"}, status=400)
+        if booking.paid:
+            try:
+                refund(booking)
+            except Exception:
+                return Response({"detail": "refund_failed"}, status=502)
+            booking.status = Booking.STATUS_REFUNDED
+        else:
+            booking.status = Booking.STATUS_CANCELLED
+        booking.save(update_fields=["status"])
+        booking.slot.current_participants = F("current_participants") - booking.pax
+        booking.slot.save(update_fields=["current_participants"])
+        booking.slot.refresh_from_db()
+        ser = BookingSerializer(booking)
+        return Response(ser.data)

--- a/backend/sports/migrations/0020_booking_status_choices.py
+++ b/backend/sports/migrations/0020_booking_status_choices.py
@@ -1,0 +1,27 @@
+from django.db import migrations, models
+
+
+def set_pending(apps, schema_editor):
+    Booking = apps.get_model('sports', 'Booking')
+    Booking.objects.filter(status__isnull=True).update(status='pending')
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0019_slot_is_active_alter_activity_organization_and_more'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='booking',
+            name='status',
+            field=models.CharField(max_length=20, choices=[
+                ('pending', 'Pending'),
+                ('confirmed', 'Confirmed'),
+                ('cancelled', 'Cancelled'),
+                ('refunded', 'Refunded'),
+                ('completed', 'Completed'),
+            ], default='pending'),
+        ),
+        migrations.RunPython(set_pending, migrations.RunPython.noop),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -237,7 +237,21 @@ class Booking(models.Model):
     )
     user = models.ForeignKey("auth.User", on_delete=models.CASCADE)
     booked_at = models.DateTimeField(default=timezone.now)
-    status = models.CharField(max_length=20, default="confirmed")
+    STATUS_PENDING = "pending"
+    STATUS_CONFIRMED = "confirmed"
+    STATUS_CANCELLED = "cancelled"
+    STATUS_REFUNDED = "refunded"
+    STATUS_COMPLETED = "completed"
+
+    STATUS_CHOICES = [
+        (STATUS_PENDING, "Pending"),
+        (STATUS_CONFIRMED, "Confirmed"),
+        (STATUS_CANCELLED, "Cancelled"),
+        (STATUS_REFUNDED, "Refunded"),
+        (STATUS_COMPLETED, "Completed"),
+    ]
+
+    status = models.CharField(max_length=20, choices=STATUS_CHOICES, default=STATUS_PENDING)
     paid = models.BooleanField(default=False)
     payment_intent_id = models.CharField(max_length=255, null=True, blank=True)
     pax = models.PositiveSmallIntegerField(

--- a/backend/sports/urls.py
+++ b/backend/sports/urls.py
@@ -18,7 +18,7 @@ from .views import (
     MerchantBookingList,
     FavoriteViewSet,
 )
-from .merchant_views import MerchantSlotViewSet, MerchantSlotBulkDeleteView
+from .merchant_views import MerchantSlotViewSet, MerchantSlotBulkDeleteView, MerchantBookingListPaged, MerchantBookingCancelView
 
 router = DefaultRouter()
 router.register(r"sports",    SportViewSet,    basename="sport")
@@ -36,6 +36,8 @@ router.register(r"merchant/slots", MerchantSlotViewSet, basename="merchant-slots
 urlpatterns = router.urls + [
     path("slots/bulk/", BulkSlotCreateView.as_view(), name="slot-bulk"),
     path("merchant/bookings/", MerchantBookingList.as_view()),
+    path("merchant/bookings/paged/", MerchantBookingListPaged.as_view()),
+    path("merchant/bookings/<int:pk>/cancel/", MerchantBookingCancelView.as_view()),
     path("merchant/slots/bulk-delete/", MerchantSlotBulkDeleteView.as_view()),
     path("activities/<int:activity_id>/reviews/", ActivityReviewList.as_view(), name="activity-reviews"),
     path("home/continue-planning/", ContinuePlanningView.as_view()),

--- a/backend/tests/test_bookings_nonbreaking.py
+++ b/backend/tests/test_bookings_nonbreaking.py
@@ -1,0 +1,152 @@
+from django.contrib.auth.models import User
+from django.core.management import call_command
+from django.utils import timezone
+import pytest
+
+from sports.models import Booking, Activity, Slot, Category, Sport
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def activity(provider_user):
+    sport = Sport.objects.create(name="S")
+    cat = Category.objects.create(name="CatN")
+    return Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title="Act",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=0,
+        organization=provider_user.org,
+    )
+
+
+@pytest.fixture
+def slot(activity):
+    begins = timezone.now() + timezone.timedelta(hours=1)
+    ends = begins + timezone.timedelta(hours=1)
+    return Slot.objects.create(
+        activity=activity,
+        sport=activity.sport,
+        title="S",
+        location="L",
+        begins_at=begins,
+        ends_at=ends,
+        capacity=100,
+        price=0,
+    )
+
+
+def test_paged_list_cursor_filters(auth_client, activity, slot):
+    for i in range(55):
+        u = User.objects.create_user(f"u{i}")
+        Booking.objects.create(
+            slot=slot,
+            activity=activity,
+            user=u,
+            pax=1,
+            status="pending",
+            paid=False,
+            booked_at=timezone.now() - timezone.timedelta(minutes=i),
+        )
+    u = User.objects.create_user("conf")
+    Booking.objects.create(
+        slot=slot,
+        activity=activity,
+        user=u,
+        pax=1,
+        status="confirmed",
+        paid=True,
+    )
+    resp_old = auth_client.get("/api/merchant/bookings/")
+    assert resp_old.status_code == 200
+    assert isinstance(resp_old.data, list)
+    assert len(resp_old.data) == 56
+
+    resp = auth_client.get("/api/merchant/bookings/paged/?status=pending")
+    assert resp.status_code == 200
+    assert "results" in resp.data and len(resp.data["results"]) == 50
+    next_url = resp.data["next"]
+    assert next_url
+    resp2 = auth_client.get(next_url)
+    assert len(resp2.data["results"]) == 5
+    assert all(b["status"] == "pending" for b in resp.data["results"])
+
+
+def test_cancel_pending_and_confirmed(auth_client, activity, slot):
+    u1 = User.objects.create_user("p1")
+    u2 = User.objects.create_user("p2")
+    pending = Booking.objects.create(slot=slot, activity=activity, user=u1, pax=1, status="pending", paid=False)
+    confirmed = Booking.objects.create(slot=slot, activity=activity, user=u2, pax=1, status="confirmed", paid=False)
+    slot.current_participants = 2
+    slot.save(update_fields=["current_participants"])
+    resp1 = auth_client.post(f"/api/merchant/bookings/{pending.id}/cancel/")
+    assert resp1.status_code == 200
+    pending.refresh_from_db()
+    assert pending.status == "cancelled"
+    resp2 = auth_client.post(f"/api/merchant/bookings/{confirmed.id}/cancel/")
+    assert resp2.status_code == 200
+    confirmed.refresh_from_db()
+    assert confirmed.status == "cancelled"
+    u3 = User.objects.create_user("p3")
+    completed = Booking.objects.create(slot=slot, activity=activity, user=u3, pax=1, status="completed", paid=True)
+    resp3 = auth_client.post(f"/api/merchant/bookings/{completed.id}/cancel/")
+    assert resp3.status_code == 400
+
+
+def test_refund_success_and_failure(auth_client, activity, slot, monkeypatch):
+    u1 = User.objects.create_user("r1")
+    b1 = Booking.objects.create(slot=slot, activity=activity, user=u1, pax=1, status="confirmed", paid=True, payment_intent_id="pi_1")
+    slot.current_participants = 2
+    slot.save(update_fields=["current_participants"])
+    def ok(_):
+        return None
+    monkeypatch.setattr("sports.merchant_views.refund", ok)
+    resp = auth_client.post(f"/api/merchant/bookings/{b1.id}/cancel/")
+    assert resp.status_code == 200
+    b1.refresh_from_db()
+    assert b1.status == "refunded"
+
+    u2 = User.objects.create_user("r2")
+    b2 = Booking.objects.create(slot=slot, activity=activity, user=u2, pax=1, status="confirmed", paid=True, payment_intent_id="pi_2")
+    def boom(_):
+        raise Exception("fail")
+    monkeypatch.setattr("sports.merchant_views.refund", boom)
+    resp2 = auth_client.post(f"/api/merchant/bookings/{b2.id}/cancel/")
+    assert resp2.status_code == 502
+    b2.refresh_from_db()
+    assert b2.status == "confirmed"
+
+
+def test_timeout_job_or_command(activity, slot):
+    u = User.objects.create_user("t1")
+    b = Booking.objects.create(slot=slot, activity=activity, user=u, pax=1, status="pending", paid=False, booked_at=timezone.now() - timezone.timedelta(minutes=31))
+    slot.current_participants = 1
+    slot.save(update_fields=["current_participants"])
+    call_command("bookings_cancel_timeouts")
+    b.refresh_from_db()
+    assert b.status == "cancelled"
+
+
+def test_concurrency_unchanged(db):
+    sport = Sport.objects.create(name="S")
+    cat = Category.objects.create(name="C")
+    from accounts.models import Organization
+    from uuid import uuid4
+    org = Organization.objects.create(name="Org", slug=f"org-{uuid4().hex[:8]}")
+    activity = Activity.objects.create(sport=sport, discipline=cat, title="A", description="", difficulty=1, duration=60, base_price=0, organization=org)
+    begins = timezone.now() + timezone.timedelta(hours=1)
+    ends = begins + timezone.timedelta(hours=1)
+    slot = Slot.objects.create(activity=activity, sport=sport, title="T", location="L", begins_at=begins, ends_at=ends, capacity=1, price=0)
+    u1 = User.objects.create_user("u1")
+    u2 = User.objects.create_user("u2")
+    client1 = pytest.importorskip("rest_framework.test").APIClient()
+    client2 = pytest.importorskip("rest_framework.test").APIClient()
+    client1.force_authenticate(u1)
+    client2.force_authenticate(u2)
+    r1 = client1.post("/api/bookings/", {"slot_id": slot.id, "pax": 1})
+    r2 = client2.post("/api/bookings/", {"slot_id": slot.id, "pax": 1})
+    assert [r1.status_code, r2.status_code].count(201) == 1

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- 新增分页版商家订单列表 `/merchant/bookings/paged/`；旧端点 `/merchant/bookings/` 保持兼容。


### PR DESCRIPTION
## Summary
- add cursor-paginated merchant bookings list with filters
- support booking cancellation with optional Stripe refund
- auto-cancel pending bookings via management command

## Testing
- `pytest backend/tests/test_bookings_nonbreaking.py`
- `python backend/manage.py check --deploy` (warnings about drf_spectacular and security settings)


------
https://chatgpt.com/codex/tasks/task_e_68989a0059788326a7c7cbec106683dd