### PR TITLE
Enable image uploads and activity list pagination

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,9 @@
     <!-- Needed for geolocator -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.CAMERA" />
     <application
         android:label="sports_booking_app"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,9 @@
         <true/>
         <key>NSLocationWhenInUseUsageDescription</key>
         <string>This app requires location access to show nearby activities.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>需要访问相册以选择活动图片。</string>
+        <key>NSCameraUsageDescription</key>
+        <string>需要访问相机以拍摄活动图片。</string>
 </dict>
 </plist>

--- a/lib/providers/org_provider.dart
+++ b/lib/providers/org_provider.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import '../services/org_service.dart';
+
+class OrgsNotifier extends StateNotifier<AsyncValue<List<Map<String, dynamic>>>> {
+  OrgsNotifier() : super(const AsyncValue.loading());
+
+  int? selectedId;
+
+  Future<void> load() async {
+    if (state is AsyncData) return;
+    try {
+      final orgs = await orgService.fetchMine();
+      if (selectedId == null && orgs.length == 1) {
+        selectedId = orgs.first['id'] as int;
+      }
+      state = AsyncValue.data(orgs);
+    } catch (e, st) {
+      state = AsyncValue.error(e, st);
+    }
+  }
+
+  void select(int id) {
+    selectedId = id;
+  }
+}
+
+final orgsProvider =
+    StateNotifierProvider<OrgsNotifier, AsyncValue<List<Map<String, dynamic>>>>(
+        (ref) => OrgsNotifier());
+

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -1,35 +1,42 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../models/activity.dart';
+import '../models/category.dart';
+import '../models/sport.dart';
+import '../models/variant.dart';
+import '../providers/org_provider.dart';
 import '../services/activity_service.dart';
 import '../services/sports_service.dart';
 import '../utils/snackbar.dart';
-import 'package:dio/dio.dart';
 
-import '../models/activity.dart';
-import '../models/sport.dart';
-import '../models/category.dart';
-import '../models/variant.dart';
-
-class AddActivityPage extends StatefulWidget {
+class AddActivityPage extends ConsumerStatefulWidget {
   final Activity? activity;
   const AddActivityPage({this.activity, super.key});
 
   @override
-  State<AddActivityPage> createState() => _AddActivityPageState();
+  ConsumerState<AddActivityPage> createState() => _AddActivityPageState();
 }
 
-class _AddActivityPageState extends State<AddActivityPage> {
+class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   final _formKey = GlobalKey<FormState>();
   final titleCtrl = TextEditingController();
   final descCtrl = TextEditingController();
   final priceCtrl = TextEditingController();
   final durationCtrl = TextEditingController(text: '60');
-  final imageCtrl = TextEditingController();
 
   int? sportId;
   int? disciplineId;
   int? variantId;
   int difficulty = 1;
+  int? organizationId;
   bool _submitting = false;
+  XFile? _imageFile;
+  Map<String, String> fieldErrors = {};
 
   late Future<void> _loadFuture;
   List<Sport> sports = [];
@@ -48,16 +55,19 @@ class _AddActivityPageState extends State<AddActivityPage> {
       descCtrl.text = a.description;
       priceCtrl.text = a.basePrice.toStringAsFixed(2);
       durationCtrl.text = a.duration.toString();
-      imageCtrl.text = a.image;
       difficulty = a.difficulty;
     }
     _loadFuture = _loadData();
   }
 
   Future<void> _loadData() async {
-    sports = await sportsService.fetchSports();
-    categories = await sportsService.fetchCategories();
-    variants = await sportsService.fetchVariants();
+    await Future.wait([
+      sportsService.fetchSports().then((v) => sports = v),
+      sportsService.fetchCategories().then((v) => categories = v),
+      sportsService.fetchVariants().then((v) => variants = v),
+      ref.read(orgsProvider.notifier).load(),
+    ]);
+    organizationId = ref.read(orgsProvider.notifier).selectedId;
   }
 
   @override
@@ -66,12 +76,13 @@ class _AddActivityPageState extends State<AddActivityPage> {
     descCtrl.dispose();
     priceCtrl.dispose();
     durationCtrl.dispose();
-    imageCtrl.dispose();
     super.dispose();
   }
 
   @override
   Widget build(BuildContext context) {
+    final orgsAsync = ref.watch(orgsProvider);
+    final orgs = orgsAsync.value ?? [];
     return Scaffold(
       appBar: AppBar(title: const Text('Create Activity')),
       body: FutureBuilder(
@@ -86,6 +97,26 @@ class _AddActivityPageState extends State<AddActivityPage> {
               key: _formKey,
               child: ListView(
                 children: [
+                  if (orgs.length > 1)
+                    DropdownButtonFormField<int>(
+                      value: organizationId,
+                      items: orgs
+                          .map<DropdownMenuItem<int>>((e) => DropdownMenuItem(
+                                value: e['id'] as int,
+                                child: Text(e['name'].toString()),
+                              ))
+                          .toList(),
+                      onChanged: (v) {
+                        setState(() => organizationId = v);
+                        if (v != null) {
+                          ref.read(orgsProvider.notifier).select(v);
+                        }
+                      },
+                      decoration: InputDecoration(
+                          labelText: '组织',
+                          errorText: fieldErrors['organization']),
+                      validator: (v) => v == null ? 'Required' : null,
+                    ),
                   DropdownButtonFormField<int>(
                     value: sportId,
                     items: sports
@@ -95,7 +126,8 @@ class _AddActivityPageState extends State<AddActivityPage> {
                             ))
                         .toList(),
                     onChanged: (v) => setState(() => sportId = v),
-                    decoration: const InputDecoration(labelText: 'Sport'),
+                    decoration: InputDecoration(
+                        labelText: 'Sport', errorText: fieldErrors['sport']),
                     validator: (v) => v == null ? 'Required' : null,
                   ),
                   DropdownButtonFormField<int>(
@@ -107,7 +139,9 @@ class _AddActivityPageState extends State<AddActivityPage> {
                             ))
                         .toList(),
                     onChanged: (v) => setState(() => disciplineId = v),
-                    decoration: const InputDecoration(labelText: 'Discipline'),
+                    decoration: InputDecoration(
+                        labelText: 'Discipline',
+                        errorText: fieldErrors['discipline']),
                     validator: (v) => v == null ? 'Required' : null,
                   ),
                   DropdownButtonFormField<int?>(
@@ -123,21 +157,25 @@ class _AddActivityPageState extends State<AddActivityPage> {
                           .toList(),
                     ],
                     onChanged: (v) => setState(() => variantId = v),
-                    decoration: const InputDecoration(labelText: 'Variant'),
+                    decoration: InputDecoration(labelText: 'Variant', errorText: fieldErrors['variant']),
                   ),
                   TextFormField(
                     controller: titleCtrl,
-                    decoration: const InputDecoration(labelText: 'Title'),
+                    decoration: InputDecoration(
+                        labelText: 'Title', errorText: fieldErrors['title']),
                     validator: (v) => v == null || v.isEmpty ? 'Required' : null,
                   ),
                   TextFormField(
                     controller: descCtrl,
-                    decoration: const InputDecoration(labelText: 'Description'),
+                    decoration: InputDecoration(
+                        labelText: 'Description', errorText: fieldErrors['description']),
                     maxLines: 3,
+                    validator: (v) => v == null || v.isEmpty ? 'Required' : null,
                   ),
                   DropdownButtonFormField<int>(
                     value: difficulty,
-                    decoration: const InputDecoration(labelText: 'Difficulty'),
+                    decoration: InputDecoration(
+                        labelText: 'Difficulty', errorText: fieldErrors['difficulty']),
                     items: List.generate(
                       5,
                       (i) => DropdownMenuItem(value: i + 1, child: Text('${i + 1}')),
@@ -146,27 +184,71 @@ class _AddActivityPageState extends State<AddActivityPage> {
                   ),
                   TextFormField(
                     controller: durationCtrl,
-                    decoration: const InputDecoration(labelText: 'Duration (min)'),
+                    decoration: InputDecoration(
+                        labelText: 'Duration (min)',
+                        errorText: fieldErrors['duration']),
                     keyboardType: TextInputType.number,
-                    validator: (v) => int.tryParse(v ?? '') == null ? 'Enter number' : null,
+                    validator: (v) {
+                      final n = int.tryParse(v ?? '');
+                      if (n == null || n <= 0) return 'Enter positive number';
+                      return null;
+                    },
                   ),
                   TextFormField(
                     controller: priceCtrl,
-                    decoration: const InputDecoration(labelText: 'Base Price'),
+                    decoration: InputDecoration(
+                        labelText: 'Base Price', errorText: fieldErrors['base_price']),
                     keyboardType: TextInputType.number,
-                    validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
+                    validator: (v) {
+                      final n = double.tryParse(v ?? '');
+                      if (n == null || n < 0) return 'Enter number';
+                      return null;
+                    },
                   ),
-                  TextFormField(
-                    controller: imageCtrl,
-                    decoration: const InputDecoration(labelText: 'Image URL'),
-                  ),
+                  const SizedBox(height: 8),
+                  if (_imageFile != null)
+                    Stack(
+                      children: [
+                        Image.file(File(_imageFile!.path), height: 150, fit: BoxFit.cover),
+                        Positioned(
+                          right: 0,
+                          top: 0,
+                          child: IconButton(
+                            icon: const Icon(Icons.close),
+                            onPressed: () => setState(() => _imageFile = null),
+                          ),
+                        ),
+                      ],
+                    )
+                  else
+                    OutlinedButton.icon(
+                      icon: const Icon(Icons.image),
+                      label: const Text('选择图片'),
+                      onPressed: () async {
+                        final picker = ImagePicker();
+                        final file = await picker.pickImage(source: ImageSource.gallery);
+                        if (file != null) setState(() => _imageFile = file);
+                      },
+                    ),
+                  if (fieldErrors['image'] != null)
+                    Padding(
+                      padding: const EdgeInsets.only(top: 4),
+                      child: Text(
+                        fieldErrors['image']!,
+                        style: TextStyle(
+                            color: Theme.of(context).colorScheme.error, fontSize: 12),
+                      ),
+                    ),
                   const SizedBox(height: 20),
                   ElevatedButton(
                     onPressed: _submitting
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) return;
-                            setState(() => _submitting = true);
+                            setState(() {
+                              _submitting = true;
+                              fieldErrors = {};
+                            });
                             try {
                               if (widget.activity == null) {
                                 await activityService.createActivity(
@@ -178,6 +260,8 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  organizationId: organizationId!,
+                                  imageFile: _imageFile,
                                 );
                               } else {
                                 await activityService.updateActivity(
@@ -190,13 +274,24 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  organizationId: organizationId!,
+                                  imageFile: _imageFile,
                                 );
                               }
                               if (context.mounted) {
+                                ScaffoldMessenger.of(context)
+                                    .showSnackBar(const SnackBar(content: Text('创建成功')));
                                 Navigator.pop(context, true);
                               }
+                            } on FieldErrors catch (e) {
+                              setState(() {
+                                fieldErrors =
+                                    e.errors.map((k, v) => MapEntry(k, v.join(', ')));
+                              });
                             } on DioException catch (e) {
-                              if (context.mounted) showApiError(context, e, 'Create activity');
+                              if (context.mounted) {
+                                showApiError(context, e, 'Create activity');
+                              }
                             } finally {
                               if (mounted) setState(() => _submitting = false);
                             }

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -2,8 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../providers/activity_provider.dart';
 import '../models/activity.dart';
+import '../services/activity_service.dart';
 import '../services/slot_service.dart';
 
 import 'add_activity_page.dart';
@@ -11,13 +11,61 @@ import 'add_slot_page.dart';
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
 
-class ProviderDashboardPage extends ConsumerWidget {
+class ProviderDashboardPage extends ConsumerStatefulWidget {
   const ProviderDashboardPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final asyncActivities = ref.watch(activitiesProvider);
+  ConsumerState<ProviderDashboardPage> createState() => _ProviderDashboardPageState();
+}
 
+class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
+  final List<Activity> _activities = [];
+  final ScrollController _controller = ScrollController();
+  bool _loading = false;
+  String? _next;
+  int _page = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+    _controller.addListener(() {
+      if (_controller.position.pixels >=
+              _controller.position.maxScrollExtent - 200 &&
+          !_loading &&
+          _next != null) {
+        _loadMore();
+      }
+    });
+  }
+
+  Future<void> _refresh() async {
+    setState(() {
+      _activities.clear();
+      _page = 1;
+      _next = null;
+    });
+    await _loadMore();
+  }
+
+  Future<void> _loadMore() async {
+    if (_loading) return;
+    setState(() => _loading = true);
+    try {
+      final page =
+          await activityService.fetchActivities(params: {'mine': '1', 'page': _page});
+      setState(() {
+        _activities.addAll(page.results);
+        _next = page.next;
+        if (page.next != null) _page += 1;
+      });
+    } finally {
+      setState(() => _loading = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Merchant Dashboard'),
@@ -33,23 +81,54 @@ class ProviderDashboardPage extends ConsumerWidget {
         ],
       ),
       drawer: _MerchantDrawer(),
-      body: asyncActivities.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
-        data: (page) => ListView(
-          padding: const EdgeInsets.all(16),
-          children: [
-            _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
-              if (created == true) ref.invalidate(activitiesProvider);
-            }),
-            const SizedBox(height: 16),
-            Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            ...page.results.map((a) => _ActivityCard(activity: a, onChanged: () => ref.invalidate(activitiesProvider))),
-            const SizedBox(height: 80),
-          ],
-        ),
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: _activities.isEmpty && !_loading
+            ? ListView(
+                physics: const AlwaysScrollableScrollPhysics(),
+                children: [
+                  const SizedBox(height: 120),
+                  const Center(child: Text('暂无活动')),
+                  const SizedBox(height: 16),
+                  Center(
+                    child: ElevatedButton(
+                      onPressed: () async {
+                        final created = await Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                                builder: (_) => const AddActivityPage()));
+                        if (created == true) _refresh();
+                      },
+                      child: const Text('去创建活动'),
+                    ),
+                  ),
+                ],
+              )
+            : ListView.builder(
+                controller: _controller,
+                padding: const EdgeInsets.all(16),
+                itemCount: _activities.length + 2,
+                itemBuilder: (context, index) {
+                  if (index == 0) {
+                    return _AddActivityHero(onTap: () async {
+                      final created = await Navigator.push(context,
+                          MaterialPageRoute(builder: (_) => const AddActivityPage()));
+                      if (created == true) _refresh();
+                    });
+                  }
+                  index -= 1;
+                  if (index < _activities.length) {
+                    final a = _activities[index];
+                    return _ActivityCard(activity: a, onChanged: _refresh);
+                  }
+                  return _loading
+                      ? const Padding(
+                          padding: EdgeInsets.symmetric(vertical: 16),
+                          child: Center(child: CircularProgressIndicator()),
+                        )
+                      : const SizedBox(height: 80);
+                },
+              ),
       ),
     );
   }

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -1,4 +1,7 @@
 import 'package:dio/dio.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
+
 import '../models/activity.dart';
 import '../models/paginated.dart';
 import 'api_client.dart';
@@ -67,18 +70,44 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.post('/activities/', data: {
+    double basePrice, {
+    required int organizationId,
+    XFile? imageFile,
+  }) async {
+    final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
+      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (imageFile != null)
+        'image': await MultipartFile.fromFile(imageFile.path,
+            filename: p.basename(imageFile.path)),
     });
+    try {
+      await apiClient.post('/activities/', data: form);
+    } on DioException catch (e) {
+      final status = e.response?.statusCode ?? 0;
+      if (status == 400 || status == 422) {
+        final data = e.response?.data;
+        if (data is Map<String, dynamic>) {
+          final errors = <String, List<String>>{};
+          data.forEach((k, v) {
+            if (v is List) {
+              errors[k] = v.map((e) => e.toString()).toList();
+            } else {
+              errors[k] = [v.toString()];
+            }
+          });
+          throw FieldErrors(errors);
+        }
+      }
+      rethrow;
+    }
   }
 
   Future<void> updateActivity(
@@ -90,19 +119,50 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.patch('/activities/' + id.toString() + '/', data: {
+    double basePrice, {
+    required int organizationId,
+    XFile? imageFile,
+  }) async {
+    final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
-      'variant': variant,
+      if (variant != null) 'variant': variant,
+      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (imageFile != null)
+        'image': await MultipartFile.fromFile(imageFile.path,
+            filename: p.basename(imageFile.path)),
     });
+    try {
+      await apiClient.patch('/activities/' + id.toString() + '/', data: form);
+    } on DioException catch (e) {
+      final status = e.response?.statusCode ?? 0;
+      if (status == 400 || status == 422) {
+        final data = e.response?.data;
+        if (data is Map<String, dynamic>) {
+          final errors = <String, List<String>>{};
+          data.forEach((k, v) {
+            if (v is List) {
+              errors[k] = v.map((e) => e.toString()).toList();
+            } else {
+              errors[k] = [v.toString()];
+            }
+          });
+          throw FieldErrors(errors);
+        }
+      }
+      rethrow;
+    }
   }
 }
 
 final activityService = ActivityService();
+
+class FieldErrors implements Exception {
+  FieldErrors(this.errors);
+  final Map<String, List<String>> errors;
+}

--- a/lib/services/org_service.dart
+++ b/lib/services/org_service.dart
@@ -1,0 +1,17 @@
+import 'package:dio/dio.dart';
+
+import 'api_client.dart';
+
+class OrgService {
+  Future<List<Map<String, dynamic>>> fetchMine() async {
+    final Response res = await apiClient.get('/accounts/merchant/orgs/me/');
+    final data = res.data;
+    if (data is List) {
+      return data.cast<Map<String, dynamic>>();
+    }
+    return [];
+  }
+}
+
+final orgService = OrgService();
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   qr_flutter: ^4.1.0
   flutter_stripe: ^10.0.0
   shared_preferences: ^2.2.2
+  image_picker: ^1.0.7
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- allow selecting merchant organization and local image when creating activities
- upload activity images via multipart including organization id and surface field errors
- add pull-to-refresh and infinite scroll for provider dashboard activity list

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d6925ee483268156f10477b6fbff