### PR TITLE
R1: multipart activity & slot timezone

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,10 @@ dashboard. Simply choose a name and categories; the app will use the device's
 current location as the facility position. Once created the facility appears in
 the *Nearby Activities* list for customers near you.
 
+// R2: From the dashboard you can search your activities and tap any card to
+manage its slots. Use the receipt icon in the app bar to review and cancel
+orders.
+
 ### Provider sign-up
 
 Use `/api/provider/register/` to create a provider account. The request body

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -155,8 +155,8 @@ class VariantSerializer(serializers.ModelSerializer):
 
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
-    organization = serializers.PrimaryKeyRelatedField(
-        queryset=Organization.objects.all()
+    organization = serializers.PrimaryKeyRelatedField(  # R1
+        queryset=Organization.objects.all(), required=False
     )
 
     class Meta:
@@ -191,6 +191,12 @@ class ActivitySerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, attrs):
+        request = self.context.get("request")  # R1
+        org = attrs.get("organization")  # R1
+        if org is None and request and request.user.is_authenticated:  # R1
+            members = OrganizationMember.objects.filter(user=request.user)  # R1
+            if members.count() == 1:  # R1
+                attrs["organization"] = members.first().organization  # R1
         variant = attrs.get("variant")
         discipline = attrs.get("discipline")
         if variant and discipline and variant.discipline_id != discipline.id:
@@ -201,6 +207,8 @@ class ActivitySerializer(serializers.ModelSerializer):
         desc = attrs.get("description", "")
         if len(desc) > 500:
             raise serializers.ValidationError({"description": "Max 500 characters"})
+        if attrs.get("organization") is None:  # R1
+            raise serializers.ValidationError({"organization": "This field is required."})  # R1
         return attrs
 
     def validate_organization(self, value):

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -5,6 +5,7 @@ from django.contrib.gis.db.models.functions import Distance
 from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
+from rest_framework.parsers import MultiPartParser, FormParser, JSONParser  # R1
 from accounts.permissions import IsVendor
 from accounts.models import OrganizationMember
 from rest_framework.views import APIView
@@ -126,6 +127,7 @@ class VariantViewSet(viewsets.ReadOnlyModelViewSet):
 class ActivityViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitySerializer
     pagination_class = DefaultPagination
+    parser_classes = (MultiPartParser, FormParser, JSONParser)  # R1
 
     def get_permissions(self):
         if self.action in ("create", "update", "partial_update", "destroy"):

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## Unreleased
 - 新增分页版商家订单列表 `/merchant/bookings/paged/`；旧端点 `/merchant/bookings/` 保持兼容。
 - R1: Added activity image upload with auto-organization fallback and fixed slot timezone serialization. // R1
+- R2: Added merchant activity search, slot management, and paged order list. // R2

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - 新增分页版商家订单列表 `/merchant/bookings/paged/`；旧端点 `/merchant/bookings/` 保持兼容。
+- R1: Added activity image upload with auto-organization fallback and fixed slot timezone serialization. // R1

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -1,4 +1,6 @@
+import 'dart:io'; // R1
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart'; // R1 requires `flutter pub add image_picker` (iOS: NSPhotoLibraryUsageDescription, Android: storage permission)
 import '../services/activity_service.dart';
 import '../services/sports_service.dart';
 import '../utils/snackbar.dart';
@@ -23,7 +25,7 @@ class _AddActivityPageState extends State<AddActivityPage> {
   final descCtrl = TextEditingController();
   final priceCtrl = TextEditingController();
   final durationCtrl = TextEditingController(text: '60');
-  final imageCtrl = TextEditingController();
+  XFile? _image; // R1
 
   int? sportId;
   int? disciplineId;
@@ -48,7 +50,6 @@ class _AddActivityPageState extends State<AddActivityPage> {
       descCtrl.text = a.description;
       priceCtrl.text = a.basePrice.toStringAsFixed(2);
       durationCtrl.text = a.duration.toString();
-      imageCtrl.text = a.image;
       difficulty = a.difficulty;
     }
     _loadFuture = _loadData();
@@ -66,7 +67,6 @@ class _AddActivityPageState extends State<AddActivityPage> {
     descCtrl.dispose();
     priceCtrl.dispose();
     durationCtrl.dispose();
-    imageCtrl.dispose();
     super.dispose();
   }
 
@@ -156,9 +156,29 @@ class _AddActivityPageState extends State<AddActivityPage> {
                     keyboardType: TextInputType.number,
                     validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
                   ),
-                  TextFormField(
-                    controller: imageCtrl,
-                    decoration: const InputDecoration(labelText: 'Image URL'),
+                  const SizedBox(height: 12), // R1
+                  if (_image != null) ...[ // R1
+                    ClipRRect( // R1
+                      borderRadius: BorderRadius.circular(8), // R1
+                      child: Image.file( // R1
+                        File(_image!.path), // R1
+                        height: 150, // R1
+                        width: 150, // R1
+                        fit: BoxFit.cover, // R1
+                      ),
+                    ),
+                    TextButton( // R1
+                      onPressed: () => setState(() => _image = null), // R1
+                      child: const Text('Remove'), // R1
+                    ),
+                  ],
+                  TextButton.icon( // R1
+                    onPressed: () async { // R1
+                      final img = await ImagePicker().pickImage(source: ImageSource.gallery); // R1
+                      if (img != null) setState(() => _image = img); // R1
+                    },
+                    icon: const Icon(Icons.image), // R1
+                    label: Text(_image == null ? 'Pick Image' : 'Change Image'), // R1
                   ),
                   const SizedBox(height: 20),
                   ElevatedButton(
@@ -178,6 +198,7 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  imagePath: _image?.path, // R1
                                 );
                               } else {
                                 await activityService.updateActivity(
@@ -190,6 +211,7 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  imagePath: _image?.path, // R1
                                 );
                               }
                               if (context.mounted) {

--- a/lib/screens/merchant_orders_page.dart
+++ b/lib/screens/merchant_orders_page.dart
@@ -1,0 +1,134 @@
+import 'package:flutter/material.dart';
+import '../services/merchant_booking_service.dart';
+import '../utils/snackbar.dart';
+
+class MerchantOrdersPage extends StatefulWidget { // R2
+  const MerchantOrdersPage({super.key}); // R2
+
+  @override
+  State<MerchantOrdersPage> createState() => _MerchantOrdersPageState(); // R2
+}
+
+class _MerchantOrdersPageState extends State<MerchantOrdersPage> { // R2
+  final ScrollController _scroll = ScrollController();
+  final List<Map<String, dynamic>> _orders = []; // R2
+  String? _cursor; // R2
+  bool _loading = false; // R2
+  String? _status; // R2
+  bool? _paid; // R2
+
+  @override
+  void initState() {
+    super.initState();
+    _load(true);
+    _scroll.addListener(() {
+      if (_scroll.position.pixels >= _scroll.position.maxScrollExtent - 200 && !_loading && _cursor != null) {
+        _load(false);
+      }
+    });
+  }
+
+  Future<void> _load(bool refresh) async { // R2
+    if (_loading) return;
+    setState(() => _loading = true);
+    if (refresh) {
+      _cursor = null;
+      _orders.clear();
+    }
+    final data = await merchantBookingService.fetchPaged(cursor: _cursor, status: _status, paid: _paid); // R2
+    _cursor = data['next'] as String?;
+    final List list = data['results'] as List? ?? [];
+    _orders.addAll(list.cast<Map<String, dynamic>>());
+    setState(() => _loading = false);
+  }
+
+  Future<void> _cancel(int id) async { // R2
+    try {
+      await merchantBookingService.cancel(id);
+      showSnackBar(context, 'Cancelled');
+      await _load(true);
+    } catch (e) {
+      showSnackBar(context, 'Failed: $e');
+    }
+  }
+
+  void _setStatus(String? s) async { // R2
+    _status = s;
+    await _load(true);
+  }
+
+  void _setPaid(bool? p) async { // R2
+    _paid = p;
+    await _load(true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Orders')), // R2
+      body: Column(
+        children: [
+          Wrap(
+            spacing: 8,
+            children: [
+              ChoiceChip(
+                label: const Text('All'),
+                selected: _status == null,
+                onSelected: (_) => _setStatus(null),
+              ),
+              for (final s in ['pending', 'confirmed', 'cancelled', 'refunded', 'completed'])
+                ChoiceChip(label: Text(s), selected: _status == s, onSelected: (_) => _setStatus(s)),
+              const SizedBox(width: 16),
+              FilterChip(
+                label: const Text('Paid'),
+                selected: _paid == true,
+                onSelected: (_) => _setPaid(_paid == true ? null : true),
+              ),
+              FilterChip(
+                label: const Text('Unpaid'),
+                selected: _paid == false,
+                onSelected: (_) => _setPaid(_paid == false ? null : false),
+              ),
+            ],
+          ),
+          Expanded(
+            child: RefreshIndicator(
+              onRefresh: () => _load(true),
+              child: ListView.builder(
+                controller: _scroll,
+                itemCount: _orders.length + 1,
+                itemBuilder: (context, i) {
+                  if (i >= _orders.length) {
+                    return _cursor == null
+                        ? const SizedBox(height: 80)
+                        : const Padding(
+                            padding: EdgeInsets.symmetric(vertical: 16),
+                            child: Center(child: CircularProgressIndicator()),
+                          );
+                  }
+                  final o = _orders[i];
+                  final id = o['id'] as int;
+                  final status = o['status'] as String? ?? '';
+                  final paid = o['paid'] as bool? ?? false;
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: ListTile(
+                      title: Text('Order #$id'),
+                      subtitle: Text('$status - ${paid ? 'paid' : 'unpaid'}'),
+                      trailing: status == 'cancelled'
+                          ? null
+                          : TextButton(
+                              onPressed: () => _cancel(id),
+                              child: const Text('Cancel'),
+                            ),
+                    ),
+                  );
+                },
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/screens/merchant_slots_page.dart
+++ b/lib/screens/merchant_slots_page.dart
@@ -1,0 +1,157 @@
+import 'package:flutter/material.dart';
+import '../models/slot.dart';
+import '../services/slot_service.dart';
+import '../utils/snackbar.dart';
+
+class MerchantSlotsPage extends StatefulWidget { // R2
+  final int activityId; // R2
+  const MerchantSlotsPage({super.key, required this.activityId}); // R2
+
+  @override
+  State<MerchantSlotsPage> createState() => _MerchantSlotsPageState(); // R2
+}
+
+class _MerchantSlotsPageState extends State<MerchantSlotsPage> { // R2
+  bool _loading = true; // R2
+  List<Slot> _slots = []; // R2
+  final Set<int> _selected = {}; // R2
+
+  @override
+  void initState() {
+    super.initState();
+    _load();
+  }
+
+  Future<void> _load() async { // R2
+    setState(() => _loading = true);
+    try {
+      _slots = await slotService.listMerchantSlots(activityId: widget.activityId); // R2
+    } catch (e) {
+      if (mounted) showSnackBar(context, 'Failed to load slots: $e');
+    }
+    setState(() => _loading = false);
+  }
+
+  Future<void> _editSlot(Slot slot) async { // R2
+    final priceCtrl = TextEditingController(text: slot.price.toString());
+    final capCtrl = TextEditingController(text: slot.capacity.toString());
+    DateTime begins = slot.beginsAt;
+    DateTime ends = slot.endsAt;
+    final ok = await showModalBottomSheet<bool>(
+      context: context,
+      isScrollControlled: true,
+      builder: (context) {
+        return Padding(
+          padding: EdgeInsets.only(bottom: MediaQuery.of(context).viewInsets.bottom + 16, left: 16, right: 16, top: 16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(
+                controller: priceCtrl,
+                decoration: const InputDecoration(labelText: 'Price'),
+                keyboardType: TextInputType.number,
+              ),
+              TextField(
+                controller: capCtrl,
+                decoration: const InputDecoration(labelText: 'Capacity'),
+                keyboardType: TextInputType.number,
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () => Navigator.pop(context, true),
+                child: const Text('Save'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    if (ok == true) {
+      final price = double.tryParse(priceCtrl.text);
+      final cap = int.tryParse(capCtrl.text);
+      if (price == null || cap == null) {
+        showSnackBar(context, 'Invalid input');
+        return;
+      }
+      if (begins.isAfter(ends) || begins.isBefore(DateTime.now())) {
+        showSnackBar(context, 'Invalid times');
+        return;
+      }
+      await slotService.updateSlot(slot.id, price: price, capacity: cap, beginsAt: begins, endsAt: ends); // R2
+      await _load();
+    }
+  }
+
+  Future<void> _deleteSlot(int id) async { // R2
+    await slotService.deleteSlot(id); // R2
+    await _load();
+  }
+
+  Future<void> _bulkDelete() async { // R2
+    if (_selected.isEmpty) return;
+    await slotService.bulkDeleteSlots(_selected.toList()); // R2
+    _selected.clear();
+    await _load();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Slots')), // R2
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _load,
+              child: ListView.builder(
+                itemCount: _slots.length,
+                itemBuilder: (context, i) {
+                  final s = _slots[i];
+                  final selected = _selected.contains(s.id);
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: CheckboxListTile(
+                      value: selected,
+                      onChanged: (_) {
+                        setState(() {
+                          if (selected) {
+                            _selected.remove(s.id);
+                          } else {
+                            _selected.add(s.id);
+                          }
+                        });
+                      },
+                      title: Text(s.title),
+                      subtitle: Text('${s.beginsAt} - ${s.endsAt}\n\$${s.price.toStringAsFixed(2)}'),
+                      isThreeLine: true,
+                      secondary: Row(
+                        mainAxisSize: MainAxisSize.min,
+                        children: [
+                          IconButton(
+                            icon: const Icon(Icons.edit),
+                            onPressed: () => _editSlot(s),
+                          ),
+                          IconButton(
+                            icon: const Icon(Icons.delete),
+                            onPressed: () => _deleteSlot(s.id),
+                          ),
+                        ],
+                      ),
+                    ),
+                  );
+                },
+              ),
+            ),
+      bottomNavigationBar: _selected.isEmpty
+          ? null
+          : SafeArea(
+              child: Padding(
+                padding: const EdgeInsets.all(8),
+                child: ElevatedButton(
+                  onPressed: _bulkDelete,
+                  child: const Text('Bulk Close'),
+                ),
+              ),
+            ),
+    );
+  }
+}

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -2,53 +2,156 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../providers/activity_provider.dart';
 import '../models/activity.dart';
+import '../services/activity_service.dart'; // R2
 import '../services/slot_service.dart';
 
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
+import 'merchant_slots_page.dart'; // R2
+import 'merchant_orders_page.dart'; // R2
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
 
-class ProviderDashboardPage extends ConsumerWidget {
+class ProviderDashboardPage extends ConsumerStatefulWidget { // R2
   const ProviderDashboardPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final asyncActivities = ref.watch(activitiesProvider);
+  ConsumerState<ProviderDashboardPage> createState() => _ProviderDashboardPageState(); // R2
+}
 
+class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> { // R2
+  final ScrollController _scroll = ScrollController(); // R2
+  final List<Activity> _activities = []; // R2
+  bool _loading = false; // R2
+  bool _hasMore = true; // R2
+  int _page = 1; // R2
+  String? _q; // R2
+  int? _category; // R2
+
+  @override
+  void initState() {
+    super.initState();
+    _load(refresh: true); // R2
+    _scroll.addListener(() { // R2
+      if (_scroll.position.pixels >= _scroll.position.maxScrollExtent - 200 && _hasMore && !_loading) {
+        _load();
+      }
+    });
+  }
+
+  @override
+  void dispose() {
+    _scroll.dispose();
+    super.dispose();
+  }
+
+  Future<void> _load({bool refresh = false}) async { // R2
+    if (_loading) return;
+    setState(() => _loading = true);
+    if (refresh) {
+      _page = 1;
+      _hasMore = true;
+      _activities.clear();
+    }
+    final page = await activityService.fetchMine(q: _q, category: _category, page: _page); // R2
+    _activities.addAll(page.results); // R2
+    _hasMore = page.next != null; // R2
+    _page += 1; // R2
+    setState(() => _loading = false);
+  }
+
+  Future<void> _showFilterSheet() async { // R2
+    final qCtrl = TextEditingController(text: _q);
+    int? selectedCat = _category;
+    await showModalBottomSheet(
+      context: context,
+      builder: (context) {
+        return Padding(
+          padding: const EdgeInsets.all(16),
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(controller: qCtrl, decoration: const InputDecoration(labelText: 'Keyword')), // R2
+              const SizedBox(height: 8),
+              TextField(
+                decoration: const InputDecoration(labelText: 'Category ID'), // R2
+                keyboardType: TextInputType.number,
+                onChanged: (v) => selectedCat = int.tryParse(v),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () {
+                  Navigator.pop(context, true);
+                },
+                child: const Text('Apply'),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+    _q = qCtrl.text.isEmpty ? null : qCtrl.text;
+    _category = selectedCat;
+    await _load(refresh: true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Merchant Dashboard'),
         actions: [
           IconButton(
+            icon: const Icon(Icons.receipt_long), // R2
+            onPressed: () => Navigator.push(context, MaterialPageRoute(builder: (_) => const MerchantOrdersPage())), // R2
+          ),
+          IconButton(
             icon: const Icon(Icons.search),
-            onPressed: () {}, // reserved for future search
+            onPressed: _showFilterSheet, // R2
           ),
           IconButton(
             icon: const Icon(Icons.account_circle_outlined),
-            onPressed: () {}, // profile quick access
+            onPressed: () {},
           ),
         ],
       ),
       drawer: _MerchantDrawer(),
-      body: asyncActivities.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
-        data: (page) => ListView(
+      body: RefreshIndicator(
+        onRefresh: () => _load(refresh: true),
+        child: ListView.builder(
+          controller: _scroll,
           padding: const EdgeInsets.all(16),
-          children: [
-            _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
-              if (created == true) ref.invalidate(activitiesProvider);
-            }),
-            const SizedBox(height: 16),
-            Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
-            const SizedBox(height: 8),
-            ...page.results.map((a) => _ActivityCard(activity: a, onChanged: () => ref.invalidate(activitiesProvider))),
-            const SizedBox(height: 80),
-          ],
+          itemCount: _activities.length + 2,
+          itemBuilder: (context, index) {
+            if (index == 0) {
+              return _AddActivityHero(onTap: () async {
+                final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
+                if (created == true) await _load(refresh: true);
+              });
+            }
+            if (index == 1) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const SizedBox(height: 16),
+                  Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
+                  const SizedBox(height: 8),
+                ],
+              );
+            }
+            final i = index - 2;
+            if (i >= _activities.length) {
+              return _hasMore
+                  ? const Padding(
+                      padding: EdgeInsets.symmetric(vertical: 24),
+                      child: Center(child: CircularProgressIndicator()),
+                    )
+                  : const SizedBox(height: 80);
+            }
+            final a = _activities[i];
+            return _ActivityCard(activity: a, onChanged: () => _load(refresh: true));
+          },
         ),
       ),
     );
@@ -148,27 +251,40 @@ class _ActivityCard extends StatelessWidget {
             return Text(c == 0 ? 'No upcoming slots' : '$c upcoming slot${c == 1 ? "" : "s"}');
           },
         ),
-        trailing: Wrap(
-          spacing: 4,
-          children: [
-            IconButton(
-              icon: const Icon(Icons.schedule),
-              tooltip: 'Add Slot',
-              onPressed: () async {
-                final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddSlotPage(activityId: activity.id)));
-                if (created == true) {
-                  ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Slot created')));
-                  onChanged();
-                }
-              },
-            ),
-            TextButton(
-              onPressed: () async {
-                final updated = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddActivityPage(activity: activity)));
-                if (updated == true) onChanged();
-              },
-              child: const Text('Edit'),
-            ),
+        onTap: () => Navigator.push(context, MaterialPageRoute(builder: (_) => MerchantSlotsPage(activityId: activity.id))), // R2
+        trailing: PopupMenuButton<String>( // R2
+          onSelected: (value) async { // R2
+            if (value == 'edit') {
+              final updated = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddActivityPage(activity: activity))); // R2
+              if (updated == true) onChanged(); // R2
+            } else if (value == 'slot') {
+              final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddSlotPage(activityId: activity.id))); // R2
+              if (created == true) {
+                ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Slot created'))); // R2
+                onChanged(); // R2
+              }
+            } else if (value == 'delete') {
+              final ok = await showDialog<bool>( // R2
+                context: context,
+                builder: (_) => AlertDialog(
+                  title: const Text('Delete Activity?'),
+                  content: const Text('This cannot be undone.'),
+                  actions: [
+                    TextButton(onPressed: () => Navigator.pop(context, false), child: const Text('Cancel')),
+                    TextButton(onPressed: () => Navigator.pop(context, true), child: const Text('Delete')),
+                  ],
+                ),
+              );
+              if (ok == true) {
+                await activityService.deleteActivity(activity.id); // R2
+                onChanged(); // R2
+              }
+            }
+          },
+          itemBuilder: (context) => [
+            const PopupMenuItem(value: 'edit', child: Text('Edit')), // R2
+            const PopupMenuItem(value: 'slot', child: Text('Add Slot')), // R2
+            const PopupMenuItem(value: 'delete', child: Text('Delete')), // R2
           ],
         ),
       ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -4,6 +4,21 @@ import '../models/paginated.dart';
 import 'api_client.dart';
 
 class ActivityService {
+  int? _cachedOrgId; // R1
+
+  Future<int?> _defaultOrg() async { // R1
+    if (_cachedOrgId != null) return _cachedOrgId;
+    final res = await apiClient.get('/merchant/orgs/me/');
+    final data = res.data as List;
+    if (data.isEmpty) {
+      throw Exception('No organizations');
+    }
+    if (data.length == 1) {
+      _cachedOrgId = data.first['id'] as int;
+      return _cachedOrgId;
+    }
+    return null;
+  }
   Paginated<Activity> _parsePage(Object data) {
     if (data is List) {
       return Paginated.fromList(
@@ -67,9 +82,12 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.post('/activities/', data: {
+    double basePrice, {
+    String? imagePath, // R1
+    int? organizationId, // R1
+  }) async {
+    final org = organizationId ?? await _defaultOrg(); // R1
+    final form = FormData.fromMap({ // R1
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
@@ -78,7 +96,15 @@ class ActivityService {
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (org != null) 'organization': org,
     });
+    if (imagePath != null) {
+      form.files.add(MapEntry(
+        'image',
+        await MultipartFile.fromFile(imagePath, filename: imagePath.split('/').last),
+      ));
+    }
+    await apiClient.post('/activities/', data: form); // R1
   }
 
   Future<void> updateActivity(
@@ -90,9 +116,12 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.patch('/activities/' + id.toString() + '/', data: {
+    double basePrice, {
+    String? imagePath, // R1
+    int? organizationId, // R1
+  }) async {
+    final org = organizationId ?? await _defaultOrg(); // R1
+    final form = FormData.fromMap({ // R1
       'sport': sport,
       'discipline': discipline,
       'variant': variant,
@@ -101,7 +130,15 @@ class ActivityService {
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (org != null) 'organization': org,
     });
+    if (imagePath != null) {
+      form.files.add(MapEntry(
+        'image',
+        await MultipartFile.fromFile(imagePath, filename: imagePath.split('/').last),
+      ));
+    }
+    await apiClient.patch('/activities/$id/', data: form); // R1
   }
 }
 

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -37,8 +37,13 @@ class ActivityService {
     return _parsePage(res.data);
   }
 
-  Future<Paginated<Activity>> fetchMine() async {
-    return fetchActivities(params: {'mine': '1'});
+  Future<Paginated<Activity>> fetchMine({String? q, int? category, int page = 1}) async { // R2
+    return fetchActivities(params: { // R2
+      'mine': '1', // R2
+      if (q != null && q.isNotEmpty) 'q': q, // R2
+      if (category != null) 'category': category, // R2
+      'page': page, // R2
+    }); // R2
   }
 
   Future<Paginated<Activity>> fetchNearby() async {
@@ -72,6 +77,10 @@ class ActivityService {
   Future<Activity> fetchById(int id) async {
     final Response res = await apiClient.get('/activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);
+  }
+
+  Future<void> deleteActivity(int id) async { // R2
+    await apiClient.delete('/activities/' + id.toString() + '/'); // R2
   }
 
   Future<void> createActivity(

--- a/lib/services/merchant_booking_service.dart
+++ b/lib/services/merchant_booking_service.dart
@@ -1,0 +1,29 @@
+import 'package:dio/dio.dart';
+import 'api_client.dart';
+
+class MerchantBookingService { // R2
+  Future<Map<String, dynamic>> fetchPaged({ // R2
+    String? cursor,
+    String? status,
+    bool? paid,
+    String? createdAfter,
+    String? createdBefore,
+    int? activityId,
+  }) async {
+    final params = <String, dynamic>{};
+    if (cursor != null) params['cursor'] = cursor;
+    if (status != null) params['status'] = status;
+    if (paid != null) params['paid'] = paid.toString();
+    if (createdAfter != null) params['created_after'] = createdAfter;
+    if (createdBefore != null) params['created_before'] = createdBefore;
+    if (activityId != null) params['activity'] = activityId;
+    final res = await apiClient.get('/merchant/bookings/paged/', queryParameters: params);
+    return res.data as Map<String, dynamic>;
+  }
+
+  Future<void> cancel(int id) async { // R2
+    await apiClient.post('/merchant/bookings/' + id.toString() + '/cancel/');
+  }
+}
+
+final merchantBookingService = MerchantBookingService(); // R2

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -6,10 +6,16 @@ import 'api_client.dart';
 class SlotService {
   const SlotService();
 
-  /// Format a [DateTime] with an explicit UTC offset so Django's
-  /// `fromisoformat` can parse it as an aware datetime.
-  String _iso(DateTime dt) =>
-      dt.toUtc().toIso8601String().replaceFirst('Z', '+00:00');
+  /// Format [dt] as RFC3339 including timezone offset or Z. // R1
+  String _iso(DateTime dt) {
+    final iso = dt.toIso8601String(); // R1
+    if (iso.endsWith('Z')) return iso; // R1
+    final offset = dt.timeZoneOffset; // R1
+    final sign = offset.isNegative ? '-' : '+'; // R1
+    final hours = offset.inHours.abs().toString().padLeft(2, '0'); // R1
+    final minutes = (offset.inMinutes.abs() % 60).toString().padLeft(2, '0'); // R1
+    return '$iso$sign$hours:$minutes'; // R1
+  }
 
   /// GET /api/slots/?sport=<sportId>
   Future<List<Slot>> fetchBySport(int sportId) async {
@@ -97,8 +103,8 @@ class SlotService {
       String location,) async {
     await apiClient.post('/merchant/slots/', data: {
       'activity': activityId,
-      'begins_at': start.toIso8601String(),
-      'ends_at': end.toIso8601String(),
+      'begins_at': _iso(start), // R1
+      'ends_at': _iso(end), // R1
       'capacity': capacity,
       'price': price,
       'title': title,

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -111,6 +111,48 @@ class SlotService {
       'location': location,
     });
   }
+
+  Future<List<Slot>> listMerchantSlots({int? activityId}) async { // R2
+    final res = await apiClient.get('/merchant/slots/', queryParameters: { // R2
+      if (activityId != null) 'activity': activityId, // R2
+    }); // R2
+    final List data = res.data as List; // R2
+    return data.map((e) => Slot.fromJson(e as Map<String, dynamic>)).toList(); // R2
+  }
+
+  Future<void> updateSlot( // R2
+    int id, {
+    DateTime? beginsAt,
+    DateTime? endsAt,
+    double? price,
+    int? capacity,
+    String? title,
+    String? location,
+    int? facility,
+  }) async {
+    final body = <String, dynamic>{};
+    if (beginsAt != null) body['begins_at'] = _iso(beginsAt); // R2
+    if (endsAt != null) body['ends_at'] = _iso(endsAt); // R2
+    if (price != null) body['price'] = price; // R2
+    if (capacity != null) body['capacity'] = capacity; // R2
+    if (title != null) body['title'] = title; // R2
+    if (location != null) body['location'] = location; // R2
+    if (facility != null) body['facility'] = facility; // R2
+    await apiClient.patch('/merchant/slots/' + id.toString() + '/', data: body); // R2
+  }
+
+  Future<void> deleteSlot(int id) async { // R2
+    await apiClient.delete('/merchant/slots/' + id.toString() + '/'); // R2
+  }
+
+  Future<Map<String, dynamic>> bulkDeleteSlots(List<int> ids) async { // R2
+    final res = await apiClient.post('/merchant/slots/bulk-delete/', data: {'ids': ids}); // R2
+    return res.data as Map<String, dynamic>; // R2
+  }
+
+  Future<void> bulkCreateSlots(List<Map<String, dynamic>> slots) async { // R2
+    await apiClient.post('/slots/bulk/', data: {'slots': slots}); // R2
+  }
 }
 
 /// Global singleton – keep existing usage unchanged

--- a/lib/utils/snackbar.dart
+++ b/lib/utils/snackbar.dart
@@ -28,3 +28,8 @@ void showApiError(BuildContext context, DioException e, String action) {
   ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(text)));
 }
 
+// R2: simple helper for plain messages
+void showSnackBar(BuildContext context, String message) {
+  ScaffoldMessenger.of(context).showSnackBar(SnackBar(content: Text(message)));
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,7 @@ dependencies:
   qr_flutter: ^4.1.0
   flutter_stripe: ^10.0.0
   shared_preferences: ^2.2.2
+  image_picker: ^1.0.7 # R1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add multipart image upload and auto-organization lookup for activity API
- replace add-activity image URL field with picker and preview
- serialize slot datetimes with timezone-aware RFC3339 strings

## Testing
- `pip install -r ../requirements.txt`
- `pip install pysqlite3-binary`
- `pytest` *(fails: Could not find the GDAL library)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898d660a5b48326a558ef5bec040ac6