### PR TITLE
Enable image uploads and paginated provider dashboard

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,10 @@
     <!-- Needed for geolocator -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" android:maxSdkVersion="28" />
     <application
         android:label="sports_booking_app"
         android:name="${applicationName}"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -47,5 +47,9 @@
         <true/>
         <key>NSLocationWhenInUseUsageDescription</key>
         <string>This app requires location access to show nearby activities.</string>
+        <key>NSPhotoLibraryUsageDescription</key>
+        <string>This app requires photo library access to select activity images.</string>
+        <key>NSCameraUsageDescription</key>
+        <string>This app requires camera access to take activity photos.</string>
 </dict>
 </plist>

--- a/lib/providers/org_provider.dart
+++ b/lib/providers/org_provider.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../services/org_service.dart';
+
+final orgsProvider = FutureProvider<List<Map<String, dynamic>>>((ref) async {
+  return orgService.fetchMine();
+});
+
+final selectedOrgProvider = StateProvider<int?>((ref) => null);

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -1,35 +1,42 @@
+import 'dart:io';
+
+import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:image_picker/image_picker.dart';
+
+import '../models/activity.dart';
+import '../models/category.dart';
+import '../models/sport.dart';
+import '../models/variant.dart';
+import '../providers/org_provider.dart';
 import '../services/activity_service.dart';
 import '../services/sports_service.dart';
 import '../utils/snackbar.dart';
-import 'package:dio/dio.dart';
 
-import '../models/activity.dart';
-import '../models/sport.dart';
-import '../models/category.dart';
-import '../models/variant.dart';
-
-class AddActivityPage extends StatefulWidget {
+class AddActivityPage extends ConsumerStatefulWidget {
   final Activity? activity;
   const AddActivityPage({this.activity, super.key});
 
   @override
-  State<AddActivityPage> createState() => _AddActivityPageState();
+  ConsumerState<AddActivityPage> createState() => _AddActivityPageState();
 }
 
-class _AddActivityPageState extends State<AddActivityPage> {
+class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   final _formKey = GlobalKey<FormState>();
   final titleCtrl = TextEditingController();
   final descCtrl = TextEditingController();
   final priceCtrl = TextEditingController();
   final durationCtrl = TextEditingController(text: '60');
-  final imageCtrl = TextEditingController();
 
   int? sportId;
   int? disciplineId;
   int? variantId;
   int difficulty = 1;
   bool _submitting = false;
+  XFile? _imageFile;
+  String? _existingImage;
+  Map<String, String> fieldErrors = {};
 
   late Future<void> _loadFuture;
   List<Sport> sports = [];
@@ -48,7 +55,7 @@ class _AddActivityPageState extends State<AddActivityPage> {
       descCtrl.text = a.description;
       priceCtrl.text = a.basePrice.toStringAsFixed(2);
       durationCtrl.text = a.duration.toString();
-      imageCtrl.text = a.image;
+      _existingImage = a.imageUrl?.isNotEmpty == true ? a.imageUrl : a.image;
       difficulty = a.difficulty;
     }
     _loadFuture = _loadData();
@@ -66,7 +73,6 @@ class _AddActivityPageState extends State<AddActivityPage> {
     descCtrl.dispose();
     priceCtrl.dispose();
     durationCtrl.dispose();
-    imageCtrl.dispose();
     super.dispose();
   }
 
@@ -80,12 +86,14 @@ class _AddActivityPageState extends State<AddActivityPage> {
           if (snap.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
+          final orgsAsync = ref.watch(orgsProvider);
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Form(
               key: _formKey,
               child: ListView(
                 children: [
+                  _buildOrgField(orgsAsync),
                   DropdownButtonFormField<int>(
                     value: sportId,
                     items: sports
@@ -95,7 +103,10 @@ class _AddActivityPageState extends State<AddActivityPage> {
                             ))
                         .toList(),
                     onChanged: (v) => setState(() => sportId = v),
-                    decoration: const InputDecoration(labelText: 'Sport'),
+                    decoration: InputDecoration(
+                      labelText: 'Sport',
+                      errorText: fieldErrors['sport'],
+                    ),
                     validator: (v) => v == null ? 'Required' : null,
                   ),
                   DropdownButtonFormField<int>(
@@ -107,7 +118,10 @@ class _AddActivityPageState extends State<AddActivityPage> {
                             ))
                         .toList(),
                     onChanged: (v) => setState(() => disciplineId = v),
-                    decoration: const InputDecoration(labelText: 'Discipline'),
+                    decoration: InputDecoration(
+                      labelText: 'Discipline',
+                      errorText: fieldErrors['discipline'],
+                    ),
                     validator: (v) => v == null ? 'Required' : null,
                   ),
                   DropdownButtonFormField<int?>(
@@ -123,21 +137,33 @@ class _AddActivityPageState extends State<AddActivityPage> {
                           .toList(),
                     ],
                     onChanged: (v) => setState(() => variantId = v),
-                    decoration: const InputDecoration(labelText: 'Variant'),
+                    decoration: InputDecoration(
+                      labelText: 'Variant',
+                      errorText: fieldErrors['variant'],
+                    ),
                   ),
                   TextFormField(
                     controller: titleCtrl,
-                    decoration: const InputDecoration(labelText: 'Title'),
+                    decoration: InputDecoration(
+                      labelText: 'Title',
+                      errorText: fieldErrors['title'],
+                    ),
                     validator: (v) => v == null || v.isEmpty ? 'Required' : null,
                   ),
                   TextFormField(
                     controller: descCtrl,
-                    decoration: const InputDecoration(labelText: 'Description'),
+                    decoration: InputDecoration(
+                      labelText: 'Description',
+                      errorText: fieldErrors['description'],
+                    ),
                     maxLines: 3,
                   ),
                   DropdownButtonFormField<int>(
                     value: difficulty,
-                    decoration: const InputDecoration(labelText: 'Difficulty'),
+                    decoration: InputDecoration(
+                      labelText: 'Difficulty',
+                      errorText: fieldErrors['difficulty'],
+                    ),
                     items: List.generate(
                       5,
                       (i) => DropdownMenuItem(value: i + 1, child: Text('${i + 1}')),
@@ -146,26 +172,37 @@ class _AddActivityPageState extends State<AddActivityPage> {
                   ),
                   TextFormField(
                     controller: durationCtrl,
-                    decoration: const InputDecoration(labelText: 'Duration (min)'),
+                    decoration: InputDecoration(
+                      labelText: 'Duration (min)',
+                      errorText: fieldErrors['duration'],
+                    ),
                     keyboardType: TextInputType.number,
                     validator: (v) => int.tryParse(v ?? '') == null ? 'Enter number' : null,
                   ),
                   TextFormField(
                     controller: priceCtrl,
-                    decoration: const InputDecoration(labelText: 'Base Price'),
+                    decoration: InputDecoration(
+                      labelText: 'Base Price',
+                      errorText: fieldErrors['base_price'],
+                    ),
                     keyboardType: TextInputType.number,
                     validator: (v) => double.tryParse(v ?? '') == null ? 'Enter number' : null,
                   ),
-                  TextFormField(
-                    controller: imageCtrl,
-                    decoration: const InputDecoration(labelText: 'Image URL'),
-                  ),
+                  _imagePickerField(),
                   const SizedBox(height: 20),
                   ElevatedButton(
                     onPressed: _submitting
                         ? null
                         : () async {
+                            fieldErrors = {};
                             if (!_formKey.currentState!.validate()) return;
+                            final orgId = ref.read(selectedOrgProvider);
+                            if (orgId == null) {
+                              setState(() {
+                                fieldErrors['organization'] = 'Required';
+                              });
+                              return;
+                            }
                             setState(() => _submitting = true);
                             try {
                               if (widget.activity == null) {
@@ -173,11 +210,13 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   sportId!,
                                   disciplineId!,
                                   variantId,
-                                  titleCtrl.text,
-                                  descCtrl.text,
+                                  titleCtrl.text.trim(),
+                                  descCtrl.text.trim(),
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  organizationId: orgId,
+                                  imageFile: _imageFile,
                                 );
                               } else {
                                 await activityService.updateActivity(
@@ -185,24 +224,49 @@ class _AddActivityPageState extends State<AddActivityPage> {
                                   sportId!,
                                   disciplineId!,
                                   variantId,
-                                  titleCtrl.text,
-                                  descCtrl.text,
+                                  titleCtrl.text.trim(),
+                                  descCtrl.text.trim(),
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
+                                  organizationId: orgId,
+                                  imageFile: _imageFile,
                                 );
                               }
                               if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(widget.activity == null
+                                        ? 'Activity created'
+                                        : 'Activity updated'),
+                                  ),
+                                );
                                 Navigator.pop(context, true);
                               }
                             } on DioException catch (e) {
-                              if (context.mounted) showApiError(context, e, 'Create activity');
+                              final err = e.error;
+                              if (err is Map<String, List<String>>) {
+                                setState(() {
+                                  fieldErrors = err
+                                      .map((k, v) => MapEntry(k, v.join(', ')));
+                                });
+                              } else if (context.mounted) {
+                                showApiError(
+                                    context,
+                                    e,
+                                    widget.activity == null
+                                        ? 'Create activity'
+                                        : 'Update activity');
+                              }
                             } finally {
                               if (mounted) setState(() => _submitting = false);
                             }
                           },
                     child: _submitting
-                        ? const SizedBox(height:20,width:20,child:CircularProgressIndicator(strokeWidth:2))
+                        ? const SizedBox(
+                            height: 20,
+                            width: 20,
+                            child: CircularProgressIndicator(strokeWidth: 2))
                         : Text(widget.activity == null ? 'Create' : 'Save'),
                   ),
                 ],
@@ -211,6 +275,126 @@ class _AddActivityPageState extends State<AddActivityPage> {
           );
         },
       ),
+    );
+  }
+
+  Widget _buildOrgField(AsyncValue<List<Map<String, dynamic>>> orgsAsync) {
+    return orgsAsync.when(
+      data: (orgs) {
+        final selectedOrg = ref.watch(selectedOrgProvider);
+        if (orgs.length == 1) {
+          Future.microtask(() {
+            if (ref.read(selectedOrgProvider) == null) {
+              ref.read(selectedOrgProvider.notifier).state =
+                  orgs.first['id'] as int;
+            }
+          });
+          return const SizedBox.shrink();
+        }
+        return DropdownButtonFormField<int>(
+          value: selectedOrg,
+          items: orgs
+              .map<DropdownMenuItem<int>>((e) => DropdownMenuItem(
+                    value: e['id'] as int,
+                    child: Text(e['name']?.toString() ?? ''),
+                  ))
+              .toList(),
+          onChanged: (v) => ref.read(selectedOrgProvider.notifier).state = v,
+          decoration: InputDecoration(
+            labelText: 'Organization',
+            errorText: fieldErrors['organization'],
+          ),
+          validator: (v) => v == null ? 'Required' : null,
+        );
+      },
+      loading: () => const SizedBox.shrink(),
+      error: (_, __) => const SizedBox.shrink(),
+    );
+  }
+
+  Widget _imagePickerField() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Image', style: Theme.of(context).textTheme.labelLarge),
+        const SizedBox(height: 6),
+        Row(
+          children: [
+            _buildImagePreview(),
+            const SizedBox(width: 12),
+            OutlinedButton(
+              onPressed: () async {
+                final picker = ImagePicker();
+                final file =
+                    await picker.pickImage(source: ImageSource.gallery);
+                if (file != null) {
+                  setState(() {
+                    _imageFile = file;
+                    _existingImage = null;
+                  });
+                }
+              },
+              child:
+                  Text(_imageFile == null ? 'Select Image' : 'Change Image'),
+            ),
+          ],
+        ),
+        if (fieldErrors['image'] != null)
+          Padding(
+            padding: const EdgeInsets.only(top: 6),
+            child: Text(
+              fieldErrors['image']!,
+              style: TextStyle(
+                  color: Theme.of(context).colorScheme.error, fontSize: 12),
+            ),
+          ),
+      ],
+    );
+  }
+
+  Widget _buildImagePreview() {
+    const double size = 80;
+    final radius = BorderRadius.circular(12);
+    if (_imageFile != null) {
+      return Stack(
+        children: [
+          ClipRRect(
+            borderRadius: radius,
+            child: Image.file(File(_imageFile!.path),
+                width: size, height: size, fit: BoxFit.cover),
+          ),
+          Positioned(
+            top: 0,
+            right: 0,
+            child: InkWell(
+              onTap: () => setState(() => _imageFile = null),
+              child: Container(
+                decoration: const BoxDecoration(
+                  color: Colors.black54,
+                  shape: BoxShape.circle,
+                ),
+                child: const Icon(Icons.close, color: Colors.white, size: 16),
+              ),
+            ),
+          ),
+        ],
+      );
+    }
+    if (_existingImage != null && _existingImage!.isNotEmpty) {
+      return ClipRRect(
+        borderRadius: radius,
+        child: Image.network(_existingImage!,
+            width: size, height: size, fit: BoxFit.cover),
+      );
+    }
+    return Container(
+      width: size,
+      height: size,
+      decoration: BoxDecoration(
+        color: Theme.of(context).colorScheme.surfaceVariant,
+        borderRadius: radius,
+      ),
+      child: const Icon(Icons.image, color: Colors.grey),
     );
   }
 }

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -2,8 +2,8 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 
-import '../providers/activity_provider.dart';
 import '../models/activity.dart';
+import '../services/activity_service.dart';
 import '../services/slot_service.dart';
 
 import 'add_activity_page.dart';
@@ -11,42 +11,120 @@ import 'add_slot_page.dart';
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
 
-class ProviderDashboardPage extends ConsumerWidget {
+class ProviderDashboardPage extends ConsumerStatefulWidget {
   const ProviderDashboardPage({super.key});
 
   @override
-  Widget build(BuildContext context, WidgetRef ref) {
-    final asyncActivities = ref.watch(activitiesProvider);
+  ConsumerState<ProviderDashboardPage> createState() => _ProviderDashboardPageState();
+}
 
+class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
+  final List<Activity> _activities = [];
+  String? _next;
+  bool _loading = true;
+  bool _loadingMore = false;
+  int _page = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    try {
+      final page = await activityService.fetchActivities(params: {'mine': '1'});
+      setState(() {
+        _activities
+          ..clear()
+          ..addAll(page.results);
+        _next = page.next;
+        _page = 1;
+      });
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_next == null || _loadingMore) return;
+    setState(() => _loadingMore = true);
+    try {
+      final nextPage = _page + 1;
+      final page =
+          await activityService.fetchActivities(params: {'mine': '1', 'page': nextPage});
+      setState(() {
+        _activities.addAll(page.results);
+        _next = page.next;
+        _page = nextPage;
+      });
+    } finally {
+      if (mounted) setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (_loading) {
+      return const Scaffold(
+        appBar: AppBar(title: Text('Merchant Dashboard')),
+        body: Center(child: CircularProgressIndicator()),
+      );
+    }
     return Scaffold(
       appBar: AppBar(
         title: const Text('Merchant Dashboard'),
         actions: [
           IconButton(
             icon: const Icon(Icons.search),
-            onPressed: () {}, // reserved for future search
+            onPressed: () {},
           ),
           IconButton(
             icon: const Icon(Icons.account_circle_outlined),
-            onPressed: () {}, // profile quick access
+            onPressed: () {},
           ),
         ],
       ),
       drawer: _MerchantDrawer(),
-      body: asyncActivities.when(
-        loading: () => const Center(child: CircularProgressIndicator()),
-        error: (e, _) => Center(child: Text('Error: $e')),
-        data: (page) => ListView(
+      body: RefreshIndicator(
+        onRefresh: _refresh,
+        child: ListView(
           padding: const EdgeInsets.all(16),
           children: [
             _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
-              if (created == true) ref.invalidate(activitiesProvider);
+              final created = await Navigator.push(
+                  context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
+              if (created == true) {
+                await _refresh();
+                if (mounted) {
+                  ScaffoldMessenger.of(context)
+                      .showSnackBar(const SnackBar(content: Text('Activity created')));
+                }
+              }
             }),
             const SizedBox(height: 16),
             Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
-            ...page.results.map((a) => _ActivityCard(activity: a, onChanged: () => ref.invalidate(activitiesProvider))),
+            if (_activities.isEmpty)
+              _EmptyState(onCreate: () async {
+                final created = await Navigator.push(
+                    context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
+                if (created == true) {
+                  await _refresh();
+                }
+              })
+            else
+              ..._activities.map(
+                (a) => _ActivityCard(activity: a, onChanged: () => _refresh()),
+              ),
+            if (_loadingMore)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 16),
+                child: Center(child: CircularProgressIndicator()),
+              )
+            else if (_next != null)
+              TextButton(onPressed: _loadMore, child: const Text('Load more')),
             const SizedBox(height: 80),
           ],
         ),
@@ -116,6 +194,35 @@ class _AddActivityHero extends StatelessWidget {
                 padding: EdgeInsets.only(right: 12),
                 child: Icon(Icons.chevron_right),
               ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _EmptyState extends StatelessWidget {
+  const _EmptyState({required this.onCreate});
+  final VoidCallback onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(16),
+        side: BorderSide(color: Theme.of(context).dividerColor),
+      ),
+      child: SizedBox(
+        height: 120,
+        child: Center(
+          child: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              const Text('No activities yet'),
+              const SizedBox(height: 8),
+              TextButton(onPressed: onCreate, child: const Text('Create Activity')),
             ],
           ),
         ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -1,4 +1,7 @@
 import 'package:dio/dio.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
+
 import '../models/activity.dart';
 import '../models/paginated.dart';
 import 'api_client.dart';
@@ -67,18 +70,29 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.post('/activities/', data: {
+    double basePrice, {
+    required int organizationId,
+    XFile? imageFile,
+  }) async {
+    final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
+      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (imageFile != null)
+        'image': await MultipartFile.fromFile(imageFile.path,
+            filename: p.basename(imageFile.path)),
     });
+    try {
+      await apiClient.post('/activities/', data: form);
+    } on DioException catch (e) {
+      _rethrowFieldErrors(e);
+    }
   }
 
   Future<void> updateActivity(
@@ -90,18 +104,52 @@ class ActivityService {
     String description,
     int difficulty,
     int duration,
-    double basePrice,
-  ) async {
-    await apiClient.patch('/activities/' + id.toString() + '/', data: {
+    double basePrice, {
+    required int organizationId,
+    XFile? imageFile,
+  }) async {
+    final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
-      'variant': variant,
+      if (variant != null) 'variant': variant,
+      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
       'duration': duration,
       'base_price': basePrice,
+      if (imageFile != null)
+        'image': await MultipartFile.fromFile(imageFile.path,
+            filename: p.basename(imageFile.path)),
     });
+    try {
+      await apiClient.patch('/activities/$id/', data: form);
+    } on DioException catch (e) {
+      _rethrowFieldErrors(e);
+    }
+  }
+
+  void _rethrowFieldErrors(DioException e) {
+    if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
+      final data = e.response?.data;
+      if (data is Map<String, dynamic>) {
+        final map = <String, List<String>>{};
+        data.forEach((key, value) {
+          if (value is List) {
+            map[key] = value.map((v) => v.toString()).toList();
+          } else {
+            map[key] = [value.toString()];
+          }
+        });
+        throw DioException(
+          requestOptions: e.requestOptions,
+          response: e.response,
+          type: e.type,
+          error: map,
+        );
+      }
+    }
+    throw e;
   }
 }
 

--- a/lib/services/org_service.dart
+++ b/lib/services/org_service.dart
@@ -1,0 +1,11 @@
+import 'package:dio/dio.dart';
+import 'api_client.dart';
+
+class OrgService {
+  Future<List<Map<String, dynamic>>> fetchMine() async {
+    final Response res = await apiClient.get('/accounts/merchant/orgs/me/');
+    return (res.data as List).cast<Map<String, dynamic>>();
+  }
+}
+
+final orgService = OrgService();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -26,6 +26,8 @@ dependencies:
   qr_flutter: ^4.1.0
   flutter_stripe: ^10.0.0
   shared_preferences: ^2.2.2
+  image_picker: ^1.0.7
+  path: ^1.9.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- support selecting local images and organization when creating activities
- submit activities as multipart with organization id and image file
- add pull-to-refresh and paging to provider dashboard with empty state

## Testing
- `flutter pub get` *(fails: command not found)*
- `dart pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6898fb2f4a708326bf8ff2a7d7d859de