### PR TITLE
feat: manage activities and slots on merchant dashboard

### DIFF
--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -1,4 +1,7 @@
 import 'package:flutter/material.dart';
+import 'package:dio/dio.dart';
+import '../models/facility.dart';
+import '../services/facility_service.dart';
 import '../services/slot_service.dart';
 
 class AddSlotPage extends StatefulWidget {
@@ -17,7 +20,18 @@ class _AddSlotPageState extends State<AddSlotPage> {
   final priceCtrl = TextEditingController(text: '0');
   final titleCtrl = TextEditingController();
   final locationCtrl = TextEditingController();
+  List<Facility> _facilities = [];
+  int? _facilityId;
+  Map<String, String> _errors = {};
   bool _submitting = false;
+
+  @override
+  void initState() {
+    super.initState();
+    facilityService.fetchMine().then((list) {
+      if (mounted) setState(() => _facilities = list);
+    });
+  }
 
   @override
   void dispose() {
@@ -47,15 +61,37 @@ class _AddSlotPageState extends State<AddSlotPage> {
                 controller: locationCtrl,
                 decoration: const InputDecoration(labelText: 'Location'),
               ),
+              DropdownButtonFormField<int>(
+                value: _facilityId,
+                decoration: InputDecoration(
+                    labelText: 'Facility', errorText: _errors['facility'] ?? null),
+                items: _facilities
+                    .map((f) => DropdownMenuItem(value: f.id, child: Text(f.name)))
+                    .toList(),
+                onChanged: (v) => setState(() => _facilityId = v),
+                validator: (v) => v == null ? 'Required' : null,
+              ),
               TextFormField(
                 controller: capacityCtrl,
-                decoration: const InputDecoration(labelText: 'Capacity'),
+                decoration: InputDecoration(
+                    labelText: 'Capacity', errorText: _errors['capacity']),
                 keyboardType: TextInputType.number,
+                validator: (v) {
+                  final n = int.tryParse(v ?? '');
+                  if (n == null || n <= 0) return 'Invalid capacity';
+                  return null;
+                },
               ),
               TextFormField(
                 controller: priceCtrl,
-                decoration: const InputDecoration(labelText: 'Price'),
+                decoration:
+                    InputDecoration(labelText: 'Price', errorText: _errors['price']),
                 keyboardType: TextInputType.number,
+                validator: (v) {
+                  final n = double.tryParse(v ?? '');
+                  if (n == null || n < 0) return 'Invalid price';
+                  return null;
+                },
               ),
               ListTile(
                 title: Text(start == null
@@ -106,8 +142,14 @@ class _AddSlotPageState extends State<AddSlotPage> {
                 onPressed: _submitting
                     ? null
                     : () async {
+                        setState(() => _errors.clear());
                         if (!_formKey.currentState!.validate()) return;
                         if (start == null || end == null) return;
+                        if (!end!.isAfter(start!)) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('End must be after start')));
+                          return;
+                        }
                         setState(() => _submitting = true);
                         try {
                           await slotService.createSlot(
@@ -118,8 +160,20 @@ class _AddSlotPageState extends State<AddSlotPage> {
                             double.parse(priceCtrl.text),
                             titleCtrl.text,
                             locationCtrl.text,
+                            facilityId: _facilityId!,
                           );
                           if (context.mounted) Navigator.pop(context, true);
+                        } on DioException catch (e) {
+                          if (e.error is Map<String, List<String>>) {
+                            final map = e.error as Map<String, List<String>>;
+                            setState(() {
+                              _errors =
+                                  map.map((k, v) => MapEntry(k, v.join(', ')));
+                            });
+                          } else {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Failed to create slot')));
+                          }
                         } finally {
                           if (mounted) setState(() => _submitting = false);
                         }

--- a/lib/screens/merchant_bookings_page.dart
+++ b/lib/screens/merchant_bookings_page.dart
@@ -1,0 +1,13 @@
+import 'package:flutter/material.dart';
+
+class MerchantBookingsPage extends StatelessWidget {
+  const MerchantBookingsPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: AppBar(title: Text('Merchant Bookings')),
+      body: Center(child: Text('No bookings yet')),
+    );
+  }
+}

--- a/lib/screens/merchant_slots_page.dart
+++ b/lib/screens/merchant_slots_page.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import '../models/slot.dart';
+import '../services/slot_service.dart';
+
+class MerchantSlotsPage extends StatefulWidget {
+  const MerchantSlotsPage({super.key});
+
+  @override
+  State<MerchantSlotsPage> createState() => _MerchantSlotsPageState();
+}
+
+class _MerchantSlotsPageState extends State<MerchantSlotsPage> {
+  final List<Slot> _slots = [];
+  String? _next;
+  bool _loading = true;
+  bool _loadingMore = false;
+  int _page = 1;
+
+  @override
+  void initState() {
+    super.initState();
+    _refresh();
+  }
+
+  Future<void> _refresh() async {
+    setState(() => _loading = true);
+    try {
+      final page = await slotService.fetchMine(page: 1);
+      setState(() {
+        _slots
+          ..clear()
+          ..addAll(page.results);
+        _next = page.next;
+        _page = 1;
+      });
+    } finally {
+      if (mounted) setState(() => _loading = false);
+    }
+  }
+
+  Future<void> _loadMore() async {
+    if (_next == null || _loadingMore) return;
+    setState(() => _loadingMore = true);
+    try {
+      final nextPage = _page + 1;
+      final page = await slotService.fetchMine(page: nextPage);
+      setState(() {
+        _slots.addAll(page.results);
+        _next = page.next;
+        _page = nextPage;
+      });
+    } finally {
+      if (mounted) setState(() => _loadingMore = false);
+    }
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('My Slots')),
+      body: _loading
+          ? const Center(child: CircularProgressIndicator())
+          : RefreshIndicator(
+              onRefresh: _refresh,
+              child: ListView.builder(
+                itemCount: _slots.length + 1,
+                itemBuilder: (context, index) {
+                  if (index == _slots.length) {
+                    if (_loadingMore) {
+                      return const Padding(
+                        padding: EdgeInsets.all(16),
+                        child: Center(child: CircularProgressIndicator()),
+                      );
+                    } else if (_next != null) {
+                      _loadMore();
+                      return const SizedBox();
+                    } else {
+                      return const SizedBox(height: 80);
+                    }
+                  }
+                  final s = _slots[index];
+                  return Card(
+                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                    child: ListTile(
+                      title: Text(s.title),
+                      subtitle: Text(
+                          '${s.beginsAt.toLocal()} - ${s.endsAt.toLocal()}'),
+                      trailing: Text(s.price.toStringAsFixed(2)),
+                    ),
+                  );
+                },
+              ),
+            ),
+    );
+  }
+}

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -1,6 +1,7 @@
 // lib/screens/provider_dashboard_page.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:dio/dio.dart';
 
 import '../models/activity.dart';
 import '../services/activity_service.dart';
@@ -8,6 +9,9 @@ import '../services/slot_service.dart';
 
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
+import 'add_facility_page.dart';
+import 'merchant_slots_page.dart';
+import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
 
@@ -103,6 +107,27 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
                 }
               }
             }),
+            const SizedBox(height: 16),
+            _QuickLinkCard(
+              label: 'Add Facility',
+              icon: Icons.store_mall_directory_outlined,
+              onTap: () => Navigator.push(
+                  context, MaterialPageRoute(builder: (_) => const AddFacilityPage())),
+            ),
+            const SizedBox(height: 16),
+            _QuickLinkCard(
+              label: 'Manage Slots',
+              icon: Icons.schedule,
+              onTap: () => Navigator.push(
+                  context, MaterialPageRoute(builder: (_) => const MerchantSlotsPage())),
+            ),
+            const SizedBox(height: 16),
+            _QuickLinkCard(
+              label: 'Merchant Bookings',
+              icon: Icons.event_note,
+              onTap: () => Navigator.push(
+                  context, MaterialPageRoute(builder: (_) => const MerchantBookingsPage())),
+            ),
             const SizedBox(height: 16),
             Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 8),
@@ -202,6 +227,54 @@ class _AddActivityHero extends StatelessWidget {
   }
 }
 
+class _QuickLinkCard extends StatelessWidget {
+  const _QuickLinkCard({required this.label, required this.icon, required this.onTap});
+  final String label;
+  final IconData icon;
+  final VoidCallback onTap;
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 0,
+      shape: RoundedRectangleBorder(
+        borderRadius: BorderRadius.circular(20),
+        side: BorderSide(color: Theme.of(context).dividerColor),
+      ),
+      child: InkWell(
+        borderRadius: BorderRadius.circular(20),
+        onTap: onTap,
+        child: SizedBox(
+          height: 88,
+          child: Row(
+            children: [
+              const SizedBox(width: 16),
+              Container(
+                width: 44,
+                height: 44,
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.surfaceVariant,
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(icon),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Text(label,
+                    style: const TextStyle(fontSize: 16, fontWeight: FontWeight.w600)),
+              ),
+              const Padding(
+                padding: EdgeInsets.only(right: 12),
+                child: Icon(Icons.chevron_right),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
 class _EmptyState extends StatelessWidget {
   const _EmptyState({required this.onCreate});
   final VoidCallback onCreate;
@@ -275,6 +348,43 @@ class _ActivityCard extends StatelessWidget {
                 if (updated == true) onChanged();
               },
               child: const Text('Edit'),
+            ),
+            PopupMenuButton<String>(
+              onSelected: (value) async {
+                if (value == 'delete') {
+                  final confirm = await showDialog<bool>(
+                    context: context,
+                    builder: (ctx) => AlertDialog(
+                      title: Text('Delete ${activity.title}?'),
+                      content: const Text('This action cannot be undone.'),
+                      actions: [
+                        TextButton(
+                            onPressed: () => Navigator.pop(ctx, false),
+                            child: const Text('Cancel')),
+                        TextButton(
+                            onPressed: () => Navigator.pop(ctx, true),
+                            child: const Text('Delete')),
+                      ],
+                    ),
+                  );
+                  if (confirm == true) {
+                    try {
+                      await activityService.deleteActivity(activity.id);
+                      if (context.mounted) {
+                        ScaffoldMessenger.of(context)
+                            .showSnackBar(const SnackBar(content: Text('Activity deleted')));
+                      }
+                      onChanged();
+                    } on DioException catch (e) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                          SnackBar(content: Text(e.message ?? 'Delete failed')));
+                    }
+                  }
+                }
+              },
+              itemBuilder: (ctx) => const [
+                PopupMenuItem(value: 'delete', child: Text('Delete')),
+              ],
             ),
           ],
         ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -129,6 +129,14 @@ class ActivityService {
     }
   }
 
+  Future<void> deleteActivity(int id) async {
+    await apiClient.delete('/activities/$id/');
+  }
+
+  Future<void> updateActivityStatus(int id, {required bool isActive}) async {
+    await apiClient.patch('/activities/$id/', data: {'is_active': isActive});
+  }
+
   void _rethrowFieldErrors(DioException e) {
     if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
       final data = e.response?.data;

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -1,6 +1,7 @@
 // lib/services/slot_service.dart
 import 'package:dio/dio.dart';
 import '../models/slot.dart';
+import '../models/paginated.dart';
 import 'api_client.dart';
 
 class SlotService {
@@ -94,16 +95,55 @@ class SlotService {
       int capacity,
       double price,
       String title,
-      String location,) async {
-    await apiClient.post('/merchant/slots/', data: {
-      'activity': activityId,
-      'begins_at': start.toIso8601String(),
-      'ends_at': end.toIso8601String(),
-      'capacity': capacity,
-      'price': price,
-      'title': title,
-      'location': location,
-    });
+      String location,
+      {required int facilityId}) async {
+    try {
+      await apiClient.post('/merchant/slots/', data: {
+        'activity': activityId,
+        'facility': facilityId,
+        'begins_at': start.toIso8601String(),
+        'ends_at': end.toIso8601String(),
+        'capacity': capacity,
+        'price': price,
+        'title': title,
+        'location': location,
+      });
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
+        final data = e.response?.data;
+        if (data is Map<String, dynamic>) {
+          final map = <String, List<String>>{};
+          data.forEach((key, value) {
+            if (value is List) {
+              map[key] = value.map((v) => v.toString()).toList();
+            } else {
+              map[key] = [value.toString()];
+            }
+          });
+          throw DioException(
+            requestOptions: e.requestOptions,
+            response: e.response,
+            type: e.type,
+            error: map,
+          );
+        }
+      }
+      throw e;
+    }
+  }
+
+  Future<Paginated<Slot>> fetchMine({int page = 1}) async {
+    final res = await apiClient.get('/merchant/slots/', queryParameters: {'page': page});
+    final data = res.data as Map<String, dynamic>;
+    return Paginated.fromJson(data, (j) => Slot.fromJson(j));
+  }
+
+  Future<void> updateMerchantSlot(int id, Map<String, dynamic> patch) async {
+    await apiClient.patch('/merchant/slots/$id/', data: patch);
+  }
+
+  Future<void> deleteMerchantSlot(int id) async {
+    await apiClient.delete('/merchant/slots/$id/');
   }
 }
 


### PR DESCRIPTION
## Summary
- add facility selection and validation when creating a slot
- support deleting activities from merchant dashboard and expose delete API
- add dashboard quick links plus basic merchant slots and bookings pages

## Testing
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899033c134c8326a87d66e8a2d6b363