### PR TITLE
feat: add sport creation and improve facility handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ When testing on the Android emulator the correct value for `API_BASE_URL` is
 `http://10.0.2.2:8000/api`.
 `initApiClient` automatically appends a trailing slash so either form
 (`http://10.0.2.2:8000/api` or `http://10.0.2.2:8000/api/`) works.
+For Web or desktop builds the Android emulator host `10.0.2.2` is not reachable;
+the client automatically swaps it to `127.0.0.1` so the backend running on the
+same machine can be accessed without editing `.env`.
 
 If running the backend without Docker, install dependencies with
 `pip install -r requirements.txt` and apply migrations using `python manage.py migrate`.
@@ -97,6 +100,8 @@ The client uses the device's location to show nearby activities. Android
 requires `ACCESS_FINE_LOCATION` or `ACCESS_COARSE_LOCATION` to be declared in
 `AndroidManifest.xml`. iOS must include `NSLocationWhenInUseUsageDescription` in
 `Info.plist`.
+The `geocoding` package is used to translate typed addresses into coordinates;
+no additional setup is required beyond network access.
 
 ## Merchant interface
 
@@ -104,6 +109,9 @@ Logged-in providers can publish new facilities via the **Add** button on the
 dashboard. Simply choose a name and categories; the app will use the device's
 current location as the facility position. Once created the facility appears in
 the *Nearby Activities* list for customers near you.
+All create forms return to the previous screen with
+`Navigator.pop(context, true)` so the caller can `await` the result and refresh
+its data when a new item is added.
 
 ### Provider sign-up
 

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -54,10 +54,16 @@ class DefaultPagination(PageNumberPagination):
     page_size_query_param = "page_size"
 
 
-class SportViewSet(viewsets.ReadOnlyModelViewSet):
+class SportViewSet(viewsets.ModelViewSet):
     queryset = Sport.objects.all()
     serializer_class = SportSerializer
-    permission_classes = [permissions.AllowAny]
+
+    def get_permissions(self):
+        if self.action == "create":
+            return [IsVendor()]
+        if self.action in ("update", "partial_update", "destroy"):
+            return [permissions.IsAdminUser()]
+        return [permissions.AllowAny()]
 
 
 class CategoryViewSet(viewsets.ReadOnlyModelViewSet):

--- a/backend/tests/test_facility_categories.py
+++ b/backend/tests/test_facility_categories.py
@@ -1,0 +1,40 @@
+import pytest
+from rest_framework.test import APIClient
+from accounts.models import VendorProfile
+from sports.models import Category
+
+
+@pytest.fixture
+def vendor_client(django_user_model):
+    user = django_user_model.objects.create_user('v@example.com', 'v@example.com', 'pass')
+    VendorProfile.objects.create(user=user)
+    client = APIClient()
+    token = client.post('/api/token/', {'email': 'v@example.com', 'password': 'pass'})
+    access = token.data['access']
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+    return client
+
+
+def test_facility_categories_int(vendor_client):
+    c1 = Category.objects.create(name='Cat1')
+    c2 = Category.objects.create(name='Cat2')
+    resp = vendor_client.post('/api/facilities/', {
+        'name': 'New',
+        'lat': 1,
+        'lng': 2,
+        'radius': 1000,
+        'categories': [c1.id, c2.id],
+    })
+    assert resp.status_code == 201
+
+
+def test_facility_categories_str_invalid(vendor_client):
+    Category.objects.create(name='Cat1')
+    resp = vendor_client.post('/api/facilities/', {
+        'name': 'Bad',
+        'lat': 1,
+        'lng': 2,
+        'radius': 1000,
+        'categories': ['1'],
+    })
+    assert resp.status_code == 400

--- a/backend/tests/test_sport_api.py
+++ b/backend/tests/test_sport_api.py
@@ -1,0 +1,63 @@
+import pytest
+from rest_framework.test import APIClient
+from accounts.models import VendorProfile
+from sports.models import Sport
+
+
+@pytest.fixture
+def vendor_client(django_user_model):
+    user = django_user_model.objects.create_user('v@example.com', 'v@example.com', 'pass')
+    VendorProfile.objects.create(user=user)
+    client = APIClient()
+    token = client.post('/api/token/', {'email': 'v@example.com', 'password': 'pass'})
+    access = token.data['access']
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+    return client
+
+
+@pytest.fixture
+def user_client(django_user_model):
+    user = django_user_model.objects.create_user('u@example.com', 'u@example.com', 'pass')
+    client = APIClient()
+    token = client.post('/api/token/', {'email': 'u@example.com', 'password': 'pass'})
+    access = token.data['access']
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+    return client
+
+
+@pytest.fixture
+def admin_client(django_user_model):
+    user = django_user_model.objects.create_superuser('a@example.com', 'a@example.com', 'pass')
+    client = APIClient()
+    token = client.post('/api/token/', {'email': 'a@example.com', 'password': 'pass'})
+    access = token.data['access']
+    client.credentials(HTTP_AUTHORIZATION=f'Bearer {access}')
+    return client
+
+
+def test_vendor_can_create_sport(vendor_client):
+    resp = vendor_client.post('/api/sports/', {'name': 'Tennis'})
+    assert resp.status_code == 201
+
+
+def test_non_vendor_cannot_create_sport(user_client):
+    resp = user_client.post('/api/sports/', {'name': 'Badminton'})
+    assert resp.status_code == 403
+
+
+def test_anonymous_cannot_create_sport():
+    resp = APIClient().post('/api/sports/', {'name': 'Soccer'})
+    assert resp.status_code == 403
+
+
+def test_admin_crud_sport(admin_client):
+    resp = admin_client.post('/api/sports/', {'name': 'Basketball'})
+    assert resp.status_code == 201
+    sport_id = resp.data['id']
+
+    resp = admin_client.patch(f'/api/sports/{sport_id}/', {'description': 'team sport'})
+    assert resp.status_code == 200
+
+    resp = admin_client.delete(f'/api/sports/{sport_id}/')
+    assert resp.status_code == 204
+    assert not Sport.objects.filter(id=sport_id).exists()

--- a/docs/dev-setup.md
+++ b/docs/dev-setup.md
@@ -1,0 +1,9 @@
+# Dev Setup Notes
+
+- `.env` files control runtime configuration. When running on Web or desktop,
+  `API_BASE_URL` containing `10.0.2.2` is automatically rewritten to
+  `127.0.0.1` so the backend on the same machine is reachable.
+- Creation pages return with `Navigator.pop(context, true)`; callers should
+  `await` the result and refresh their data providers.
+- The app uses the `geocoding` package for turning addresses into coordinates.
+  Ensure network access and provide location permissions on mobile platforms.

--- a/lib/screens/activities_by_category_page.dart
+++ b/lib/screens/activities_by_category_page.dart
@@ -102,7 +102,7 @@ class _ActivitiesByCategoryPageState
                     onPressed: () async {
                       final created = await Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (_) => const AddActivityPage()),
+                        MaterialPageRoute(builder: (_) => AddActivityPage()),
                       );
                       if (created == true) {
                         await _refresh();
@@ -191,7 +191,7 @@ class _ActivitiesByCategoryPageState
         onPressed: () async {
           final created = await Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const AddActivityPage()),
+            MaterialPageRoute(builder: (_) => AddActivityPage()),
           );
           if (created == true) {
             await _refresh();

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -12,11 +12,13 @@ import '../models/variant.dart';
 import '../providers/org_provider.dart';
 import '../services/activity_service.dart';
 import '../services/sports_service.dart';
+import 'provider_registration_page.dart';
 import '../utils/snackbar.dart';
 
 class AddActivityPage extends ConsumerStatefulWidget {
   final Activity? activity;
-  const AddActivityPage({this.activity, super.key});
+  final ActivityService service;
+  const AddActivityPage({this.activity, this.service = activityService, super.key});
 
   @override
   ConsumerState<AddActivityPage> createState() => _AddActivityPageState();
@@ -206,7 +208,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                             setState(() => _submitting = true);
                             try {
                               if (widget.activity == null) {
-                                await activityService.createActivity(
+                                await widget.service.createActivity(
                                   sportId!,
                                   disciplineId!,
                                   variantId,
@@ -219,7 +221,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   imageFile: _imageFile,
                                 );
                               } else {
-                                await activityService.updateActivity(
+                                await widget.service.updateActivity(
                                   widget.activity!.id,
                                   sportId!,
                                   disciplineId!,
@@ -247,8 +249,8 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                               final err = e.error;
                               if (err is Map<String, List<String>>) {
                                 setState(() {
-                                  fieldErrors = err
-                                      .map((k, v) => MapEntry(k, v.join(', ')));
+                                  fieldErrors =
+                                      err.map((k, v) => MapEntry(k, v.join(', ')));
                                 });
                               } else if (context.mounted) {
                                 showApiError(
@@ -257,6 +259,16 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                     widget.activity == null
                                         ? 'Create activity'
                                         : 'Update activity');
+                              }
+                            } catch (e) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                    content: Text(widget.activity == null
+                                        ? 'Create activity failed: $e'
+                                        : 'Update activity failed: $e'),
+                                  ),
+                                );
                               }
                             } finally {
                               if (mounted) setState(() => _submitting = false);
@@ -282,6 +294,40 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
     return orgsAsync.when(
       data: (orgs) {
         final selectedOrg = ref.watch(selectedOrgProvider);
+        if (orgs.isEmpty) {
+          return Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: Theme.of(context).colorScheme.primaryContainer,
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Row(
+                  children: [
+                    const Icon(Icons.info_outline),
+                    const SizedBox(width: 8),
+                    const Expanded(
+                        child: Text(
+                            'No organisations found. Create or join one first.')),
+                  ],
+                ),
+              ),
+              const SizedBox(height: 8),
+              ElevatedButton(
+                onPressed: () async {
+                  await Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                          builder: (_) => const ProviderRegistrationPage()));
+                  ref.invalidate(orgsProvider);
+                },
+                child: const Text('Create/Join Organization'),
+              ),
+            ],
+          );
+        }
         if (orgs.length == 1) {
           Future.microtask(() {
             if (ref.read(selectedOrgProvider) == null) {

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -18,7 +18,8 @@ import '../utils/snackbar.dart';
 class AddActivityPage extends ConsumerStatefulWidget {
   final Activity? activity;
   final ActivityService service;
-  const AddActivityPage({this.activity, this.service = activityService, super.key});
+  AddActivityPage({super.key, this.activity, ActivityService? service})
+      : service = service ?? activityService;
 
   @override
   ConsumerState<AddActivityPage> createState() => _AddActivityPageState();

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -14,13 +14,14 @@ class AddFacilityPage extends StatefulWidget {
   final FacilityService service;
   final SportsService sportsService;
   final Future<List<Location>> Function(String) geocode;
-  const AddFacilityPage({
+  AddFacilityPage({
     super.key,
     this.facility,
-    this.service = facilityService,
-    this.sportsService = sportsService,
+    FacilityService? service,
+    SportsService? sportsSvc,
     this.geocode = locationFromAddress,
-  });
+  })  : service = service ?? facilityService,
+        sportsService = sportsSvc ?? sportsService;
 
   @override
   State<AddFacilityPage> createState() => _AddFacilityPageState();

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -5,23 +5,23 @@ import 'package:geocoding/geocoding.dart';
 import '../models/facility.dart';
 import '../models/category.dart';
 import '../services/facility_service.dart';
-import '../services/sports_service.dart';
+import '../services/sports_service.dart' as sport_service;
 import '../services/location_service.dart';
 import '../utils/snackbar.dart';
 
 class AddFacilityPage extends StatefulWidget {
   final Facility? facility;
   final FacilityService service;
-  final SportsService sportsService;
+  final sport_service.SportsService sportsService;
   final Future<List<Location>> Function(String) geocode;
   AddFacilityPage({
     super.key,
     this.facility,
     FacilityService? service,
-    SportsService? sportsSvc,
+    sport_service.SportsService? sportsSvc,
     this.geocode = locationFromAddress,
   })  : service = service ?? facilityService,
-        sportsService = sportsSvc ?? sportsService;
+        sportsService = sportsSvc ?? sport_service.sportsService;
 
   @override
   State<AddFacilityPage> createState() => _AddFacilityPageState();

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
+import 'package:geocoding/geocoding.dart';
+
 import '../models/facility.dart';
 import '../models/category.dart';
 import '../services/facility_service.dart';
@@ -9,7 +11,16 @@ import '../utils/snackbar.dart';
 
 class AddFacilityPage extends StatefulWidget {
   final Facility? facility;
-  const AddFacilityPage({super.key, this.facility});
+  final FacilityService service;
+  final SportsService sportsService;
+  final Future<List<Location>> Function(String) geocode;
+  const AddFacilityPage({
+    super.key,
+    this.facility,
+    this.service = facilityService,
+    this.sportsService = sportsService,
+    this.geocode = locationFromAddress,
+  });
 
   @override
   State<AddFacilityPage> createState() => _AddFacilityPageState();
@@ -18,9 +29,10 @@ class AddFacilityPage extends StatefulWidget {
 class _AddFacilityPageState extends State<AddFacilityPage> {
   final _formKey = GlobalKey<FormState>();
   final nameCtrl = TextEditingController();
+  final addressCtrl = TextEditingController();
   double? lat;
   double? lng;
-  List<String> selectedCats = [];
+  List<int> selectedCats = [];
   List<Category> categories = [];
   bool _submitting = false;
   late Future<void> _loadFuture;
@@ -33,7 +45,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
       nameCtrl.text = f.name;
       lat = f.lat;
       lng = f.lng;
-      selectedCats = List<String>.from(f.categories);
+      selectedCats = f.categories.map(int.parse).toList();
     } else {
       _setCurrentLocation();
     }
@@ -41,7 +53,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   }
 
   Future<void> _loadData() async {
-    categories = await sportsService.fetchCategories();
+    categories = await widget.sportsService.fetchCategories();
   }
 
   Future<void> _setCurrentLocation() async {
@@ -51,16 +63,48 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
         lat = pos.latitude;
         lng = pos.longitude;
       });
-    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('Location set to current position')));
+      }
+    } catch (e) {
       ScaffoldMessenger.of(context).showSnackBar(
-        const SnackBar(content: Text('Could not get current location')),
+        SnackBar(content: Text('Could not get current location: $e')),
       );
+    }
+  }
+
+  Future<void> _setFromAddress() async {
+    try {
+      final results = await widget.geocode(addressCtrl.text.trim());
+      if (results.isNotEmpty) {
+        setState(() {
+          lat = results.first.latitude;
+          lng = results.first.longitude;
+        });
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+              content: Text(
+                  'Location set to ${lat!.toStringAsFixed(5)}, ${lng!.toStringAsFixed(5)}')));
+        }
+      } else {
+        if (mounted) {
+          ScaffoldMessenger.of(context).showSnackBar(
+              const SnackBar(content: Text('Address not found')));
+        }
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(SnackBar(content: Text('Could not geocode address: $e')));
+      }
     }
   }
 
   @override
   void dispose() {
     nameCtrl.dispose();
+    addressCtrl.dispose();
     super.dispose();
   }
 
@@ -93,6 +137,15 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                     onPressed: _setCurrentLocation,
                     child: const Text('Use current location'),
                   ),
+                  TextFormField(
+                    controller: addressCtrl,
+                    decoration:
+                        const InputDecoration(labelText: 'Address (optional)'),
+                  ),
+                  TextButton(
+                    onPressed: _setFromAddress,
+                    child: const Text('Use address'),
+                  ),
                   const SizedBox(height: 12),
                   Wrap(
                     spacing: 8,
@@ -100,13 +153,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                       for (final c in categories)
                         FilterChip(
                           label: Text(c.name),
-                          selected: selectedCats.contains(c.id.toString()),
+                          selected: selectedCats.contains(c.id),
                           onSelected: (sel) {
                             setState(() {
                               if (sel) {
-                                selectedCats.add(c.id.toString());
+                                selectedCats.add(c.id);
                               } else {
-                                selectedCats.remove(c.id.toString());
+                                selectedCats.remove(c.id);
                               }
                             });
                           },
@@ -125,7 +178,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                                 await _setCurrentLocation();
                               }
                               if (isEditing) {
-                                await facilityService.updateFacility(
+                                await widget.service.updateFacility(
                                   widget.facility!.id,
                                   nameCtrl.text,
                                   lat!,
@@ -133,7 +186,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                                   selectedCats,
                                 );
                               } else {
-                                await facilityService.createFacility(
+                                await widget.service.createFacility(
                                   nameCtrl.text,
                                   lat!,
                                   lng!,
@@ -144,6 +197,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                             } on DioException catch (e) {
                               if (context.mounted) {
                                 showApiError(context, e, 'Save facility');
+                              }
+                            } catch (e) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                      content: Text('Save facility failed: $e')),
+                                );
                               }
                             } finally {
                               if (mounted) setState(() => _submitting = false);

--- a/lib/screens/add_sport_page.dart
+++ b/lib/screens/add_sport_page.dart
@@ -1,0 +1,97 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class AddSportPage extends StatefulWidget {
+  final SportsService service;
+  const AddSportPage({super.key, this.service = sportsService});
+
+  @override
+  State<AddSportPage> createState() => _AddSportPageState();
+}
+
+class _AddSportPageState extends State<AddSportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  final descCtrl = TextEditingController();
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    nameCtrl.dispose();
+    descCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Sport')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              TextFormField(
+                controller: descCtrl,
+                decoration: const InputDecoration(labelText: 'Description'),
+                maxLines: 3,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _loading
+                    ? null
+                    : () async {
+                        if (!_formKey.currentState!.validate()) return;
+                        setState(() => _loading = true);
+                        try {
+                          await widget.service.createSport(
+                            name: nameCtrl.text.trim(),
+                            description: descCtrl.text.trim().isEmpty
+                                ? null
+                                : descCtrl.text.trim(),
+                          );
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Sport created')));
+                            Navigator.pop(context, true);
+                          }
+                        } on DioException catch (e) {
+                          if (context.mounted) {
+                            showApiError(context, e, 'Create sport');
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                  content:
+                                      Text('Create sport failed: $e')),
+                            );
+                          }
+                        } finally {
+                          if (mounted) setState(() => _loading = false);
+                        }
+                      },
+                child: _loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create'),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/add_sport_page.dart
+++ b/lib/screens/add_sport_page.dart
@@ -6,7 +6,8 @@ import '../utils/snackbar.dart';
 
 class AddSportPage extends StatefulWidget {
   final SportsService service;
-  const AddSportPage({super.key, this.service = sportsService});
+  AddSportPage({super.key, SportsService? service})
+      : service = service ?? sportsService;
 
   @override
   State<AddSportPage> createState() => _AddSportPageState();

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -498,7 +498,7 @@ class _HomePageState extends ConsumerState<HomePage> {
         onPressed: () async {
           final created = await Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const AddActivityPage()),
+            MaterialPageRoute(builder: (_) => AddActivityPage()),
           );
           if (created == true) {
             ref.invalidate(nearbyActivitiesProvider);

--- a/lib/screens/merchant_bookings_page.dart
+++ b/lib/screens/merchant_bookings_page.dart
@@ -5,9 +5,9 @@ class MerchantBookingsPage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(
-      appBar: AppBar(title: Text('Merchant Bookings')),
-      body: Center(child: Text('No bookings yet')),
+    return Scaffold(
+      appBar: AppBar(title: const Text('Merchant Bookings')),
+      body: const Center(child: Text('No bookings yet')),
     );
   }
 }

--- a/lib/screens/profile_page.dart
+++ b/lib/screens/profile_page.dart
@@ -143,7 +143,7 @@ class _ProfilePageState extends ConsumerState<ProfilePage> {
                       trailing: const Icon(Icons.chevron_right),
                       onTap: () => Navigator.push(
                         context,
-                        MaterialPageRoute(builder: (_) => const ProviderDashboardPage()),
+                        MaterialPageRoute(builder: (_) => ProviderDashboardPage()),
                       ),
                     ),
                   ),

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -18,7 +18,8 @@ import 'provider_categories_page.dart';
 
 class ProviderDashboardPage extends ConsumerStatefulWidget {
   final ActivityService activitySvc;
-  const ProviderDashboardPage({super.key, this.activitySvc = activityService});
+  ProviderDashboardPage({super.key, ActivityService? activitySvc})
+      : activitySvc = activitySvc ?? activityService;
 
   @override
   ConsumerState<ProviderDashboardPage> createState() => _ProviderDashboardPageState();
@@ -73,9 +74,9 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
   @override
   Widget build(BuildContext context) {
     if (_loading) {
-      return const Scaffold(
-        appBar: AppBar(title: Text('Merchant Dashboard')),
-        body: Center(child: CircularProgressIndicator()),
+      return Scaffold(
+        appBar: AppBar(title: const Text('Merchant Dashboard')),
+        body: const Center(child: CircularProgressIndicator()),
       );
     }
     return Scaffold(
@@ -100,7 +101,7 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
           children: [
             _AddActivityHero(onTap: () async {
               final created = await Navigator.push(
-                  context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
+                  context, MaterialPageRoute(builder: (_) => AddActivityPage()));
               if (created == true) {
                 await _refresh();
                 if (mounted) {
@@ -117,7 +118,7 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
                 final created = await Navigator.push(
                     context,
                     MaterialPageRoute(
-                        builder: (_) => const AddFacilityPage()));
+                        builder: (_) => AddFacilityPage()));
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
                       const SnackBar(content: Text('Facility created')));
@@ -131,7 +132,7 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
               onTap: () async {
                 final created = await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => const AddSportPage()),
+                  MaterialPageRoute(builder: (_) => AddSportPage()),
                 );
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -167,14 +168,18 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             if (_activities.isEmpty)
               _EmptyState(onCreate: () async {
                 final created = await Navigator.push(
-                    context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
+                    context, MaterialPageRoute(builder: (_) => AddActivityPage()));
                 if (created == true) {
                   await _refresh();
                 }
               })
             else
               ..._activities.map(
-                (a) => _ActivityCard(activity: a, onChanged: () => _refresh()),
+                (a) => _ActivityCard(
+                  activity: a,
+                  onChanged: () => _refresh(),
+                  activitySvc: widget.activitySvc,
+                ),
               ),
             if (_loadingMore)
               const Padding(
@@ -340,9 +345,14 @@ class _EmptyState extends StatelessWidget {
 }
 
 class _ActivityCard extends StatelessWidget {
-  const _ActivityCard({required this.activity, required this.onChanged});
+  const _ActivityCard({
+    required this.activity,
+    required this.onChanged,
+    required this.activitySvc,
+  });
   final Activity activity;
   final VoidCallback onChanged;
+  final ActivityService activitySvc;
 
   @override
   Widget build(BuildContext context) {
@@ -404,7 +414,7 @@ class _ActivityCard extends StatelessWidget {
                   );
                   if (confirm == true) {
                     try {
-                      await widget.activitySvc.deleteActivity(activity.id);
+                      await activitySvc.deleteActivity(activity.id);
                       if (context.mounted) {
                         ScaffoldMessenger.of(context)
                             .showSnackBar(const SnackBar(content: Text('Activity deleted')));

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -10,13 +10,15 @@ import '../services/slot_service.dart';
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
 import 'add_facility_page.dart';
+import 'add_sport_page.dart';
 import 'merchant_slots_page.dart';
 import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
 
 class ProviderDashboardPage extends ConsumerStatefulWidget {
-  const ProviderDashboardPage({super.key});
+  final ActivityService activitySvc;
+  const ProviderDashboardPage({super.key, this.activitySvc = activityService});
 
   @override
   ConsumerState<ProviderDashboardPage> createState() => _ProviderDashboardPageState();
@@ -38,7 +40,7 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
   Future<void> _refresh() async {
     setState(() => _loading = true);
     try {
-      final page = await activityService.fetchActivities(params: {'mine': '1'});
+      final page = await widget.activitySvc.fetchActivities(params: {'mine': '1'});
       setState(() {
         _activities
           ..clear()
@@ -56,8 +58,8 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
     setState(() => _loadingMore = true);
     try {
       final nextPage = _page + 1;
-      final page =
-          await activityService.fetchActivities(params: {'mine': '1', 'page': nextPage});
+      final page = await widget.activitySvc
+          .fetchActivities(params: {'mine': '1', 'page': nextPage});
       setState(() {
         _activities.addAll(page.results);
         _next = page.next;
@@ -111,22 +113,53 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             _QuickLinkCard(
               label: 'Add Facility',
               icon: Icons.store_mall_directory_outlined,
-              onTap: () => Navigator.push(
-                  context, MaterialPageRoute(builder: (_) => const AddFacilityPage())),
+              onTap: () async {
+                final created = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const AddFacilityPage()));
+                if (created == true && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Facility created')));
+                }
+              },
+            ),
+            const SizedBox(height: 16),
+            _QuickLinkCard(
+              label: 'Create Sport',
+              icon: Icons.sports_soccer_outlined,
+              onTap: () async {
+                final created = await Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (_) => const AddSportPage()),
+                );
+                if (created == true && context.mounted) {
+                  ScaffoldMessenger.of(context).showSnackBar(
+                      const SnackBar(content: Text('Sport created')));
+                }
+              },
             ),
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Manage Slots',
               icon: Icons.schedule,
-              onTap: () => Navigator.push(
-                  context, MaterialPageRoute(builder: (_) => const MerchantSlotsPage())),
+              onTap: () async {
+                await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const MerchantSlotsPage()));
+              },
             ),
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Merchant Bookings',
               icon: Icons.event_note,
-              onTap: () => Navigator.push(
-                  context, MaterialPageRoute(builder: (_) => const MerchantBookingsPage())),
+              onTap: () async {
+                await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const MerchantBookingsPage()));
+              },
             ),
             const SizedBox(height: 16),
             Text('Your Activities', style: Theme.of(context).textTheme.titleMedium),
@@ -231,7 +264,7 @@ class _QuickLinkCard extends StatelessWidget {
   const _QuickLinkCard({required this.label, required this.icon, required this.onTap});
   final String label;
   final IconData icon;
-  final VoidCallback onTap;
+  final Future<void> Function() onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -243,7 +276,9 @@ class _QuickLinkCard extends StatelessWidget {
       ),
       child: InkWell(
         borderRadius: BorderRadius.circular(20),
-        onTap: onTap,
+        onTap: () {
+          onTap();
+        },
         child: SizedBox(
           height: 88,
           child: Row(
@@ -369,7 +404,7 @@ class _ActivityCard extends StatelessWidget {
                   );
                   if (confirm == true) {
                     try {
-                      await activityService.deleteActivity(activity.id);
+                      await widget.activitySvc.deleteActivity(activity.id);
                       if (context.mounted) {
                         ScaffoldMessenger.of(context)
                             .showSnackBar(const SnackBar(content: Text('Activity deleted')));

--- a/lib/screens/provider_facilities_page.dart
+++ b/lib/screens/provider_facilities_page.dart
@@ -33,7 +33,7 @@ class ProviderFacilitiesPage extends ConsumerWidget {
         onPressed: () async {
           final created = await Navigator.push(
             context,
-            MaterialPageRoute(builder: (_) => const AddFacilityPage()),
+            MaterialPageRoute(builder: (_) => AddFacilityPage()),
           );
           if (created == true) ref.invalidate(myFacilitiesProvider);
         },

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -1,6 +1,8 @@
 /// Global Dio instance configured with base-url and sane defaults.
 /// All services import this instead of creating their own client.
 
+import 'dart:io' show Platform; // needed to detect desktop platforms
+
 import 'package:dio/dio.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
@@ -14,9 +16,25 @@ late Dio apiClient;
 // unique key for navigation without BuildContext
 final apiClientNavKey = GlobalKey<NavigatorState>();
 
+/// Adjust base URL for desktop/web platforms where Android's `10.0.2.2`
+/// (emulator localhost) is unreachable.  When running on Web or desktop and
+/// the env contains `10.0.2.2`, swap to `127.0.0.1`.
+@visibleForTesting
+String adjustBaseUrl(String base,
+    {bool? webOverride, bool? desktopOverride}) {
+  final isWeb = webOverride ?? kIsWeb;
+  final isDesktop = desktopOverride ??
+      (!isWeb && (Platform.isLinux || Platform.isMacOS || Platform.isWindows));
+  if ((isWeb || isDesktop) && base.contains('10.0.2.2')) {
+    return base.replaceFirst('10.0.2.2', '127.0.0.1');
+  }
+  return base;
+}
+
 /// Call after dotenv.load to construct the client with the base URL.
 void initApiClient() {
   var base = dotenv.env['API_BASE_URL']!; // e.g. http://10.0.2.2:8000/api
+  base = adjustBaseUrl(base);
   if (!base.endsWith('/')) base += '/';
   apiClient = Dio(
     BaseOptions(
@@ -27,7 +45,8 @@ void initApiClient() {
     ),
   );
   if (kDebugMode) {
-    apiClient.interceptors.add(LogInterceptor(requestBody: true, responseBody: true));
+    apiClient.interceptors.add(
+        LogInterceptor(requestBody: true, responseBody: true));
   }
 }
 

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -29,7 +29,7 @@ class FacilityService {
   }
 
   Future<void> createFacility(
-      String name, double lat, double lng, List<String> categories,
+      String name, double lat, double lng, List<int> categories,
       {double radius = 1000}) async {
     await apiClient.post('/facilities/', data: {
       'name': name,
@@ -45,7 +45,7 @@ class FacilityService {
   }
 
   Future<void> updateFacility(
-      int id, String name, double lat, double lng, List<String> categories,
+      int id, String name, double lat, double lng, List<int> categories,
       {double radius = 1000}) async {
     await apiClient.patch('/facilities/$id/', data: {
       'name': name,

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -51,6 +51,13 @@ class SportsService {
         .map(Variant.fromJson)
         .toList(growable: false);
   }
+
+  Future<void> createSport({required String name, String? description}) async {
+    await apiClient.post('/sports/', data: {
+      'name': name,
+      if (description != null) 'description': description,
+    });
+  }
 }
 
 final sportsService = SportsService();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   google_maps_flutter: ^2.5.0
   geolocator: ^11.0.0
   provider: ^6.0.5
+  geocoding: ^2.1.0
 
   # ──────────── Networking & State ────────────
   dio: ^5.4.0                # HTTP client

--- a/test/add_activity_page_test.dart
+++ b/test/add_activity_page_test.dart
@@ -1,0 +1,58 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+
+import 'package:image_picker/image_picker.dart';
+import 'package:sports_booking_app/services/api_client.dart';
+import 'package:sports_booking_app/screens/add_activity_page.dart';
+import 'package:sports_booking_app/services/activity_service.dart';
+import 'package:sports_booking_app/providers/org_provider.dart';
+
+class _ThrowingActivityService extends ActivityService {
+  @override
+  Future<void> createActivity(
+      int sport,
+      int discipline,
+      int? variant,
+      String title,
+      String description,
+      int difficulty,
+      int duration,
+      double basePrice,
+      {required int organizationId,
+      XFile? imageFile}) async {
+    throw Exception('boom');
+  }
+}
+
+void main() {
+  testWidgets('non DioException surfaces as snackbar', (tester) async {
+    apiClient = Dio()
+      ..interceptors.add(InterceptorsWrapper(onRequest: (options, handler) {
+        handler.resolve(Response(requestOptions: options, data: []));
+      }));
+
+    await tester.pumpWidget(ProviderScope(
+      overrides: [
+        orgsProvider.overrideWith((ref) async => [
+              {'id': 1, 'name': 'Org'}
+            ]),
+        selectedOrgProvider.overrideWith((ref) => StateController<int?>(1)),
+      ],
+      child: MaterialApp(home: AddActivityPage(service: _ThrowingActivityService())),
+    ));
+    await tester.pumpAndSettle();
+
+    final state = tester.state<_AddActivityPageState>(find.byType(AddActivityPage));
+    state.sportId = 1;
+    state.disciplineId = 1;
+    state.titleCtrl.text = 'T';
+    state.descCtrl.text = 'D';
+    state.durationCtrl.text = '60';
+    state.priceCtrl.text = '10';
+    await tester.tap(find.text('Create'));
+    await tester.pump();
+    expect(find.textContaining('Create activity failed'), findsOneWidget);
+  });
+}

--- a/test/add_facility_page_test.dart
+++ b/test/add_facility_page_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:sports_booking_app/models/category.dart';
+import 'package:sports_booking_app/screens/add_facility_page.dart';
+import 'package:sports_booking_app/services/facility_service.dart';
+import 'package:sports_booking_app/services/sports_service.dart';
+import 'package:geocoding/geocoding.dart';
+
+class _FakeFacilityService extends FacilityService {
+  List<int>? seen;
+  @override
+  Future<void> createFacility(
+      String name, double lat, double lng, List<int> categories,
+      {double radius = 1000}) async {
+    seen = categories;
+  }
+}
+
+class _FakeSportsService extends SportsService {
+  @override
+  Future<List<Category>> fetchCategories() async {
+    return [Category(id: 1, name: 'A')];
+  }
+}
+
+void main() {
+  testWidgets('address geocoding updates lat/lng and sends int categories',
+      (tester) async {
+    final service = _FakeFacilityService();
+    await tester.pumpWidget(MaterialApp(
+        home: AddFacilityPage(
+      service: service,
+      sportsService: _FakeSportsService(),
+      geocode: (_) async => [Location(latitude: 1, longitude: 2)],
+    )));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byLabelText('Name'), 'F1');
+    await tester.enterText(find.byLabelText('Address (optional)'), 'addr');
+    await tester.tap(find.text('Use address'));
+    await tester.pump();
+    expect(find.textContaining('Location set to 1.00000, 2.00000'),
+        findsOneWidget);
+    await tester.tap(find.text('A'));
+    await tester.tap(find.text('Create'));
+    await tester.pump();
+    expect(service.seen, [1]);
+  });
+}

--- a/test/api_client_test.dart
+++ b/test/api_client_test.dart
@@ -1,0 +1,15 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:sports_booking_app/services/api_client.dart';
+
+void main() {
+  test('replace 10.0.2.2 on web/desktop', () {
+    final url = adjustBaseUrl('http://10.0.2.2:8000/api', webOverride: true);
+    expect(url, 'http://127.0.0.1:8000/api');
+  });
+
+  test('keep 10.0.2.2 on android', () {
+    final url = adjustBaseUrl('http://10.0.2.2:8000/api',
+        webOverride: false, desktopOverride: false);
+    expect(url, 'http://10.0.2.2:8000/api');
+  });
+}

--- a/test/provider_dashboard_test.dart
+++ b/test/provider_dashboard_test.dart
@@ -1,0 +1,35 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import 'package:sports_booking_app/models/activity.dart';
+import 'package:sports_booking_app/models/paginated.dart';
+import 'package:sports_booking_app/screens/provider_dashboard_page.dart';
+import 'package:sports_booking_app/services/activity_service.dart';
+import 'package:sports_booking_app/services/api_client.dart';
+
+class _FakeActivityService extends ActivityService {
+  @override
+  Future<Paginated<Activity>> fetchActivities({Map<String, dynamic>? params}) async {
+    return Paginated(count: 0, next: null, previous: null, results: []);
+  }
+}
+
+void main() {
+  testWidgets('dashboard has Create Sport entry and shows snackbar after create',
+      (tester) async {
+    apiClient = Dio()
+      ..interceptors.add(InterceptorsWrapper(onRequest: (o, h) {
+        h.resolve(Response(requestOptions: o, data: {}));
+      }));
+    await tester.pumpWidget(MaterialApp(home: ProviderDashboardPage(activitySvc: _FakeActivityService())));
+    await tester.pumpAndSettle();
+    expect(find.text('Create Sport'), findsOneWidget);
+    await tester.tap(find.text('Create Sport'));
+    await tester.pumpAndSettle();
+    await tester.enterText(find.byLabelText('Name'), 'S1');
+    await tester.tap(find.text('Create'));
+    await tester.pump();
+    expect(find.text('Sport created'), findsWidgets);
+  });
+}


### PR DESCRIPTION
## Summary
- fix API base URL for web/desktop and add coverage
- show org guidance and catch generic errors on activity creation
- allow vendors to create sports and expose front-end flow
- send facility categories as integers with address geocoding
- document setup differences and refresh convention

## Testing
- `flutter test test/api_client_test.dart` *(fails: command not found: flutter)*
- `flutter pub get` *(fails: command not found: flutter)*
- `pytest backend/tests/test_sport_api.py backend/tests/test_facility_categories.py` *(fails: ImproperlyConfigured: Could not find the GDAL library / status 401)*


------
https://chatgpt.com/codex/tasks/task_e_6899dfcc9bd88326bd4ead247d10591d