### PR TITLE
Enable sport creation and improve activity & facility flows

### DIFF
--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -34,6 +34,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   int? variantId;
   int difficulty = 1;
   bool _submitting = false;
+  bool _orgReady = false;
   XFile? _imageFile;
   String? _existingImage;
   Map<String, String> fieldErrors = {};
@@ -87,6 +88,8 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
             return const Center(child: CircularProgressIndicator());
           }
           final orgsAsync = ref.watch(orgsProvider);
+          final selectedOrg = ref.watch(selectedOrgProvider);
+          _orgReady = orgsAsync is AsyncData && selectedOrg != null;
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Form(
@@ -191,7 +194,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                   _imagePickerField(),
                   const SizedBox(height: 20),
                   ElevatedButton(
-                    onPressed: _submitting
+                    onPressed: (!_orgReady || _submitting)
                         ? null
                         : () async {
                             fieldErrors = {};
@@ -205,8 +208,9 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                             }
                             setState(() => _submitting = true);
                             try {
+                              Activity res;
                               if (widget.activity == null) {
-                                await activityService.createActivity(
+                                res = await activityService.createActivity(
                                   sportId!,
                                   disciplineId!,
                                   variantId,
@@ -219,7 +223,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   imageFile: _imageFile,
                                 );
                               } else {
-                                await activityService.updateActivity(
+                                res = await activityService.updateActivity(
                                   widget.activity!.id,
                                   sportId!,
                                   disciplineId!,
@@ -234,21 +238,14 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                 );
                               }
                               if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(widget.activity == null
-                                        ? 'Activity created'
-                                        : 'Activity updated'),
-                                  ),
-                                );
-                                Navigator.pop(context, true);
+                                Navigator.pop(context, res);
                               }
                             } on DioException catch (e) {
                               final err = e.error;
                               if (err is Map<String, List<String>>) {
                                 setState(() {
-                                  fieldErrors = err
-                                      .map((k, v) => MapEntry(k, v.join(', ')));
+                                  fieldErrors =
+                                      err.map((k, v) => MapEntry(k, v.join(', ')));
                                 });
                               } else if (context.mounted) {
                                 showApiError(
@@ -289,7 +286,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                   orgs.first['id'] as int;
             }
           });
-          return const SizedBox.shrink();
         }
         return DropdownButtonFormField<int>(
           value: selectedOrg,
@@ -299,7 +295,10 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                     child: Text(e['name']?.toString() ?? ''),
                   ))
               .toList(),
-          onChanged: (v) => ref.read(selectedOrgProvider.notifier).state = v,
+          onChanged: orgs.length == 1
+              ? null
+              : (v) =>
+                  ref.read(selectedOrgProvider.notifier).state = v,
           decoration: InputDecoration(
             labelText: 'Organization',
             errorText: fieldErrors['organization'],
@@ -307,8 +306,17 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           validator: (v) => v == null ? 'Required' : null,
         );
       },
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      loading: () => const Padding(
+        padding: EdgeInsets.only(bottom: 16),
+        child: Text('Loading organization…',
+            style: TextStyle(color: Colors.grey)),
+      ),
+      error: (_, __) => Padding(
+        padding: const EdgeInsets.only(bottom: 16),
+        child: Text('Failed to load organization.',
+            style: TextStyle(
+                color: Theme.of(context).colorScheme.error, fontSize: 12)),
+      ),
     );
   }
 

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
+import 'package:geocoding/geocoding.dart';
+
 import '../models/facility.dart';
 import '../models/category.dart';
 import '../services/facility_service.dart';
@@ -18,11 +20,13 @@ class AddFacilityPage extends StatefulWidget {
 class _AddFacilityPageState extends State<AddFacilityPage> {
   final _formKey = GlobalKey<FormState>();
   final nameCtrl = TextEditingController();
+  final addressCtrl = TextEditingController();
   double? lat;
   double? lng;
   List<String> selectedCats = [];
   List<Category> categories = [];
   bool _submitting = false;
+  String? addressError;
   late Future<void> _loadFuture;
 
   @override
@@ -61,6 +65,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   @override
   void dispose() {
     nameCtrl.dispose();
+    addressCtrl.dispose();
     super.dispose();
   }
 
@@ -85,6 +90,39 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                     controller: nameCtrl,
                     decoration: const InputDecoration(labelText: 'Name'),
                     validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                  ),
+                  Row(
+                    children: [
+                      Expanded(
+                        child: TextFormField(
+                          controller: addressCtrl,
+                          decoration: InputDecoration(
+                            labelText: 'Address',
+                            errorText: addressError,
+                          ),
+                        ),
+                      ),
+                      const SizedBox(width: 8),
+                      TextButton(
+                        onPressed: () async {
+                          try {
+                            final list = await locationFromAddress(addressCtrl.text);
+                            if (list.isNotEmpty) {
+                              setState(() {
+                                lat = list.first.latitude;
+                                lng = list.first.longitude;
+                                addressError = null;
+                              });
+                            }
+                          } catch (_) {
+                            setState(() {
+                              addressError = 'Could not resolve address';
+                            });
+                          }
+                        },
+                        child: const Text('Resolve address'),
+                      ),
+                    ],
                   ),
                   if (lat != null && lng != null)
                     Text(
@@ -119,11 +157,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) return;
+                            if (lat == null || lng == null) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('Location required')));
+                              return;
+                            }
                             setState(() => _submitting = true);
                             try {
-                              if (lat == null || lng == null) {
-                                await _setCurrentLocation();
-                              }
                               if (isEditing) {
                                 await facilityService.updateFacility(
                                   widget.facility!.id,
@@ -144,6 +184,11 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                             } on DioException catch (e) {
                               if (context.mounted) {
                                 showApiError(context, e, 'Save facility');
+                              }
+                            } catch (e) {
+                              if (mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text('Save facility failed: $e')));
                               }
                             } finally {
                               if (mounted) setState(() => _submitting = false);

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -1,0 +1,83 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class EditSportPage extends StatefulWidget {
+  const EditSportPage({super.key});
+
+  @override
+  State<EditSportPage> createState() => _EditSportPageState();
+}
+
+class _EditSportPageState extends State<EditSportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  bool _submitting = false;
+
+  @override
+  void dispose() {
+    nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Sport')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.stretch,
+            children: [
+              TextFormField(
+                controller: nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) => v == null || v.trim().isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submitting
+                    ? null
+                    : () async {
+                        if (!_formKey.currentState!.validate()) return;
+                        setState(() => _submitting = true);
+                        try {
+                          await sportsService.createSport(nameCtrl.text.trim());
+                          if (mounted) {
+                            ScaffoldMessenger.of(context)
+                                .showSnackBar(const SnackBar(content: Text('Sport created')));
+                            Navigator.pop(context, true);
+                          }
+                        } on DioException catch (e) {
+                          if (mounted) {
+                            if (e.response?.statusCode == 401 ||
+                                e.response?.statusCode == 403) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Permission denied (contact admin)')));
+                            } else {
+                              showApiError(context, e, 'Create sport');
+                            }
+                          }
+                        } finally {
+                          if (mounted) setState(() => _submitting = false);
+                        }
+                      },
+                child: _submitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2))
+                    : const Text('Create'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -1,4 +1,6 @@
 // lib/screens/provider_dashboard_page.dart
+import 'dart:async';
+
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
@@ -14,6 +16,7 @@ import 'merchant_slots_page.dart';
 import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
 import 'provider_categories_page.dart';
+import 'edit_sport_page.dart';
 
 class ProviderDashboardPage extends ConsumerStatefulWidget {
   const ProviderDashboardPage({super.key});
@@ -97,16 +100,20 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
           padding: const EdgeInsets.all(16),
           children: [
             _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(
+              final result = await Navigator.push(
                   context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
-              if (created == true) {
-                await _refresh();
-                if (mounted) {
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(const SnackBar(content: Text('Activity created')));
-                }
+              if (result is Activity) {
+                setState(() => _activities.insert(0, result));
+                unawaited(_refresh());
               }
             }),
+            const SizedBox(height: 16),
+            _QuickLinkCard(
+              label: 'Create Sport',
+              icon: Icons.sports_martial_arts_outlined,
+              onTap: () => Navigator.push(
+                  context, MaterialPageRoute(builder: (_) => const EditSportPage())),
+            ),
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Add Facility',
@@ -133,10 +140,11 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 8),
             if (_activities.isEmpty)
               _EmptyState(onCreate: () async {
-                final created = await Navigator.push(
+                final result = await Navigator.push(
                     context, MaterialPageRoute(builder: (_) => const AddActivityPage()));
-                if (created == true) {
-                  await _refresh();
+                if (result is Activity) {
+                  setState(() => _activities.insert(0, result));
+                  unawaited(_refresh());
                 }
               })
             else
@@ -344,8 +352,11 @@ class _ActivityCard extends StatelessWidget {
             ),
             TextButton(
               onPressed: () async {
-                final updated = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddActivityPage(activity: activity)));
-                if (updated == true) onChanged();
+                final updated = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => AddActivityPage(activity: activity)));
+                if (updated is Activity) onChanged();
               },
               child: const Text('Edit'),
             ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -62,7 +62,7 @@ class ActivityService {
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
-  Future<void> createActivity(
+  Future<Activity> createActivity(
     int sport,
     int discipline,
     int? variant,
@@ -89,13 +89,15 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.post('/activities/', data: form);
+      final res = await apiClient.post('/activities/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
+      rethrow;
     }
   }
 
-  Future<void> updateActivity(
+  Future<Activity> updateActivity(
     int id,
     int sport,
     int discipline,
@@ -123,9 +125,11 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.patch('/activities/$id/', data: form);
+      final res = await apiClient.patch('/activities/$id/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
+      rethrow;
     }
   }
 

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -31,12 +31,14 @@ class FacilityService {
   Future<void> createFacility(
       String name, double lat, double lng, List<String> categories,
       {double radius = 1000}) async {
+    final catIds =
+        categories.map((e) => int.parse(e)).toList(growable: false);
     await apiClient.post('/facilities/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
-      'categories': categories,
+      'categories': catIds,
     });
   }
 
@@ -47,12 +49,14 @@ class FacilityService {
   Future<void> updateFacility(
       int id, String name, double lat, double lng, List<String> categories,
       {double radius = 1000}) async {
+    final catIds =
+        categories.map((e) => int.parse(e)).toList(growable: false);
     await apiClient.patch('/facilities/$id/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
-      'categories': categories,
+      'categories': catIds,
     });
   }
 

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -51,6 +51,10 @@ class SportsService {
         .map(Variant.fromJson)
         .toList(growable: false);
   }
+
+  Future<void> createSport(String name) async {
+    await apiClient.post('/sports/', data: {'name': name});
+  }
 }
 
 final sportsService = SportsService();

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,6 +15,7 @@ dependencies:
   flutter_rating_bar: ^4.0.1    # ⭐ star-rating widget (restored)
   google_maps_flutter: ^2.5.0
   geolocator: ^11.0.0
+  geocoding: ^2.1.0
   provider: ^6.0.5
 
   # ──────────── Networking & State ────────────


### PR DESCRIPTION
## Summary
- return created activities and insert them locally for instant dashboard updates
- add sport creation screen and wire into provider dashboard
- allow facility address geocoding and submit category IDs

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899df9e90fc832681efc50351ea8600