### PR TITLE
Improve merchant creation flows

### DIFF
--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -46,6 +46,16 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   List<Category> categories = [];
   List<Variant> variants = [];
 
+  bool get _orgReady {
+    final a = ref.watch(orgsProvider);
+    if (a is AsyncData<List<Map<String, dynamic>>>) {
+      final list = a.value ?? const [];
+      final sel = ref.read(selectedOrgProvider);
+      return list.isNotEmpty && sel != null;
+    }
+    return false;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -194,7 +204,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                   _imagePickerField(),
                   const SizedBox(height: 20),
                   ElevatedButton(
-                    onPressed: _submitting
+                    onPressed: _submitting || !_orgReady
                         ? null
                         : () async {
                             fieldErrors = {};
@@ -208,8 +218,9 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                             }
                             setState(() => _submitting = true);
                             try {
+                              Activity created;
                               if (widget.activity == null) {
-                                await widget.service.createActivity(
+                                created = await widget.service.createActivity(
                                   sportId!,
                                   disciplineId!,
                                   variantId,
@@ -222,7 +233,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   imageFile: _imageFile,
                                 );
                               } else {
-                                await widget.service.updateActivity(
+                                created = await widget.service.updateActivity(
                                   widget.activity!.id,
                                   sportId!,
                                   disciplineId!,
@@ -244,7 +255,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                         : 'Activity updated'),
                                   ),
                                 );
-                                Navigator.pop(context, true);
+                                Navigator.pop(context, created);
                               }
                             } on DioException catch (e) {
                               final err = e.error;
@@ -354,8 +365,18 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           validator: (v) => v == null ? 'Required' : null,
         );
       },
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
+      loading: () => const Padding(
+          padding: EdgeInsets.symmetric(vertical: 8),
+          child: Text(
+            'Loading organization…',
+            style: TextStyle(color: Colors.grey),
+          )),
+      error: (_, __) => Padding(
+          padding: const EdgeInsets.symmetric(vertical: 8),
+          child: Text(
+            'Failed to load organization. Pull to refresh.',
+            style: TextStyle(color: Theme.of(context).colorScheme.error),
+          )),
     );
   }
 

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -33,6 +33,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   final addressCtrl = TextEditingController();
   double? lat;
   double? lng;
+  String? addressError;
   List<int> selectedCats = [];
   List<Category> categories = [];
   bool _submitting = false;
@@ -76,6 +77,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   }
 
   Future<void> _setFromAddress() async {
+    setState(() => addressError = null);
     try {
       final results = await widget.geocode(addressCtrl.text.trim());
       if (results.isNotEmpty) {
@@ -89,16 +91,14 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   'Location set to ${lat!.toStringAsFixed(5)}, ${lng!.toStringAsFixed(5)}')));
         }
       } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Address not found')));
-        }
+        setState(() {
+          addressError = 'Address not found';
+        });
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not geocode address: $e')));
-      }
+      setState(() {
+        addressError = 'Could not geocode address';
+      });
     }
   }
 
@@ -140,8 +140,10 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   ),
                   TextFormField(
                     controller: addressCtrl,
-                    decoration:
-                        const InputDecoration(labelText: 'Address (optional)'),
+                    decoration: InputDecoration(
+                      labelText: 'Address (optional)',
+                      errorText: addressError,
+                    ),
                   ),
                   TextButton(
                     onPressed: _setFromAddress,
@@ -173,11 +175,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) return;
+                            if (lat == null || lng == null) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Location is required')));
+                                return;
+                            }
                             setState(() => _submitting = true);
                             try {
-                              if (lat == null || lng == null) {
-                                await _setCurrentLocation();
-                              }
                               if (isEditing) {
                                 await widget.service.updateFacility(
                                   widget.facility!.id,
@@ -202,8 +206,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                             } catch (e) {
                               if (context.mounted) {
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                      content: Text('Save facility failed: $e')),
+                                  SnackBar(content: Text('Save facility failed: $e')),
                                 );
                               }
                             } finally {

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -1,0 +1,92 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class EditSportPage extends StatefulWidget {
+  final SportsService service;
+  const EditSportPage({super.key, SportsService? service})
+      : service = service ?? sportsService;
+
+  @override
+  State<EditSportPage> createState() => _EditSportPageState();
+}
+
+class _EditSportPageState extends State<EditSportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Sport')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _loading
+                    ? null
+                    : () async {
+                        if (!_formKey.currentState!.validate()) return;
+                        setState(() => _loading = true);
+                        try {
+                          await widget.service
+                              .createSportSimple(nameCtrl.text.trim());
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Sport created')));
+                            Navigator.pop(context, true);
+                          }
+                        } on DioException catch (e) {
+                          if (!mounted) return;
+                          if (e.response?.statusCode == 401 ||
+                              e.response?.statusCode == 403) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(
+                                    content: Text(
+                                        'Permission denied (contact admin)')));
+                          } else {
+                            showApiError(context, e, 'Create sport');
+                          }
+                        } catch (e) {
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                SnackBar(
+                                    content: Text('Create sport failed: $e')));
+                          }
+                        } finally {
+                          if (mounted) setState(() => _loading = false);
+                        }
+                      },
+                child: _loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -6,7 +6,7 @@ import '../utils/snackbar.dart';
 
 class EditSportPage extends StatefulWidget {
   final SportsService service;
-  const EditSportPage({super.key, SportsService? service})
+  EditSportPage({super.key, SportsService? service})
       : service = service ?? sportsService;
 
   @override

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -134,7 +134,7 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
               onTap: () async {
                 final created = await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => const EditSportPage()),
+                  MaterialPageRoute(builder: (_) => EditSportPage()),
                 );
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -1,4 +1,5 @@
 // lib/screens/provider_dashboard_page.dart
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
@@ -10,7 +11,7 @@ import '../services/slot_service.dart';
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
 import 'add_facility_page.dart';
-import 'add_sport_page.dart';
+import 'edit_sport_page.dart';
 import 'merchant_slots_page.dart';
 import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
@@ -100,14 +101,15 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
           padding: const EdgeInsets.all(16),
           children: [
             _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(
+              final result = await Navigator.push(
                   context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-              if (created == true) {
+              if (result is Activity) {
+                setState(() {
+                  _activities.insert(0, result);
+                });
+                unawaited(_refresh());
+              } else if (result == true) {
                 await _refresh();
-                if (mounted) {
-                  ScaffoldMessenger.of(context)
-                      .showSnackBar(const SnackBar(content: Text('Activity created')));
-                }
               }
             }),
             const SizedBox(height: 16),
@@ -128,11 +130,11 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Create Sport',
-              icon: Icons.sports_soccer_outlined,
+              icon: Icons.sports_martial_arts_outlined,
               onTap: () async {
                 final created = await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => AddSportPage()),
+                  MaterialPageRoute(builder: (_) => const EditSportPage()),
                 );
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -167,9 +169,14 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 8),
             if (_activities.isEmpty)
               _EmptyState(onCreate: () async {
-                final created = await Navigator.push(
+                final result = await Navigator.push(
                     context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-                if (created == true) {
+                if (result is Activity) {
+                  setState(() {
+                    _activities.insert(0, result);
+                  });
+                  unawaited(_refresh());
+                } else if (result == true) {
                   await _refresh();
                 }
               })
@@ -389,8 +396,11 @@ class _ActivityCard extends StatelessWidget {
             ),
             TextButton(
               onPressed: () async {
-                final updated = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddActivityPage(activity: activity)));
-                if (updated == true) onChanged();
+                final updated = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => AddActivityPage(activity: activity)));
+                if (updated is Activity || updated == true) onChanged();
               },
               child: const Text('Edit'),
             ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -62,7 +62,7 @@ class ActivityService {
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
-  Future<void> createActivity(
+  Future<Activity> createActivity(
     int sport,
     int discipline,
     int? variant,
@@ -89,13 +89,15 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.post('/activities/', data: form);
+      final res = await apiClient.post('/activities/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
+    throw Exception('Create activity failed');
   }
 
-  Future<void> updateActivity(
+  Future<Activity> updateActivity(
     int id,
     int sport,
     int discipline,
@@ -123,10 +125,12 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.patch('/activities/$id/', data: form);
+      final res = await apiClient.patch('/activities/$id/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
+    throw Exception('Update activity failed');
   }
 
   Future<void> deleteActivity(int id) async {

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -28,36 +28,64 @@ class FacilityService {
         .toList(growable: false);
   }
 
-  Future<void> createFacility(
+  Future<Facility> createFacility(
       String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.post('/facilities/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.post('/merchant/facilities/', data: data);
+      return Facility.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.post('/facilities/', data: data);
+        return Facility.fromJson(res.data as Map<String, dynamic>);
+      }
+      rethrow;
+    }
   }
 
   Future<List<Facility>> fetchMine() async {
     return fetchFacilities([], 0, 0, 0, mine: true);
   }
 
-  Future<void> updateFacility(
+  Future<Facility> updateFacility(
       int id, String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.patch('/facilities/$id/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.patch('/merchant/facilities/$id/', data: data);
+      return Facility.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.patch('/facilities/$id/', data: data);
+        return Facility.fromJson(res.data as Map<String, dynamic>);
+      }
+      rethrow;
+    }
   }
 
   Future<void> deleteFacility(int id) async {
-    await apiClient.delete('/facilities/$id/');
+    try {
+      await apiClient.delete('/merchant/facilities/$id/');
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        await apiClient.delete('/facilities/$id/');
+      } else {
+        rethrow;
+      }
+    }
   }
 
   Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -58,6 +58,11 @@ class SportsService {
       if (description != null) 'description': description,
     });
   }
+
+  // Simple creator using only the name field.
+  Future<void> createSportSimple(String name) async {
+    await createSport(name: name);
+  }
 }
 
 final sportsService = SportsService();


### PR DESCRIPTION
## Summary
- ensure activity creation waits for organization and returns new object
- allow merchants to create sports and facilities with address geocoding
- add dedicated sport creation page and immediate dashboard refresh

## Testing
- `dart format lib/screens/add_activity_page.dart lib/services/activity_service.dart lib/screens/provider_dashboard_page.dart lib/screens/edit_sport_page.dart lib/screens/add_facility_page.dart lib/services/facility_service.dart lib/services/sports_service.dart` *(command not found)*
- `flutter analyze` *(command not found)*
- `flutter test` *(command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899f606fa208326a545ea1390778685