### PR TITLE
Support default organization and facility/sport creation

### DIFF
--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -3,6 +3,7 @@ from rest_framework import serializers
 from rest_framework_gis.serializers import GeoFeatureModelSerializer
 from django.contrib.gis.geos import Point
 from django.utils import timezone
+from rest_framework.exceptions import PermissionDenied
 from .models import (
     Sport,
     Slot,
@@ -156,7 +157,7 @@ class VariantSerializer(serializers.ModelSerializer):
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
     organization = serializers.PrimaryKeyRelatedField(
-        queryset=Organization.objects.all()
+        queryset=Organization.objects.all(), required=False, allow_null=True
     )
 
     class Meta:
@@ -208,10 +209,13 @@ class ActivitySerializer(serializers.ModelSerializer):
         user = getattr(request, "user", None)
         if user is None:
             return value
-        if not OrganizationMember.objects.filter(
-            organization=value, user=user
-        ).exists():
-            raise serializers.ValidationError("Not a member of this organization")
+        if (
+            value
+            and not OrganizationMember.objects.filter(
+                organization=value, user=user
+            ).exists()
+        ):
+            raise PermissionDenied("Not a member of this organization")
         return value
 
 

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -6,12 +6,13 @@ from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
-from accounts.models import OrganizationMember
+from accounts.models import Organization, OrganizationMember
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
 from django.utils import timezone
 from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from rest_framework.exceptions import ValidationError, PermissionDenied
 
 from .models import (
     Sport,
@@ -45,6 +46,16 @@ from .serializers import (
     SlotCreateSerializer,
     FavoriteSerializer,
 )
+
+
+def _get_default_org_for_user(user):
+    default = getattr(user, "primary_org", None)
+    if default:
+        return default
+    qs = Organization.objects.filter(members__user=user).distinct()[:2]
+    if qs.count() == 1:
+        return qs.first()
+    return None
 
 
 class DefaultPagination(PageNumberPagination):
@@ -141,7 +152,9 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return [p() if isinstance(p, type) else p for p in perms]
 
     def get_queryset(self):
-        qs = Activity.objects.select_related("sport", "discipline", "variant", "organization")
+        qs = Activity.objects.select_related(
+            "sport", "discipline", "variant", "organization"
+        )
         if self.action in ("update", "partial_update", "destroy"):
             qs = qs.filter(organization__members__user=self.request.user)
         mine = self.request.query_params.get("mine")
@@ -177,14 +190,39 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        serializer.save()
+        request = self.request
+        data_org_id = request.data.get("organization")
+        if not data_org_id:
+            org = _get_default_org_for_user(request.user)
+            if not org:
+                raise ValidationError(
+                    {"organization": ["No default organization for current user."]}
+                )
+            if not OrganizationMember.objects.filter(
+                organization=org, user=request.user
+            ).exists():
+                raise PermissionDenied("Not a member of the default organization.")
+            serializer.save(organization=org)
+        else:
+            org = Organization.objects.filter(id=data_org_id).first()
+            if not org:
+                raise ValidationError(
+                    {"organization": ["Organization does not exist."]}
+                )
+            if not OrganizationMember.objects.filter(
+                organization=org, user=request.user
+            ).exists():
+                raise PermissionDenied("Not a member of this organization.")
+            serializer.save()
 
-    @action(detail=True, methods=["post"], url_path="favorite/toggle",
-            permission_classes=[permissions.IsAuthenticated])
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="favorite/toggle",
+        permission_classes=[permissions.IsAuthenticated],
+    )
     def favorite_toggle(self, request, pk=None):
-        fav, created = Favorite.objects.get_or_create(
-            user=request.user, activity_id=pk
-        )
+        fav, created = Favorite.objects.get_or_create(user=request.user, activity_id=pk)
         if not created:
             fav.delete()
             return Response({"favorited": False})
@@ -286,10 +324,7 @@ class BookingViewSet(viewsets.ModelViewSet):
         # connection when listing bookings (My Bookings → "connection closed").
         # FIX: only join the Slot; facility id is enough for clients
         # (covers: My Bookings list).
-        return (
-            Booking.objects.filter(user=self.request.user)
-            .select_related("slot")
-        )
+        return Booking.objects.filter(user=self.request.user).select_related("slot")
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):
@@ -356,18 +391,16 @@ class ContinuePlanningView(APIView):
 
     def get(self, request):
         user = request.user
-        histories = (
-            UserActivityHistory.objects.filter(user=user)
-            .order_by("-timestamp")[:20]
-        )
+        histories = UserActivityHistory.objects.filter(user=user).order_by(
+            "-timestamp"
+        )[:20]
         act_ids = []
         for h in histories:
             if h.activity_id not in act_ids:
                 act_ids.append(h.activity_id)
 
-        unfinished = (
-            Booking.objects.filter(user=user, paid=False)
-            .values_list("activity_id", flat=True)
+        unfinished = Booking.objects.filter(user=user, paid=False).values_list(
+            "activity_id", flat=True
         )
         for aid in unfinished:
             if aid and aid not in act_ids:
@@ -375,9 +408,7 @@ class ContinuePlanningView(APIView):
 
         acts = {a.id: a for a in Activity.objects.filter(id__in=act_ids)}
         ordered = [acts[a] for a in act_ids if a in acts]
-        ser = ActivitySimpleSerializer(
-            ordered, many=True, context={"request": request}
-        )
+        ser = ActivitySimpleSerializer(ordered, many=True, context={"request": request})
         return Response(ser.data)
 
 
@@ -488,17 +519,20 @@ class MerchantBookingList(APIView):
         return Response(ser.data)
 
 
-class FavoriteViewSet(viewsets.GenericViewSet,
-                      mixins.ListModelMixin,
-                      mixins.CreateModelMixin,
-                      mixins.DestroyModelMixin):
+class FavoriteViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+):
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = FavoriteSerializer
     pagination_class = DefaultPagination
 
     def get_queryset(self):
         return Favorite.objects.filter(user=self.request.user).select_related(
-            "activity")
+            "activity"
+        )
 
     def create(self, request, *args, **kwargs):
         activity_id = request.data.get("activity")
@@ -507,9 +541,7 @@ class FavoriteViewSet(viewsets.GenericViewSet,
         fav, created = Favorite.objects.get_or_create(
             user=request.user, activity_id=activity_id
         )
-        status_code = (
-            status.HTTP_201_CREATED if created else status.HTTP_200_OK
-        )
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({"favorited": True}, status=status_code)
 
     def destroy(self, request, pk=None):

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -200,16 +200,10 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                             fieldErrors = {};
                             if (!_formKey.currentState!.validate()) return;
                             final orgId = ref.read(selectedOrgProvider);
-                            if (orgId == null) {
-                              setState(() {
-                                fieldErrors['organization'] = 'Required';
-                              });
-                              return;
-                            }
                             setState(() => _submitting = true);
                             try {
                               if (widget.activity == null) {
-                                await widget.service.createActivity(
+                                final created = await widget.service.createActivity(
                                   sportId!,
                                   disciplineId!,
                                   variantId,
@@ -221,6 +215,12 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   organizationId: orgId,
                                   imageFile: _imageFile,
                                 );
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Activity created')),
+                                  );
+                                  Navigator.pop(context, created);
+                                }
                               } else {
                                 await widget.service.updateActivity(
                                   widget.activity!.id,
@@ -235,16 +235,12 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   organizationId: orgId,
                                   imageFile: _imageFile,
                                 );
-                              }
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(widget.activity == null
-                                        ? 'Activity created'
-                                        : 'Activity updated'),
-                                  ),
-                                );
-                                Navigator.pop(context, true);
+                                if (context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Activity updated')),
+                                  );
+                                  Navigator.pop(context, true);
+                                }
                               }
                             } on DioException catch (e) {
                               final err = e.error;
@@ -351,7 +347,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
             labelText: 'Organization',
             errorText: fieldErrors['organization'],
           ),
-          validator: (v) => v == null ? 'Required' : null,
+          validator: (_) => null,
         );
       },
       loading: () => const SizedBox.shrink(),

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -33,6 +33,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   final addressCtrl = TextEditingController();
   double? lat;
   double? lng;
+  String? addressError;
   List<int> selectedCats = [];
   List<Category> categories = [];
   bool _submitting = false;
@@ -76,12 +77,14 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   }
 
   Future<void> _setFromAddress() async {
+    setState(() => addressError = null);
     try {
       final results = await widget.geocode(addressCtrl.text.trim());
       if (results.isNotEmpty) {
         setState(() {
           lat = results.first.latitude;
           lng = results.first.longitude;
+          addressError = null;
         });
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(SnackBar(
@@ -89,16 +92,14 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   'Location set to ${lat!.toStringAsFixed(5)}, ${lng!.toStringAsFixed(5)}')));
         }
       } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Address not found')));
-        }
+        setState(() {
+          addressError = 'Address not found';
+        });
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not geocode address: $e')));
-      }
+      setState(() {
+        addressError = 'Could not geocode address';
+      });
     }
   }
 
@@ -140,8 +141,10 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   ),
                   TextFormField(
                     controller: addressCtrl,
-                    decoration:
-                        const InputDecoration(labelText: 'Address (optional)'),
+                    decoration: InputDecoration(
+                      labelText: 'Address (optional)',
+                      errorText: addressError,
+                    ),
                   ),
                   TextButton(
                     onPressed: _setFromAddress,
@@ -173,11 +176,16 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) return;
+                            if (lat == null || lng == null) {
+                              if (context.mounted) {
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(content: Text('Please set location (current or address).')),
+                                );
+                              }
+                              return;
+                            }
                             setState(() => _submitting = true);
                             try {
-                              if (lat == null || lng == null) {
-                                await _setCurrentLocation();
-                              }
                               if (isEditing) {
                                 await widget.service.updateFacility(
                                   widget.facility!.id,
@@ -201,9 +209,11 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                               }
                             } catch (e) {
                               if (context.mounted) {
+                                final msg = e.toString().isNotEmpty
+                                    ? e.toString()
+                                    : 'Unknown error';
                                 ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                      content: Text('Save facility failed: $e')),
+                                  SnackBar(content: Text('Save facility failed: $msg')),
                                 );
                               }
                             } finally {

--- a/lib/screens/add_sport_page.dart
+++ b/lib/screens/add_sport_page.dart
@@ -54,12 +54,8 @@ class _AddSportPageState extends State<AddSportPage> {
                         if (!_formKey.currentState!.validate()) return;
                         setState(() => _loading = true);
                         try {
-                          await widget.service.createSport(
-                            name: nameCtrl.text.trim(),
-                            description: descCtrl.text.trim().isEmpty
-                                ? null
-                                : descCtrl.text.trim(),
-                          );
+                          await widget.service
+                              .createSport(nameCtrl.text.trim());
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
                                 const SnackBar(content: Text('Sport created')));

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -1,0 +1,91 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class EditSportPage extends StatefulWidget {
+  const EditSportPage({super.key});
+
+  @override
+  State<EditSportPage> createState() => _EditSportPageState();
+}
+
+class _EditSportPageState extends State<EditSportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final _nameCtrl = TextEditingController();
+  bool _loading = false;
+
+  @override
+  void dispose() {
+    _nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Sport')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: _nameCtrl,
+                decoration: const InputDecoration(labelText: 'Name'),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _loading
+                    ? null
+                    : () async {
+                        if (!_formKey.currentState!.validate()) return;
+                        setState(() => _loading = true);
+                        try {
+                          await sportsService.createSport(_nameCtrl.text.trim());
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Sport created')));
+                            Navigator.pop(context, true);
+                          }
+                        } on DioException catch (e) {
+                          if (e.response?.statusCode == 401 ||
+                              e.response?.statusCode == 403) {
+                            if (context.mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text(
+                                          'Permission denied (contact admin)')));
+                            }
+                          } else if (context.mounted) {
+                            showApiError(context, e, 'Create sport');
+                          }
+                        } catch (e) {
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(
+                                  content: Text('Create sport failed: $e')),
+                            );
+                          }
+                        } finally {
+                          if (mounted) setState(() => _loading = false);
+                        }
+                      },
+                child: _loading
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create'),
+              )
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -1,4 +1,5 @@
 // lib/screens/provider_dashboard_page.dart
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
@@ -10,7 +11,7 @@ import '../services/slot_service.dart';
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
 import 'add_facility_page.dart';
-import 'add_sport_page.dart';
+import 'edit_sport_page.dart';
 import 'merchant_slots_page.dart';
 import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
@@ -100,14 +101,19 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
           padding: const EdgeInsets.all(16),
           children: [
             _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(
+              final result = await Navigator.push(
                   context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-              if (created == true) {
-                await _refresh();
+              if (result is Activity) {
+                setState(() {
+                  _activities.insert(0, result);
+                });
                 if (mounted) {
                   ScaffoldMessenger.of(context)
                       .showSnackBar(const SnackBar(content: Text('Activity created')));
                 }
+                unawaited(_refresh());
+              } else if (result == true) {
+                await _refresh();
               }
             }),
             const SizedBox(height: 16),
@@ -128,11 +134,11 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Create Sport',
-              icon: Icons.sports_soccer_outlined,
+              icon: Icons.sports_martial_arts_outlined,
               onTap: () async {
                 final created = await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => AddSportPage()),
+                  MaterialPageRoute(builder: (_) => const EditSportPage()),
                 );
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -167,9 +173,14 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 8),
             if (_activities.isEmpty)
               _EmptyState(onCreate: () async {
-                final created = await Navigator.push(
+                final result = await Navigator.push(
                     context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-                if (created == true) {
+                if (result is Activity) {
+                  setState(() {
+                    _activities.insert(0, result);
+                  });
+                  unawaited(_refresh());
+                } else if (result == true) {
                   await _refresh();
                 }
               })

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -62,7 +62,7 @@ class ActivityService {
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
-  Future<void> createActivity(
+  Future<Activity> createActivity(
     int sport,
     int discipline,
     int? variant,
@@ -71,14 +71,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -89,13 +89,15 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.post('/activities/', data: form);
+      final res = await apiClient.post('/activities/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
+      rethrow;
     }
   }
 
-  Future<void> updateActivity(
+  Future<Activity> updateActivity(
     int id,
     int sport,
     int discipline,
@@ -105,14 +107,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -123,9 +125,11 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.patch('/activities/$id/', data: form);
+      final res = await apiClient.patch('/activities/$id/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
+      rethrow;
     }
   }
 

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -28,36 +28,99 @@ class FacilityService {
         .toList(growable: false);
   }
 
-  Future<void> createFacility(
+  Future<Facility> createFacility(
       String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.post('/facilities/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.post('/merchant/facilities/', data: data);
+      return _parseFacility(res.data);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.post('/facilities/', data: data);
+        return _parseFacility(res.data);
+      }
+      _rethrowFieldErrors(e);
+      rethrow;
+    }
   }
 
   Future<List<Facility>> fetchMine() async {
     return fetchFacilities([], 0, 0, 0, mine: true);
   }
 
-  Future<void> updateFacility(
+  Future<Facility> updateFacility(
       int id, String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.patch('/facilities/$id/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.patch('/merchant/facilities/$id/', data: data);
+      return _parseFacility(res.data);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.patch('/facilities/$id/', data: data);
+        return _parseFacility(res.data);
+      }
+      _rethrowFieldErrors(e);
+      rethrow;
+    }
   }
 
   Future<void> deleteFacility(int id) async {
-    await apiClient.delete('/facilities/$id/');
+    try {
+      await apiClient.delete('/merchant/facilities/$id/');
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        await apiClient.delete('/facilities/$id/');
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  Facility _parseFacility(dynamic data) {
+    final map = Map<String, dynamic>.from(data as Map);
+    if (!map.containsKey('geometry')) {
+      map['geometry'] = {
+        'coordinates': [map['lng'], map['lat']]
+      };
+    }
+    return Facility.fromJson(map);
+  }
+
+  void _rethrowFieldErrors(DioException e) {
+    if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
+      final data = e.response?.data;
+      if (data is Map<String, dynamic>) {
+        final map = <String, List<String>>{};
+        data.forEach((key, value) {
+          if (value is List) {
+            map[key] = value.map((v) => v.toString()).toList();
+          } else {
+            map[key] = [value.toString()];
+          }
+        });
+        throw DioException(
+          requestOptions: e.requestOptions,
+          response: e.response,
+          type: e.type,
+          error: map,
+        );
+      }
+    }
+    throw e;
   }
 
   Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -52,11 +52,8 @@ class SportsService {
         .toList(growable: false);
   }
 
-  Future<void> createSport({required String name, String? description}) async {
-    await apiClient.post('/sports/', data: {
-      'name': name,
-      if (description != null) 'description': description,
-    });
+  Future<void> createSport(String name) async {
+    await apiClient.post('/sports/', data: {'name': name});
   }
 }
 

--- a/test/add_activity_page_test.dart
+++ b/test/add_activity_page_test.dart
@@ -8,10 +8,11 @@ import 'package:sports_booking_app/services/api_client.dart';
 import 'package:sports_booking_app/screens/add_activity_page.dart';
 import 'package:sports_booking_app/services/activity_service.dart';
 import 'package:sports_booking_app/providers/org_provider.dart';
+import 'package:sports_booking_app/models/activity.dart';
 
 class _ThrowingActivityService extends ActivityService {
   @override
-  Future<void> createActivity(
+  Future<Activity> createActivity(
       int sport,
       int discipline,
       int? variant,
@@ -20,7 +21,7 @@ class _ThrowingActivityService extends ActivityService {
       int difficulty,
       int duration,
       double basePrice,
-      {required int organizationId,
+      {int? organizationId,
       XFile? imageFile}) async {
     throw Exception('boom');
   }

--- a/test/add_facility_page_test.dart
+++ b/test/add_facility_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 import 'package:sports_booking_app/models/category.dart';
+import 'package:sports_booking_app/models/facility.dart';
 import 'package:sports_booking_app/screens/add_facility_page.dart';
 import 'package:sports_booking_app/services/facility_service.dart';
 import 'package:sports_booking_app/services/sports_service.dart';
@@ -10,10 +11,17 @@ import 'package:geocoding/geocoding.dart';
 class _FakeFacilityService extends FacilityService {
   List<int>? seen;
   @override
-  Future<void> createFacility(
+  Future<Facility> createFacility(
       String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
+      {int radius = 1000}) async {
     seen = categories;
+    return Facility(
+        id: 1,
+        name: name,
+        lat: lat,
+        lng: lng,
+        radius: radius.toDouble(),
+        categories: categories.map((e) => e.toString()).toList());
   }
 }
 


### PR DESCRIPTION
## Summary
- auto-fill activity organization from user's default and relax serializer requirement
- allow activity creation without org selection in UI and insert result instantly
- add simple sport creation flow and enhance facility creation with address geocoding

## Testing
- `python -m pytest` *(fails: Could not find the GDAL library)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899fc02e0a08326b7c8dd1ee0a96006