### PR TITLE
Fix provider checks for activity and facility creation

### DIFF
--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -5,6 +5,8 @@ from .models import OrganizationMember
 class IsVendor(BasePermission):
     """Allows access only to users with a VendorProfile."""
 
+    message = "You need a provider account to perform this action."  # NEW:
+
     def has_permission(self, request, view):
         return request.user and hasattr(request.user, "vendorprofile")
 

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -191,6 +191,20 @@ class ActivitySerializer(serializers.ModelSerializer):
         return value
 
     def validate(self, attrs):
+        request = self.context.get("request")
+        if request and request.method == "POST":  # NEW: only on create
+            user = request.user
+            if not hasattr(user, "vendorprofile"):
+                raise serializers.ValidationError(
+                    {"non_field_errors": ["Only providers can create activities."]}
+                )
+            org = attrs.get("organization")
+            if org and not OrganizationMember.objects.filter(
+                organization=org, user=user
+            ).exists():
+                raise serializers.ValidationError(
+                    {"organization": "You are not a member of this organization."}
+                )
         variant = attrs.get("variant")
         discipline = attrs.get("discipline")
         if variant and discipline and variant.discipline_id != discipline.id:
@@ -202,17 +216,6 @@ class ActivitySerializer(serializers.ModelSerializer):
         if len(desc) > 500:
             raise serializers.ValidationError({"description": "Max 500 characters"})
         return attrs
-
-    def validate_organization(self, value):
-        request = self.context.get("request")
-        user = getattr(request, "user", None)
-        if user is None:
-            return value
-        if not OrganizationMember.objects.filter(
-            organization=value, user=user
-        ).exists():
-            raise serializers.ValidationError("Not a member of this organization")
-        return value
 
 
 class ActivitySimpleSerializer(serializers.ModelSerializer):

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -46,6 +46,94 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   List<Category> categories = [];
   List<Variant> variants = [];
 
+  Future<void> _submit() async { // NEW: handle submission with organization check
+    fieldErrors = {};
+    if (!_formKey.currentState!.validate()) return;
+    final orgId = ref.read(selectedOrgProvider);
+    if (orgId == null) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: const Text(
+              'You need an organization to create activities.'),
+          action: SnackBarAction(
+            label: 'Become a Provider',
+            onPressed: () => Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (_) => const ProviderRegistrationPage()),
+            ),
+          ),
+        ),
+      );
+      return;
+    }
+    setState(() => _submitting = true);
+    try {
+      if (widget.activity == null) {
+        await widget.service.createActivity(
+          sportId!,
+          disciplineId!,
+          variantId,
+          titleCtrl.text.trim(),
+          descCtrl.text.trim(),
+          difficulty,
+          int.parse(durationCtrl.text),
+          double.parse(priceCtrl.text),
+          organizationId: orgId,
+          imageFile: _imageFile,
+        );
+      } else {
+        await widget.service.updateActivity(
+          widget.activity!.id,
+          sportId!,
+          disciplineId!,
+          variantId,
+          titleCtrl.text.trim(),
+          descCtrl.text.trim(),
+          difficulty,
+          int.parse(durationCtrl.text),
+          double.parse(priceCtrl.text),
+          organizationId: orgId,
+          imageFile: _imageFile,
+        );
+      }
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text(
+              widget.activity == null ? 'Activity created' : 'Activity updated'),
+        ),
+      );
+      Navigator.pop(context, true);
+    } on DioException catch (e) {
+      final err = e.error;
+      if (err is Map<String, List<String>>) {
+        setState(() {
+          fieldErrors =
+              err.map((k, v) => MapEntry(k, v.join(', ')));
+        });
+      } else if (mounted) {
+        showApiError(
+            context,
+            e,
+            widget.activity == null ? 'Create activity' : 'Update activity');
+      }
+    } catch (e) {
+      if (mounted) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          SnackBar(
+            content: Text(widget.activity == null
+                ? 'Create activity failed: $e'
+                : 'Update activity failed: $e'),
+          ),
+        );
+      }
+    } finally {
+      if (mounted) setState(() => _submitting = false);
+    }
+  }
+
   @override
   void initState() {
     super.initState();
@@ -90,6 +178,9 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
             return const Center(child: CircularProgressIndicator());
           }
           final orgsAsync = ref.watch(orgsProvider);
+          final orgId = ref.watch(selectedOrgProvider); // NEW: watch selected org
+          final orgs = orgsAsync.value ?? [];
+          final canSubmit = !_submitting && orgId != null && orgs.isNotEmpty; // NEW: enable only when org selected
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Form(
@@ -194,87 +285,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                   _imagePickerField(),
                   const SizedBox(height: 20),
                   ElevatedButton(
-                    onPressed: _submitting
-                        ? null
-                        : () async {
-                            fieldErrors = {};
-                            if (!_formKey.currentState!.validate()) return;
-                            final orgId = ref.read(selectedOrgProvider);
-                            if (orgId == null) {
-                              setState(() {
-                                fieldErrors['organization'] = 'Required';
-                              });
-                              return;
-                            }
-                            setState(() => _submitting = true);
-                            try {
-                              if (widget.activity == null) {
-                                await widget.service.createActivity(
-                                  sportId!,
-                                  disciplineId!,
-                                  variantId,
-                                  titleCtrl.text.trim(),
-                                  descCtrl.text.trim(),
-                                  difficulty,
-                                  int.parse(durationCtrl.text),
-                                  double.parse(priceCtrl.text),
-                                  organizationId: orgId,
-                                  imageFile: _imageFile,
-                                );
-                              } else {
-                                await widget.service.updateActivity(
-                                  widget.activity!.id,
-                                  sportId!,
-                                  disciplineId!,
-                                  variantId,
-                                  titleCtrl.text.trim(),
-                                  descCtrl.text.trim(),
-                                  difficulty,
-                                  int.parse(durationCtrl.text),
-                                  double.parse(priceCtrl.text),
-                                  organizationId: orgId,
-                                  imageFile: _imageFile,
-                                );
-                              }
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(widget.activity == null
-                                        ? 'Activity created'
-                                        : 'Activity updated'),
-                                  ),
-                                );
-                                Navigator.pop(context, true);
-                              }
-                            } on DioException catch (e) {
-                              final err = e.error;
-                              if (err is Map<String, List<String>>) {
-                                setState(() {
-                                  fieldErrors =
-                                      err.map((k, v) => MapEntry(k, v.join(', ')));
-                                });
-                              } else if (context.mounted) {
-                                showApiError(
-                                    context,
-                                    e,
-                                    widget.activity == null
-                                        ? 'Create activity'
-                                        : 'Update activity');
-                              }
-                            } catch (e) {
-                              if (context.mounted) {
-                                ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(
-                                    content: Text(widget.activity == null
-                                        ? 'Create activity failed: $e'
-                                        : 'Update activity failed: $e'),
-                                  ),
-                                );
-                              }
-                            } finally {
-                              if (mounted) setState(() => _submitting = false);
-                            }
-                          },
+                    onPressed: canSubmit ? _submit : null,
                     child: _submitting
                         ? const SizedBox(
                             height: 20,
@@ -299,32 +310,21 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           return Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.info_outline),
-                    const SizedBox(width: 8),
-                    const Expanded(
-                        child: Text(
-                            'No organisations found. Create or join one first.')),
-                  ],
-                ),
-              ),
               const SizedBox(height: 8),
-              ElevatedButton(
+              const Text(
+                  'You need a provider account and an organization to create activities.'),
+              const SizedBox(height: 8),
+              OutlinedButton.icon(
+                icon: const Icon(Icons.store),
+                label: const Text('Become a Provider'),
                 onPressed: () async {
                   await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (_) => const ProviderRegistrationPage()));
-                  ref.invalidate(orgsProvider);
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => const ProviderRegistrationPage()),
+                  );
+                  ref.invalidate(orgsProvider); // NEW: refresh orgs after returning
                 },
-                child: const Text('Create/Join Organization'),
               ),
             ],
           );

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -8,6 +8,7 @@ import '../services/facility_service.dart';
 import '../services/sports_service.dart' as sport_service;
 import '../services/location_service.dart';
 import '../utils/snackbar.dart';
+import 'provider_registration_page.dart'; // NEW: allow navigation to registration
 
 class AddFacilityPage extends StatefulWidget {
   final Facility? facility;
@@ -196,8 +197,33 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                               }
                               if (context.mounted) Navigator.pop(context, true);
                             } on DioException catch (e) {
-                              if (context.mounted) {
-                                showApiError(context, e, 'Save facility');
+                              final status = e.response?.statusCode; // NEW:
+                              final detail = () { // NEW:
+                                final d = e.response?.data;
+                                if (d is Map && d['detail'] != null) {
+                                  return d['detail'].toString();
+                                }
+                                return e.message ?? e.toString();
+                              }();
+                              if (status == 403) { // NEW: provider required
+                                if (!mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text(
+                                          'You need a provider account to create facilities.')),
+                                );
+                                await Navigator.push(
+                                  context,
+                                  MaterialPageRoute(
+                                      builder: (_) => const ProviderRegistrationPage()),
+                                );
+                              } else {
+                                if (!mounted) return;
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(
+                                      content:
+                                          Text('Save facility failed: $detail')),
+                                );
                               }
                             } catch (e) {
                               if (context.mounted) {

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -58,8 +58,8 @@ void initAuthInterceptor() {
   apiClient.interceptors.add(
     InterceptorsWrapper(
       onRequest: (options, handler) async {
-        // BUG: sending expired access token to refresh endpoint => 401
-        if (!options.path.contains('token/refresh')) {
+        final isRefresh = options.path.contains('token/refresh'); // NEW: detect refresh
+        if (!isRefresh) { // NEW:
           final token = await _storage.read(key: 'access');
           if (token != null) {
             options.headers['Authorization'] = 'Bearer $token';
@@ -68,8 +68,10 @@ void initAuthInterceptor() {
         handler.next(options);
       },
       onError: (err, handler) async {
+        final isRefresh =
+            err.requestOptions.path.contains('token/refresh'); // NEW: detect refresh in error
         if (err.response?.statusCode == 401 &&
-            !err.requestOptions.path.contains('token/refresh') &&
+            !isRefresh &&
             err.requestOptions.extra['__retry'] != true) {
           final refresh = await _storage.read(key: 'refresh');
           if (refresh != null) {


### PR DESCRIPTION
## Summary
- add provider guidance and disable Create button until organization selected
- show clear facility creation errors and provider registration link on 403
- add server-side validations and permission message for providers

## Testing
- `flutter analyze` *(fails: command not found)*
- `pytest` *(fails: 19 failed, 38 passed, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_6899fca379c883269cd556fa9f7ffac9