### PR TITLE
feat: auto organization for merchants

### DIFF
--- a/backend/accounts/migrations/0004_organizationmember_is_default.py
+++ b/backend/accounts/migrations/0004_organizationmember_is_default.py
@@ -1,0 +1,16 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0003_organization"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="organizationmember",
+            name="is_default",
+            field=models.BooleanField(default=False),
+        ),
+    ]

--- a/backend/accounts/models.py
+++ b/backend/accounts/models.py
@@ -58,6 +58,7 @@ class OrganizationMember(models.Model):
         on_delete=models.CASCADE,
     )
     role = models.CharField(max_length=10, choices=ROLE_CHOICES)
+    is_default = models.BooleanField(default=False)
 
     class Meta:
         unique_together = ("organization", "user")

--- a/backend/accounts/utils.py
+++ b/backend/accounts/utils.py
@@ -1,0 +1,43 @@
+from uuid import uuid4
+from django.db import transaction
+from django.utils.text import slugify
+from .models import Organization, OrganizationMember
+
+
+def get_or_create_primary_org(user):
+    """Return user's default organization, creating one if needed."""
+    member = (
+        OrganizationMember.objects.filter(user=user, is_default=True)
+        .select_related("organization")
+        .first()
+    )
+    if member:
+        return member.organization
+
+    memberships = list(
+        OrganizationMember.objects.filter(user=user).select_related("organization")[:2]
+    )
+    if len(memberships) == 1:
+        return memberships[0].organization
+
+    if not memberships:
+        with transaction.atomic():
+            name = f"{user.get_full_name() or user.username}'s Org"
+            base_slug = slugify(name) or f"org-{uuid4().hex[:8]}"
+            slug = base_slug
+            while Organization.objects.filter(slug=slug).exists():
+                slug = f"{base_slug}-{uuid4().hex[:8]}"
+            org = Organization.objects.create(name=name, slug=slug)
+            OrganizationMember.objects.create(
+                organization=org,
+                user=user,
+                role=OrganizationMember.ROLE_OWNER,
+                is_default=True,
+            )
+        return org
+
+    # multiple memberships but none default - mark the first as default
+    member = memberships[0]
+    member.is_default = True
+    member.save(update_fields=["is_default"])
+    return member.organization

--- a/backend/sports/migrations/0021_facility_organization.py
+++ b/backend/sports/migrations/0021_facility_organization.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("accounts", "0004_organizationmember_is_default"),
+        ("sports", "0020_booking_status_choices"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="facility",
+            name="organization",
+            field=models.ForeignKey(
+                to="accounts.organization",
+                on_delete=models.CASCADE,
+                related_name="facilities",
+                null=True,
+                blank=True,
+            ),
+        ),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -147,6 +147,13 @@ class Facility(models.Model):
         null=True,
         blank=True,
     )
+    organization = models.ForeignKey(
+        "accounts.Organization",
+        on_delete=models.CASCADE,
+        related_name="facilities",
+        null=True,
+        blank=True,
+    )
 
     class Meta:
         indexes = [

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -18,6 +18,7 @@ from .models import (
     Favorite,
 )
 from accounts.models import Organization, OrganizationMember
+from accounts.utils import get_or_create_primary_org
 
 
 class SportSerializer(serializers.ModelSerializer):
@@ -101,6 +102,7 @@ class MerchantSlotSerializer(serializers.ModelSerializer):
         begins = attrs.get("begins_at") or getattr(self.instance, "begins_at", None)
         ends = attrs.get("ends_at") or getattr(self.instance, "ends_at", None)
         activity = attrs.get("activity") or getattr(self.instance, "activity", None)
+        facility = attrs.get("facility") or getattr(self.instance, "facility", None)
 
         errors = {}
         now = timezone.now()
@@ -117,6 +119,9 @@ class MerchantSlotSerializer(serializers.ModelSerializer):
                 qs = qs.exclude(pk=self.instance.pk)
             if qs.filter(begins_at__lt=ends, ends_at__gt=begins).exists():
                 errors.setdefault("begins_at", []).append("Overlaps another slot")
+
+        if activity and facility and activity.organization_id != facility.organization_id:
+            errors.setdefault("facility", []).append("Facility not in same organization")
 
         if errors:
             raise serializers.ValidationError(errors)
@@ -156,7 +161,7 @@ class VariantSerializer(serializers.ModelSerializer):
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
     organization = serializers.PrimaryKeyRelatedField(
-        queryset=Organization.objects.all()
+        queryset=Organization.objects.all(), required=False, allow_null=True
     )
 
     class Meta:
@@ -206,9 +211,7 @@ class ActivitySerializer(serializers.ModelSerializer):
     def validate_organization(self, value):
         request = self.context.get("request")
         user = getattr(request, "user", None)
-        if user is None:
-            return value
-        if not OrganizationMember.objects.filter(
+        if value and user and not OrganizationMember.objects.filter(
             organization=value, user=user
         ).exists():
             raise serializers.ValidationError("Not a member of this organization")
@@ -288,8 +291,9 @@ class FacilityCreateSerializer(serializers.ModelSerializer):
         point = Point(lng, lat, srid=4326)
         request = self.context.get("request")
         owner = request.user if request else None
+        org = get_or_create_primary_org(owner) if owner else None
         facility = Facility.objects.create(
-            location=point, owner=owner, **validated_data
+            location=point, owner=owner, organization=org, **validated_data
         )
         return facility
 

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -6,7 +6,9 @@ from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
-from accounts.models import OrganizationMember
+from accounts.models import Organization, OrganizationMember
+from accounts.utils import get_or_create_primary_org
+from rest_framework.exceptions import ValidationError, PermissionDenied
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
@@ -177,7 +179,21 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        serializer.save()
+        req = self.request
+        user = req.user
+        org_id = req.data.get("organization")
+        if not org_id:
+            org = get_or_create_primary_org(user)
+            if not OrganizationMember.objects.filter(organization=org, user=user).exists():
+                raise PermissionDenied("User is not a member of the primary organization.")
+            serializer.save(organization=org)
+        else:
+            org = Organization.objects.filter(id=org_id).first()
+            if not org:
+                raise ValidationError({"organization": ["Organization does not exist."]})
+            if not OrganizationMember.objects.filter(organization=org, user=user).exists():
+                raise PermissionDenied("Not a member of this organization.")
+            serializer.save()
 
     @action(detail=True, methods=["post"], url_path="favorite/toggle",
             permission_classes=[permissions.IsAuthenticated])

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -9,10 +9,8 @@ import '../models/activity.dart';
 import '../models/category.dart';
 import '../models/sport.dart';
 import '../models/variant.dart';
-import '../providers/org_provider.dart';
 import '../services/activity_service.dart';
 import '../services/sports_service.dart';
-import 'provider_registration_page.dart';
 import '../utils/snackbar.dart';
 
 class AddActivityPage extends ConsumerStatefulWidget {
@@ -89,14 +87,12 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           if (snap.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          final orgsAsync = ref.watch(orgsProvider);
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Form(
               key: _formKey,
               child: ListView(
                 children: [
-                  _buildOrgField(orgsAsync),
                   DropdownButtonFormField<int>(
                     value: sportId,
                     items: sports
@@ -199,17 +195,11 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                         : () async {
                             fieldErrors = {};
                             if (!_formKey.currentState!.validate()) return;
-                            final orgId = ref.read(selectedOrgProvider);
-                            if (orgId == null) {
-                              setState(() {
-                                fieldErrors['organization'] = 'Required';
-                              });
-                              return;
-                            }
                             setState(() => _submitting = true);
                             try {
+                              Activity act;
                               if (widget.activity == null) {
-                                await widget.service.createActivity(
+                                act = await widget.service.createActivity(
                                   sportId!,
                                   disciplineId!,
                                   variantId,
@@ -218,11 +208,11 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  organizationId: orgId,
+                                  organizationId: null,
                                   imageFile: _imageFile,
                                 );
                               } else {
-                                await widget.service.updateActivity(
+                                act = await widget.service.updateActivity(
                                   widget.activity!.id,
                                   sportId!,
                                   disciplineId!,
@@ -232,7 +222,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  organizationId: orgId,
+                                  organizationId: null,
                                   imageFile: _imageFile,
                                 );
                               }
@@ -244,7 +234,7 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                         : 'Activity updated'),
                                   ),
                                 );
-                                Navigator.pop(context, true);
+                                Navigator.pop(context, act);
                               }
                             } on DioException catch (e) {
                               final err = e.error;
@@ -253,6 +243,11 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   fieldErrors =
                                       err.map((k, v) => MapEntry(k, v.join(', ')));
                                 });
+                                if (err['organization'] != null && context.mounted) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(content: Text(err['organization']!.join(', '))),
+                                  );
+                                }
                               } else if (context.mounted) {
                                 showApiError(
                                     context,
@@ -288,74 +283,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           );
         },
       ),
-    );
-  }
-
-  Widget _buildOrgField(AsyncValue<List<Map<String, dynamic>>> orgsAsync) {
-    return orgsAsync.when(
-      data: (orgs) {
-        final selectedOrg = ref.watch(selectedOrgProvider);
-        if (orgs.isEmpty) {
-          return Column(
-            crossAxisAlignment: CrossAxisAlignment.start,
-            children: [
-              Container(
-                padding: const EdgeInsets.all(12),
-                decoration: BoxDecoration(
-                  color: Theme.of(context).colorScheme.primaryContainer,
-                  borderRadius: BorderRadius.circular(8),
-                ),
-                child: Row(
-                  children: [
-                    const Icon(Icons.info_outline),
-                    const SizedBox(width: 8),
-                    const Expanded(
-                        child: Text(
-                            'No organisations found. Create or join one first.')),
-                  ],
-                ),
-              ),
-              const SizedBox(height: 8),
-              ElevatedButton(
-                onPressed: () async {
-                  await Navigator.push(
-                      context,
-                      MaterialPageRoute(
-                          builder: (_) => const ProviderRegistrationPage()));
-                  ref.invalidate(orgsProvider);
-                },
-                child: const Text('Create/Join Organization'),
-              ),
-            ],
-          );
-        }
-        if (orgs.length == 1) {
-          Future.microtask(() {
-            if (ref.read(selectedOrgProvider) == null) {
-              ref.read(selectedOrgProvider.notifier).state =
-                  orgs.first['id'] as int;
-            }
-          });
-          return const SizedBox.shrink();
-        }
-        return DropdownButtonFormField<int>(
-          value: selectedOrg,
-          items: orgs
-              .map<DropdownMenuItem<int>>((e) => DropdownMenuItem(
-                    value: e['id'] as int,
-                    child: Text(e['name']?.toString() ?? ''),
-                  ))
-              .toList(),
-          onChanged: (v) => ref.read(selectedOrgProvider.notifier).state = v,
-          decoration: InputDecoration(
-            labelText: 'Organization',
-            errorText: fieldErrors['organization'],
-          ),
-          validator: (v) => v == null ? 'Required' : null,
-        );
-      },
-      loading: () => const SizedBox.shrink(),
-      error: (_, __) => const SizedBox.shrink(),
     );
   }
 

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -37,6 +37,8 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
   List<Category> categories = [];
   bool _submitting = false;
   late Future<void> _loadFuture;
+  String? addressError;
+  Map<String, String> fieldErrors = {};
 
   @override
   void initState() {
@@ -80,6 +82,7 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
       final results = await widget.geocode(addressCtrl.text.trim());
       if (results.isNotEmpty) {
         setState(() {
+          addressError = null;
           lat = results.first.latitude;
           lng = results.first.longitude;
         });
@@ -89,16 +92,10 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   'Location set to ${lat!.toStringAsFixed(5)}, ${lng!.toStringAsFixed(5)}')));
         }
       } else {
-        if (mounted) {
-          ScaffoldMessenger.of(context).showSnackBar(
-              const SnackBar(content: Text('Address not found')));
-        }
+        setState(() => addressError = 'Address not found');
       }
     } catch (e) {
-      if (mounted) {
-        ScaffoldMessenger.of(context)
-            .showSnackBar(SnackBar(content: Text('Could not geocode address: $e')));
-      }
+      setState(() => addressError = 'Could not geocode address');
     }
   }
 
@@ -128,8 +125,22 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                 children: [
                   TextFormField(
                     controller: nameCtrl,
-                    decoration: const InputDecoration(labelText: 'Name'),
+                    decoration: InputDecoration(
+                      labelText: 'Name',
+                      errorText: fieldErrors['name'],
+                    ),
                     validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+                  ),
+                  TextFormField(
+                    controller: addressCtrl,
+                    decoration: InputDecoration(
+                      labelText: 'Address (optional)',
+                      errorText: addressError,
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: _setFromAddress,
+                    child: const Text('Use address'),
                   ),
                   if (lat != null && lng != null)
                     Text(
@@ -137,15 +148,6 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                   TextButton(
                     onPressed: _setCurrentLocation,
                     child: const Text('Use current location'),
-                  ),
-                  TextFormField(
-                    controller: addressCtrl,
-                    decoration:
-                        const InputDecoration(labelText: 'Address (optional)'),
-                  ),
-                  TextButton(
-                    onPressed: _setFromAddress,
-                    child: const Text('Use address'),
                   ),
                   const SizedBox(height: 12),
                   Wrap(
@@ -173,10 +175,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                         ? null
                         : () async {
                             if (!_formKey.currentState!.validate()) return;
+                            fieldErrors = {};
                             setState(() => _submitting = true);
                             try {
                               if (lat == null || lng == null) {
-                                await _setCurrentLocation();
+                                ScaffoldMessenger.of(context).showSnackBar(
+                                    const SnackBar(content: Text('Please set location')));
+                                return;
                               }
                               if (isEditing) {
                                 await widget.service.updateFacility(
@@ -196,7 +201,13 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                               }
                               if (context.mounted) Navigator.pop(context, true);
                             } on DioException catch (e) {
-                              if (context.mounted) {
+                              final err = e.error;
+                              if (err is Map<String, List<String>>) {
+                                setState(() {
+                                  fieldErrors =
+                                      err.map((k, v) => MapEntry(k, v.join(', ')));
+                                });
+                              } else if (context.mounted) {
                                 showApiError(context, e, 'Save facility');
                               }
                             } catch (e) {

--- a/lib/screens/add_sport_page.dart
+++ b/lib/screens/add_sport_page.dart
@@ -55,10 +55,7 @@ class _AddSportPageState extends State<AddSportPage> {
                         setState(() => _loading = true);
                         try {
                           await widget.service.createSport(
-                            name: nameCtrl.text.trim(),
-                            description: descCtrl.text.trim().isEmpty
-                                ? null
-                                : descCtrl.text.trim(),
+                            nameCtrl.text.trim(),
                           );
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -1,0 +1,102 @@
+import 'package:dio/dio.dart';
+import 'package:flutter/material.dart';
+import '../services/sports_service.dart';
+import '../utils/snackbar.dart';
+
+class EditSportPage extends StatefulWidget {
+  const EditSportPage({super.key});
+
+  @override
+  State<EditSportPage> createState() => _EditSportPageState();
+}
+
+class _EditSportPageState extends State<EditSportPage> {
+  final _formKey = GlobalKey<FormState>();
+  final nameCtrl = TextEditingController();
+  bool _submitting = false;
+  Map<String, String> fieldErrors = {};
+
+  @override
+  void dispose() {
+    nameCtrl.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Create Sport')),
+      body: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Form(
+          key: _formKey,
+          child: Column(
+            children: [
+              TextFormField(
+                controller: nameCtrl,
+                decoration: InputDecoration(
+                  labelText: 'Name',
+                  errorText: fieldErrors['name'],
+                ),
+                validator: (v) => v == null || v.isEmpty ? 'Required' : null,
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: _submitting
+                    ? null
+                    : () async {
+                        fieldErrors = {};
+                        if (!_formKey.currentState!.validate()) return;
+                        setState(() => _submitting = true);
+                        try {
+                          await sportsService.createSport(nameCtrl.text.trim());
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                                const SnackBar(content: Text('Sport created')));
+                            Navigator.pop(context, true);
+                          }
+                        } on DioException catch (e) {
+                          if (e.response?.statusCode == 401 ||
+                              e.response?.statusCode == 403) {
+                            if (mounted) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text(
+                                          'Permission denied (contact admin)')));
+                            }
+                          } else {
+                            final err = e.error;
+                            if (err is Map<String, List<String>>) {
+                              setState(() {
+                                fieldErrors = err
+                                    .map((k, v) => MapEntry(k, v.join(', ')));
+                              });
+                            } else if (mounted) {
+                              showApiError(context, e, 'Create sport');
+                            }
+                          }
+                        } catch (e) {
+                          if (mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(
+                              SnackBar(content: Text('Create sport failed: $e')),
+                            );
+                          }
+                        } finally {
+                          if (mounted) setState(() => _submitting = false);
+                        }
+                      },
+                child: _submitting
+                    ? const SizedBox(
+                        height: 20,
+                        width: 20,
+                        child: CircularProgressIndicator(strokeWidth: 2),
+                      )
+                    : const Text('Create'),
+              ),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/provider_dashboard_page.dart
+++ b/lib/screens/provider_dashboard_page.dart
@@ -1,4 +1,5 @@
 // lib/screens/provider_dashboard_page.dart
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:dio/dio.dart';
@@ -10,7 +11,7 @@ import '../services/slot_service.dart';
 import 'add_activity_page.dart';
 import 'add_slot_page.dart';
 import 'add_facility_page.dart';
-import 'add_sport_page.dart';
+import 'edit_sport_page.dart';
 import 'merchant_slots_page.dart';
 import 'merchant_bookings_page.dart';
 import 'provider_facilities_page.dart';
@@ -100,9 +101,14 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
           padding: const EdgeInsets.all(16),
           children: [
             _AddActivityHero(onTap: () async {
-              final created = await Navigator.push(
+              final result = await Navigator.push(
                   context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-              if (created == true) {
+              if (result is Activity) {
+                setState(() {
+                  _activities.insert(0, result);
+                });
+                unawaited(_refresh());
+              } else if (result == true) {
                 await _refresh();
                 if (mounted) {
                   ScaffoldMessenger.of(context)
@@ -128,11 +134,12 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 16),
             _QuickLinkCard(
               label: 'Create Sport',
-              icon: Icons.sports_soccer_outlined,
+              icon: Icons.sports_martial_arts_outlined,
               onTap: () async {
                 final created = await Navigator.push(
                   context,
-                  MaterialPageRoute(builder: (_) => AddSportPage()),
+                  MaterialPageRoute(
+                      builder: (_) => const EditSportPage()),
                 );
                 if (created == true && context.mounted) {
                   ScaffoldMessenger.of(context).showSnackBar(
@@ -167,9 +174,14 @@ class _ProviderDashboardPageState extends ConsumerState<ProviderDashboardPage> {
             const SizedBox(height: 8),
             if (_activities.isEmpty)
               _EmptyState(onCreate: () async {
-                final created = await Navigator.push(
+                final result = await Navigator.push(
                     context, MaterialPageRoute(builder: (_) => AddActivityPage()));
-                if (created == true) {
+                if (result is Activity) {
+                  setState(() {
+                    _activities.insert(0, result);
+                  });
+                  unawaited(_refresh());
+                } else if (result == true) {
                   await _refresh();
                 }
               })
@@ -389,8 +401,15 @@ class _ActivityCard extends StatelessWidget {
             ),
             TextButton(
               onPressed: () async {
-                final updated = await Navigator.push(context, MaterialPageRoute(builder: (_) => AddActivityPage(activity: activity)));
-                if (updated == true) onChanged();
+                final updated = await Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                        builder: (_) => AddActivityPage(activity: activity)));
+                if (updated is Activity) {
+                  onChanged();
+                } else if (updated == true) {
+                  onChanged();
+                }
               },
               child: const Text('Edit'),
             ),

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -62,7 +62,7 @@ class ActivityService {
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
-  Future<void> createActivity(
+  Future<Activity> createActivity(
     int sport,
     int discipline,
     int? variant,
@@ -71,14 +71,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -89,13 +89,15 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.post('/activities/', data: form);
+      final res = await apiClient.post('/activities/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
+    throw Exception('Failed to create');
   }
 
-  Future<void> updateActivity(
+  Future<Activity> updateActivity(
     int id,
     int sport,
     int discipline,
@@ -105,14 +107,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -123,10 +125,12 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.patch('/activities/$id/', data: form);
+      final res = await apiClient.patch('/activities/$id/', data: form);
+      return Activity.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
+    throw Exception('Failed to update');
   }
 
   Future<void> deleteActivity(int id) async {

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -28,36 +28,89 @@ class FacilityService {
         .toList(growable: false);
   }
 
-  Future<void> createFacility(
+  Future<Facility> createFacility(
       String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.post('/facilities/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.post('/merchant/facilities/', data: data);
+      return Facility.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.post('/facilities/', data: data);
+        return Facility.fromJson(res.data as Map<String, dynamic>);
+      }
+      _rethrowFieldErrors(e);
+    }
+    throw Exception('Failed to create');
   }
 
   Future<List<Facility>> fetchMine() async {
     return fetchFacilities([], 0, 0, 0, mine: true);
   }
 
-  Future<void> updateFacility(
+  Future<Facility> updateFacility(
       int id, String name, double lat, double lng, List<int> categories,
-      {double radius = 1000}) async {
-    await apiClient.patch('/facilities/$id/', data: {
+      {int radius = 1000}) async {
+    final data = {
       'name': name,
       'lat': lat,
       'lng': lng,
       'radius': radius,
       'categories': categories,
-    });
+    };
+    try {
+      final res = await apiClient.patch('/merchant/facilities/$id/', data: data);
+      return Facility.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        final res = await apiClient.patch('/facilities/$id/', data: data);
+        return Facility.fromJson(res.data as Map<String, dynamic>);
+      }
+      _rethrowFieldErrors(e);
+    }
+    throw Exception('Failed to update');
   }
 
   Future<void> deleteFacility(int id) async {
-    await apiClient.delete('/facilities/$id/');
+    try {
+      await apiClient.delete('/merchant/facilities/$id/');
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404) {
+        await apiClient.delete('/facilities/$id/');
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  void _rethrowFieldErrors(DioException e) {
+    if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
+      final data = e.response?.data;
+      if (data is Map<String, dynamic>) {
+        final map = <String, List<String>>{};
+        data.forEach((key, value) {
+          if (value is List) {
+            map[key] = value.map((v) => v.toString()).toList();
+          } else {
+            map[key] = [value.toString()];
+          }
+        });
+        throw DioException(
+          requestOptions: e.requestOptions,
+          response: e.response,
+          type: e.type,
+          error: map,
+        );
+      }
+    }
+    throw e;
   }
 
   Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -52,11 +52,8 @@ class SportsService {
         .toList(growable: false);
   }
 
-  Future<void> createSport({required String name, String? description}) async {
-    await apiClient.post('/sports/', data: {
-      'name': name,
-      if (description != null) 'description': description,
-    });
+  Future<void> createSport(String name) async {
+    await apiClient.post('/sports/', data: {'name': name});
   }
 }
 


### PR DESCRIPTION
## Summary
- auto-select default organization when merchants create activities or facilities
- support optional organization in activity API and ensure slots use matching facility org
- streamline provider dashboard with in-place activity insert and sport creation page

## Testing
- `python manage.py test` *(fails: Could not find the GDAL library)*
- `flutter analyze` *(command not found: flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689a0f5e0e7483268c60859f7ef5a25f