### PR TITLE
Enable default org for activities and streamline creation flows

### DIFF
--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -18,6 +18,7 @@ from .models import (
     Favorite,
 )
 from accounts.models import Organization, OrganizationMember
+from rest_framework.exceptions import PermissionDenied
 
 
 class SportSerializer(serializers.ModelSerializer):
@@ -156,7 +157,7 @@ class VariantSerializer(serializers.ModelSerializer):
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
     organization = serializers.PrimaryKeyRelatedField(
-        queryset=Organization.objects.all()
+        queryset=Organization.objects.all(), required=False, allow_null=True
     )
 
     class Meta:
@@ -204,6 +205,8 @@ class ActivitySerializer(serializers.ModelSerializer):
         return attrs
 
     def validate_organization(self, value):
+        if value is None:
+            return value
         request = self.context.get("request")
         user = getattr(request, "user", None)
         if user is None:
@@ -211,7 +214,7 @@ class ActivitySerializer(serializers.ModelSerializer):
         if not OrganizationMember.objects.filter(
             organization=value, user=user
         ).exists():
-            raise serializers.ValidationError("Not a member of this organization")
+            raise PermissionDenied("Not a member of this organization.")
         return value
 
 

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -6,7 +6,8 @@ from django.db.models import Q
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
-from accounts.models import OrganizationMember
+from accounts.models import Organization, OrganizationMember
+from rest_framework.exceptions import ValidationError, PermissionDenied
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
@@ -129,6 +130,18 @@ class VariantViewSet(viewsets.ReadOnlyModelViewSet):
     permission_classes = [permissions.AllowAny]
 
 
+def _get_default_org_for_user(user):
+    default = getattr(user, "primary_org", None)
+    if default:
+        return default
+    memberships = list(
+        OrganizationMember.objects.filter(user=user).select_related("organization")[:2]
+    )
+    if len(memberships) == 1:
+        return memberships[0].organization
+    return None
+
+
 class ActivityViewSet(viewsets.ModelViewSet):
     serializer_class = ActivitySerializer
     pagination_class = DefaultPagination
@@ -141,7 +154,9 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return [p() if isinstance(p, type) else p for p in perms]
 
     def get_queryset(self):
-        qs = Activity.objects.select_related("sport", "discipline", "variant", "organization")
+        qs = Activity.objects.select_related(
+            "sport", "discipline", "variant", "organization"
+        )
         if self.action in ("update", "partial_update", "destroy"):
             qs = qs.filter(organization__members__user=self.request.user)
         mine = self.request.query_params.get("mine")
@@ -177,14 +192,39 @@ class ActivityViewSet(viewsets.ModelViewSet):
         return super().list(request, *args, **kwargs)
 
     def perform_create(self, serializer):
-        serializer.save()
+        request = self.request
+        data_org_id = request.data.get("organization")
+        if not data_org_id:
+            org = _get_default_org_for_user(request.user)
+            if not org:
+                raise ValidationError(
+                    {"organization": ["No default organization for current user."]}
+                )
+            if not OrganizationMember.objects.filter(
+                organization=org, user=request.user
+            ).exists():
+                raise PermissionDenied("Not a member of the default organization.")
+            serializer.save(organization=org)
+        else:
+            org = Organization.objects.filter(id=data_org_id).first()
+            if not org:
+                raise ValidationError(
+                    {"organization": ["Organization does not exist."]}
+                )
+            if not OrganizationMember.objects.filter(
+                organization=org, user=request.user
+            ).exists():
+                raise PermissionDenied("Not a member of this organization.")
+            serializer.save()
 
-    @action(detail=True, methods=["post"], url_path="favorite/toggle",
-            permission_classes=[permissions.IsAuthenticated])
+    @action(
+        detail=True,
+        methods=["post"],
+        url_path="favorite/toggle",
+        permission_classes=[permissions.IsAuthenticated],
+    )
     def favorite_toggle(self, request, pk=None):
-        fav, created = Favorite.objects.get_or_create(
-            user=request.user, activity_id=pk
-        )
+        fav, created = Favorite.objects.get_or_create(user=request.user, activity_id=pk)
         if not created:
             fav.delete()
             return Response({"favorited": False})
@@ -286,10 +326,7 @@ class BookingViewSet(viewsets.ModelViewSet):
         # connection when listing bookings (My Bookings → "connection closed").
         # FIX: only join the Slot; facility id is enough for clients
         # (covers: My Bookings list).
-        return (
-            Booking.objects.filter(user=self.request.user)
-            .select_related("slot")
-        )
+        return Booking.objects.filter(user=self.request.user).select_related("slot")
 
     @transaction.atomic
     def create(self, request, *args, **kwargs):
@@ -356,18 +393,16 @@ class ContinuePlanningView(APIView):
 
     def get(self, request):
         user = request.user
-        histories = (
-            UserActivityHistory.objects.filter(user=user)
-            .order_by("-timestamp")[:20]
-        )
+        histories = UserActivityHistory.objects.filter(user=user).order_by(
+            "-timestamp"
+        )[:20]
         act_ids = []
         for h in histories:
             if h.activity_id not in act_ids:
                 act_ids.append(h.activity_id)
 
-        unfinished = (
-            Booking.objects.filter(user=user, paid=False)
-            .values_list("activity_id", flat=True)
+        unfinished = Booking.objects.filter(user=user, paid=False).values_list(
+            "activity_id", flat=True
         )
         for aid in unfinished:
             if aid and aid not in act_ids:
@@ -375,9 +410,7 @@ class ContinuePlanningView(APIView):
 
         acts = {a.id: a for a in Activity.objects.filter(id__in=act_ids)}
         ordered = [acts[a] for a in act_ids if a in acts]
-        ser = ActivitySimpleSerializer(
-            ordered, many=True, context={"request": request}
-        )
+        ser = ActivitySimpleSerializer(ordered, many=True, context={"request": request})
         return Response(ser.data)
 
 
@@ -488,17 +521,20 @@ class MerchantBookingList(APIView):
         return Response(ser.data)
 
 
-class FavoriteViewSet(viewsets.GenericViewSet,
-                      mixins.ListModelMixin,
-                      mixins.CreateModelMixin,
-                      mixins.DestroyModelMixin):
+class FavoriteViewSet(
+    viewsets.GenericViewSet,
+    mixins.ListModelMixin,
+    mixins.CreateModelMixin,
+    mixins.DestroyModelMixin,
+):
     permission_classes = [permissions.IsAuthenticated]
     serializer_class = FavoriteSerializer
     pagination_class = DefaultPagination
 
     def get_queryset(self):
         return Favorite.objects.filter(user=self.request.user).select_related(
-            "activity")
+            "activity"
+        )
 
     def create(self, request, *args, **kwargs):
         activity_id = request.data.get("activity")
@@ -507,9 +543,7 @@ class FavoriteViewSet(viewsets.GenericViewSet,
         fav, created = Favorite.objects.get_or_create(
             user=request.user, activity_id=activity_id
         )
-        status_code = (
-            status.HTTP_201_CREATED if created else status.HTTP_200_OK
-        )
+        status_code = status.HTTP_201_CREATED if created else status.HTTP_200_OK
         return Response({"favorited": True}, status=status_code)
 
     def destroy(self, request, pk=None):

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -46,16 +46,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
   List<Category> categories = [];
   List<Variant> variants = [];
 
-  bool get _orgReady {
-    final a = ref.watch(orgsProvider);
-    if (a is AsyncData<List<Map<String, dynamic>>>) {
-      final list = a.value ?? const [];
-      final sel = ref.read(selectedOrgProvider);
-      return list.isNotEmpty && sel != null;
-    }
-    return false;
-  }
-
   @override
   void initState() {
     super.initState();
@@ -204,18 +194,12 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                   _imagePickerField(),
                   const SizedBox(height: 20),
                   ElevatedButton(
-                    onPressed: _submitting || !_orgReady
+                    onPressed: _submitting
                         ? null
                         : () async {
                             fieldErrors = {};
                             if (!_formKey.currentState!.validate()) return;
                             final orgId = ref.read(selectedOrgProvider);
-                            if (orgId == null) {
-                              setState(() {
-                                fieldErrors['organization'] = 'Required';
-                              });
-                              return;
-                            }
                             setState(() => _submitting = true);
                             try {
                               Activity created;
@@ -362,7 +346,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
             labelText: 'Organization',
             errorText: fieldErrors['organization'],
           ),
-          validator: (v) => v == null ? 'Required' : null,
         );
       },
       loading: () => const Padding(

--- a/lib/screens/edit_sport_page.dart
+++ b/lib/screens/edit_sport_page.dart
@@ -48,7 +48,7 @@ class _EditSportPageState extends State<EditSportPage> {
                         setState(() => _loading = true);
                         try {
                           await widget.service
-                              .createSportSimple(nameCtrl.text.trim());
+                              .createSport(name: nameCtrl.text.trim());
                           if (context.mounted) {
                             ScaffoldMessenger.of(context).showSnackBar(
                                 const SnackBar(content: Text('Sport created')));

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -71,14 +71,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -107,14 +107,14 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId,
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
+      if (organizationId != null) 'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,


### PR DESCRIPTION
## Summary
- default organization is auto-filled on activity creation with membership checks
- organization field made optional and validated, and frontend creation flow no longer requires preselected org
- simple sport creation page hooks into service

## Testing
- `python -m black backend/sports/views.py backend/sports/serializers.py`
- `flutter format lib/services/activity_service.dart lib/screens/add_activity_page.dart lib/screens/edit_sport_page.dart` *(fails: command not found)*
- `pytest` *(fails: No module named 'PlayNexus')*


------
https://chatgpt.com/codex/tasks/task_e_689a10a1ef2883268eebcf40fd762c0d