### PR TITLE
Bind provider resources to single organization

### DIFF
--- a/backend/accounts/permissions.py
+++ b/backend/accounts/permissions.py
@@ -5,6 +5,8 @@ from .models import OrganizationMember
 class IsVendor(BasePermission):
     """Allows access only to users with a VendorProfile."""
 
+    message = "You need a provider account to perform this action."
+
     def has_permission(self, request, view):
         return request.user and hasattr(request.user, "vendorprofile")
 

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -17,7 +17,7 @@ from .models import (
     FeaturedActivity,
     Favorite,
 )
-from accounts.models import Organization, OrganizationMember
+from accounts.models import Organization
 
 
 class SportSerializer(serializers.ModelSerializer):
@@ -155,9 +155,7 @@ class VariantSerializer(serializers.ModelSerializer):
 
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
-    organization = serializers.PrimaryKeyRelatedField(
-        queryset=Organization.objects.all()
-    )
+    organization = serializers.PrimaryKeyRelatedField(read_only=True)
 
     class Meta:
         model = Activity
@@ -176,7 +174,7 @@ class ActivitySerializer(serializers.ModelSerializer):
             "base_price",
             "is_nearby",
         )
-        read_only_fields = ("id", "image")
+        read_only_fields = ("id", "image", "organization")
 
     def get_image_url(self, obj):
         if obj.image:
@@ -203,16 +201,17 @@ class ActivitySerializer(serializers.ModelSerializer):
             raise serializers.ValidationError({"description": "Max 500 characters"})
         return attrs
 
-    def validate_organization(self, value):
+    def create(self, validated_data):
         request = self.context.get("request")
-        user = getattr(request, "user", None)
-        if user is None:
-            return value
-        if not OrganizationMember.objects.filter(
-            organization=value, user=user
-        ).exists():
-            raise serializers.ValidationError("Not a member of this organization")
-        return value
+        if not hasattr(request.user, "vendorprofile"):
+            raise serializers.ValidationError(
+                {"detail": "Only providers can create activities."}
+            )
+        from sports.utils.orgs import get_or_create_single_org_for_user
+
+        org = get_or_create_single_org_for_user(request.user)
+        validated_data["organization"] = org
+        return super().create(validated_data)
 
 
 class ActivitySimpleSerializer(serializers.ModelSerializer):

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -174,7 +174,7 @@ class ActivitySerializer(serializers.ModelSerializer):
             "base_price",
             "is_nearby",
         )
-        read_only_fields = ("id", "image", "organization")
+        read_only_fields = ("id", "organization")
 
     def get_image_url(self, obj):
         if obj.image:

--- a/backend/sports/utils/orgs.py
+++ b/backend/sports/utils/orgs.py
@@ -1,0 +1,40 @@
+from django.utils.text import slugify
+from accounts.models import Organization, OrganizationMember
+
+
+def get_or_create_single_org_for_user(user):
+    """Return the provider's single organization, creating if needed.
+
+    Picks an existing owner organization if available, otherwise the earliest
+    membership. If none exist, creates a new organization and assigns the user
+    as owner.
+    """
+    assert hasattr(user, "vendorprofile"), "user must be a provider (has VendorProfile)."
+
+    owner_member = (
+        OrganizationMember.objects.filter(user=user, role="owner")
+        .select_related("organization")
+        .order_by("organization__created_at", "organization__id")
+        .first()
+    )
+    if owner_member:
+        org = owner_member.organization
+    else:
+        member = (
+            OrganizationMember.objects.filter(user=user)
+            .select_related("organization")
+            .order_by("organization__created_at", "organization__id")
+            .first()
+        )
+        if member:
+            org = member.organization
+        else:
+            name = f"{user.username or 'provider'}-{user.id}"
+            org = Organization.objects.create(name=name, slug=slugify(name))
+            OrganizationMember.objects.get_or_create(
+                organization=org, user=user, defaults={"role": "owner"}
+            )
+    OrganizationMember.objects.get_or_create(
+        organization=org, user=user, defaults={"role": "owner"}
+    )
+    return org

--- a/lib/screens/add_activity_page.dart
+++ b/lib/screens/add_activity_page.dart
@@ -89,14 +89,15 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
           if (snap.connectionState != ConnectionState.done) {
             return const Center(child: CircularProgressIndicator());
           }
-          final orgsAsync = ref.watch(orgsProvider);
+          // TODO: remove after full deprecation
+          ref.watch(selectedOrgProvider);
           return Padding(
             padding: const EdgeInsets.all(16),
             child: Form(
               key: _formKey,
               child: ListView(
                 children: [
-                  _buildOrgField(orgsAsync),
+                  // _buildOrgField(orgsAsync), // deprecated
                   DropdownButtonFormField<int>(
                     value: sportId,
                     items: sports
@@ -199,13 +200,8 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                         : () async {
                             fieldErrors = {};
                             if (!_formKey.currentState!.validate()) return;
-                            final orgId = ref.read(selectedOrgProvider);
-                            if (orgId == null) {
-                              setState(() {
-                                fieldErrors['organization'] = 'Required';
-                              });
-                              return;
-                            }
+                            // TODO: remove after full deprecation
+                            ref.read(selectedOrgProvider);
                             setState(() => _submitting = true);
                             try {
                               if (widget.activity == null) {
@@ -218,7 +214,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  organizationId: orgId,
                                   imageFile: _imageFile,
                                 );
                               } else {
@@ -232,7 +227,6 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                   difficulty,
                                   int.parse(durationCtrl.text),
                                   double.parse(priceCtrl.text),
-                                  organizationId: orgId,
                                   imageFile: _imageFile,
                                 );
                               }
@@ -260,6 +254,26 @@ class _AddActivityPageState extends ConsumerState<AddActivityPage> {
                                     widget.activity == null
                                         ? 'Create activity'
                                         : 'Update activity');
+                                if (e.response?.statusCode == 403) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: const Text(
+                                          'You need a provider account to create activities.'),
+                                      action: SnackBarAction(
+                                        label: 'Become a Provider',
+                                        onPressed: () {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (_) =>
+                                                  const ProviderRegistrationPage(),
+                                            ),
+                                          );
+                                        },
+                                      ),
+                                    ),
+                                  );
+                                }
                               }
                             } catch (e) {
                               if (context.mounted) {

--- a/lib/screens/add_facility_page.dart
+++ b/lib/screens/add_facility_page.dart
@@ -8,6 +8,7 @@ import '../services/facility_service.dart';
 import '../services/sports_service.dart' as sport_service;
 import '../services/location_service.dart';
 import '../utils/snackbar.dart';
+import 'provider_registration_page.dart';
 
 class AddFacilityPage extends StatefulWidget {
   final Facility? facility;
@@ -198,6 +199,26 @@ class _AddFacilityPageState extends State<AddFacilityPage> {
                             } on DioException catch (e) {
                               if (context.mounted) {
                                 showApiError(context, e, 'Save facility');
+                                if (e.response?.statusCode == 403) {
+                                  ScaffoldMessenger.of(context).showSnackBar(
+                                    SnackBar(
+                                      content: const Text(
+                                          'You need a provider account to create facilities.'),
+                                      action: SnackBarAction(
+                                        label: 'Become a Provider',
+                                        onPressed: () {
+                                          Navigator.push(
+                                            context,
+                                            MaterialPageRoute(
+                                              builder: (_) =>
+                                                  const ProviderRegistrationPage(),
+                                            ),
+                                          );
+                                        },
+                                      ),
+                                    ),
+                                  );
+                                }
                               }
                             } catch (e) {
                               if (context.mounted) {

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -71,14 +71,13 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId, // ignored, for backward compatibility
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,
@@ -105,14 +104,13 @@ class ActivityService {
     int difficulty,
     int duration,
     double basePrice, {
-    required int organizationId,
+    int? organizationId, // ignored, for backward compatibility
     XFile? imageFile,
   }) async {
     final form = FormData.fromMap({
       'sport': sport,
       'discipline': discipline,
       if (variant != null) 'variant': variant,
-      'organization': organizationId,
       'title': title,
       'description': description,
       'difficulty': difficulty,


### PR DESCRIPTION
## Summary
- auto-assign provider's sole organization on backend
- remove organization selection from activity/facility creation
- handle missing provider permissions with user-friendly prompts

## Testing
- `python manage.py check`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a12f296f8832698e032bb607196df