### PR TITLE
feat: add merchant slot management

### DIFF
--- a/lib/models/slot.dart
+++ b/lib/models/slot.dart
@@ -5,6 +5,8 @@ class Slot {
   Slot({
     required this.id,
     required this.sport,
+    required this.activityId,
+    this.facilityId,
     required this.title,
     required this.location,
     required this.beginsAt,
@@ -17,6 +19,8 @@ class Slot {
 
   final int      id;
   final Sport    sport;
+  final int      activityId;
+  final int?     facilityId;
   final String   title;
   final String   location;
   final DateTime beginsAt;
@@ -42,16 +46,18 @@ class Slot {
     }
 
     return Slot(
-      id:        j['id']               as int,
-      sport:     sport,
-      title:     j['title']            as String,
-      location:  j['location']         as String,
-      beginsAt:  DateTime.parse(j['begins_at'] as String),
-      endsAt:    DateTime.parse(j['ends_at']   as String),
-      capacity:  j['capacity']         as int,
-      price:     double.parse(j['price'].toString()),
-      rating:    double.parse(j['rating'].toString()),
-      seatsLeft: j['seats_left']       as int? ?? j['capacity'] as int,
+      id:         j['id']               as int,
+      sport:      sport,
+      activityId: j['activity']         as int,
+      facilityId: j['facility']         as int?,
+      title:      j['title']            as String,
+      location:   j['location']         as String,
+      beginsAt:   DateTime.parse(j['begins_at'] as String),
+      endsAt:     DateTime.parse(j['ends_at']   as String),
+      capacity:   j['capacity']         as int,
+      price:      double.parse(j['price'].toString()),
+      rating:     double.parse(j['rating'].toString()),
+      seatsLeft:  j['seats_left']       as int? ?? j['capacity'] as int,
     );
   }
 
@@ -59,6 +65,8 @@ class Slot {
   Map<String, dynamic> toJson() => {
     'id'        : id,
     'sport'     : sport.id,
+    'activity'  : activityId,
+    if (facilityId != null) 'facility': facilityId,
     'title'     : title,
     'location'  : location,
     'begins_at' : beginsAt.toIso8601String(),

--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -1,12 +1,16 @@
 import 'package:flutter/material.dart';
 import 'package:dio/dio.dart';
 import '../models/facility.dart';
+import '../models/slot.dart';
 import '../services/facility_service.dart';
 import '../services/slot_service.dart';
 
 class AddSlotPage extends StatefulWidget {
-  final int activityId;
-  const AddSlotPage({super.key, required this.activityId});
+  final int? activityId;
+  final Slot? slot;
+  const AddSlotPage({super.key, this.activityId, this.slot})
+      : assert(activityId != null || slot != null,
+            'Either activityId or slot must be provided');
 
   @override
   State<AddSlotPage> createState() => _AddSlotPageState();
@@ -28,6 +32,16 @@ class _AddSlotPageState extends State<AddSlotPage> {
   @override
   void initState() {
     super.initState();
+    if (widget.slot != null) {
+      final s = widget.slot!;
+      start = s.beginsAt;
+      end = s.endsAt;
+      capacityCtrl.text = s.capacity.toString();
+      priceCtrl.text = s.price.toStringAsFixed(2);
+      titleCtrl.text = s.title;
+      locationCtrl.text = s.location;
+      _facilityId = s.facilityId;
+    }
     facilityService.fetchMine().then((list) {
       if (mounted) setState(() => _facilities = list);
     });
@@ -45,7 +59,8 @@ class _AddSlotPageState extends State<AddSlotPage> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('Create Slot')),
+      appBar: AppBar(
+          title: Text(widget.slot == null ? 'Create Slot' : 'Edit Slot')),
       body: Padding(
         padding: const EdgeInsets.all(16),
         child: Form(
@@ -152,16 +167,28 @@ class _AddSlotPageState extends State<AddSlotPage> {
                         }
                         setState(() => _submitting = true);
                         try {
-                          await slotService.createSlot(
-                            widget.activityId,
-                            start!,
-                            end!,
-                            int.parse(capacityCtrl.text),
-                            double.parse(priceCtrl.text),
-                            titleCtrl.text,
-                            locationCtrl.text,
-                            facilityId: _facilityId!,
-                          );
+                          if (widget.slot == null) {
+                            await slotService.createSlot(
+                              widget.activityId!,
+                              start!,
+                              end!,
+                              int.parse(capacityCtrl.text),
+                              double.parse(priceCtrl.text),
+                              titleCtrl.text,
+                              locationCtrl.text,
+                              facilityId: _facilityId!,
+                            );
+                          } else {
+                            await slotService.updateMerchantSlot(widget.slot!.id, {
+                              'facility': _facilityId,
+                              'begins_at': start!.toIso8601String(),
+                              'ends_at': end!.toIso8601String(),
+                              'capacity': int.parse(capacityCtrl.text),
+                              'price': double.parse(priceCtrl.text),
+                              'title': titleCtrl.text,
+                              'location': locationCtrl.text,
+                            });
+                          }
                           if (context.mounted) Navigator.pop(context, true);
                         } on DioException catch (e) {
                           if (e.error is Map<String, List<String>>) {
@@ -172,7 +199,7 @@ class _AddSlotPageState extends State<AddSlotPage> {
                             });
                           } else {
                             ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('Failed to create slot')));
+                                const SnackBar(content: Text('Failed to save slot')));
                           }
                         } finally {
                           if (mounted) setState(() => _submitting = false);
@@ -184,7 +211,7 @@ class _AddSlotPageState extends State<AddSlotPage> {
                         width: 20,
                         child: CircularProgressIndicator(strokeWidth: 2),
                       )
-                    : const Text('Create'),
+                    : Text(widget.slot == null ? 'Create' : 'Save'),
               ),
             ],
           ),

--- a/lib/screens/merchant_slots_page.dart
+++ b/lib/screens/merchant_slots_page.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
 import '../models/slot.dart';
 import '../services/slot_service.dart';
+import '../services/activity_service.dart';
+import 'add_slot_page.dart';
 
 class MerchantSlotsPage extends StatefulWidget {
   const MerchantSlotsPage({super.key});
@@ -54,6 +56,38 @@ class _MerchantSlotsPageState extends State<MerchantSlotsPage> {
     }
   }
 
+  Future<int?> _pickActivity() async {
+    try {
+      final page = await activityService.fetchMine();
+      final activities = page.results;
+      if (activities.isEmpty) {
+        if (mounted) {
+          ScaffoldMessenger.of(context)
+              .showSnackBar(const SnackBar(content: Text('No activities found')));
+        }
+        return null;
+      }
+      return showDialog<int>(
+        context: context,
+        builder: (ctx) => SimpleDialog(
+          title: const Text('Select Activity'),
+          children: activities
+              .map((a) => SimpleDialogOption(
+                    onPressed: () => Navigator.pop(ctx, a.id),
+                    child: Text(a.title),
+                  ))
+              .toList(),
+        ),
+      );
+    } catch (_) {
+      if (mounted) {
+        ScaffoldMessenger.of(context)
+            .showSnackBar(const SnackBar(content: Text('Failed to load activities')));
+      }
+      return null;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -62,35 +96,114 @@ class _MerchantSlotsPageState extends State<MerchantSlotsPage> {
           ? const Center(child: CircularProgressIndicator())
           : RefreshIndicator(
               onRefresh: _refresh,
-              child: ListView.builder(
-                itemCount: _slots.length + 1,
-                itemBuilder: (context, index) {
-                  if (index == _slots.length) {
-                    if (_loadingMore) {
-                      return const Padding(
-                        padding: EdgeInsets.all(16),
-                        child: Center(child: CircularProgressIndicator()),
-                      );
-                    } else if (_next != null) {
-                      _loadMore();
-                      return const SizedBox();
-                    } else {
-                      return const SizedBox(height: 80);
-                    }
-                  }
-                  final s = _slots[index];
-                  return Card(
-                    margin: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
-                    child: ListTile(
-                      title: Text(s.title),
-                      subtitle: Text(
-                          '${s.beginsAt.toLocal()} - ${s.endsAt.toLocal()}'),
-                      trailing: Text(s.price.toStringAsFixed(2)),
+              child: _slots.isEmpty
+                  ? ListView(
+                      children: const [
+                        SizedBox(height: 200),
+                        Center(child: Text('No slots. Tap + to create.')),
+                      ],
+                    )
+                  : ListView.builder(
+                      itemCount: _slots.length + 1,
+                      itemBuilder: (context, index) {
+                        if (index == _slots.length) {
+                          if (_loadingMore) {
+                            return const Padding(
+                              padding: EdgeInsets.all(16),
+                              child: Center(child: CircularProgressIndicator()),
+                            );
+                          } else if (_next != null) {
+                            _loadMore();
+                            return const SizedBox();
+                          } else {
+                            return const SizedBox(height: 80);
+                          }
+                        }
+                        final s = _slots[index];
+                        return Card(
+                          margin:
+                              const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+                          child: ListTile(
+                            title: Text(s.title),
+                            subtitle: Text(
+                                '${s.beginsAt.toLocal()} - ${s.endsAt.toLocal()}'),
+                            trailing: Row(
+                              mainAxisSize: MainAxisSize.min,
+                              children: [
+                                Text(s.price.toStringAsFixed(2)),
+                                IconButton(
+                                  icon: const Icon(Icons.edit),
+                                  onPressed: () async {
+                                    final updated = await Navigator.push(
+                                      context,
+                                      MaterialPageRoute(
+                                          builder: (_) => AddSlotPage(slot: s)),
+                                    );
+                                    if (updated == true) {
+                                      await _refresh();
+                                      if (mounted) {
+                                        ScaffoldMessenger.of(context).showSnackBar(
+                                            const SnackBar(content: Text('Slot updated')));
+                                      }
+                                    }
+                                  },
+                                ),
+                                IconButton(
+                                  icon: const Icon(Icons.delete),
+                                  onPressed: () async {
+                                    final confirm = await showDialog<bool>(
+                                      context: context,
+                                      builder: (ctx) => AlertDialog(
+                                        title: const Text('Delete slot?'),
+                                        content: const Text(
+                                            'This action cannot be undone.'),
+                                        actions: [
+                                          TextButton(
+                                              onPressed: () => Navigator.pop(ctx, false),
+                                              child: const Text('Cancel')),
+                                          TextButton(
+                                              onPressed: () => Navigator.pop(ctx, true),
+                                              child: const Text('Delete')),
+                                        ],
+                                      ),
+                                    );
+                                    if (confirm == true) {
+                                      await slotService.deleteMerchantSlot(s.id);
+                                      await _refresh();
+                                      if (mounted) {
+                                        ScaffoldMessenger.of(context).showSnackBar(
+                                            const SnackBar(content: Text('Slot deleted')));
+                                      }
+                                    }
+                                  },
+                                ),
+                              ],
+                            ),
+                          ),
+                        );
+                      },
                     ),
-                  );
-                },
-              ),
             ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final activityId = await _pickActivity();
+          if (activityId != null) {
+            final created = await Navigator.push(
+              context,
+              MaterialPageRoute(
+                  builder: (_) => AddSlotPage(activityId: activityId)),
+            );
+            if (created == true) {
+              await _refresh();
+              if (mounted) {
+                ScaffoldMessenger.of(context)
+                    .showSnackBar(const SnackBar(content: Text('Slot created')));
+              }
+            }
+          }
+        },
+        child: const Icon(Icons.add),
+      ),
     );
   }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # ── requirements.txt ──
-Django==5.2.3
+Django[gis]==5.2.3
 djangorestframework==3.16.0
 djangorestframework-simplejwt==5.3.1
 django-cors-headers==4.3.1
@@ -9,6 +9,7 @@ dj-rest-auth==5.0.1
 django-allauth==0.61.1
 google-auth==2.29.0
 djangorestframework-gis==1.2.0
+GDAL==3.8.4
 whitenoise==6.6.0
 Pillow==11.3.0
 stripe==9.8.0


### PR DESCRIPTION
## Summary
- support activity and facility IDs in Slot model
- allow editing slots and reuse form for updates
- implement full CRUD UI for merchant slots with activity picker

## Testing
- `dart format lib/models/slot.dart lib/screens/add_slot_page.dart lib/screens/merchant_slots_page.dart` *(fails: command not found)*
- `cd backend && pytest` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689a2b3bebb8832681943f77c487f2a0