### PR TITLE
feat: enhance merchant slot querying

### DIFF
--- a/backend/sports/merchant_views.py
+++ b/backend/sports/merchant_views.py
@@ -5,7 +5,7 @@ from rest_framework.pagination import CursorPagination
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
-from django.db.models import F
+from django.db.models import F, Q
 from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse, OpenApiParameter, OpenApiTypes
 
 from .models import Slot, Booking
@@ -20,11 +20,43 @@ class MerchantSlotViewSet(viewsets.ModelViewSet):
     permission_classes = [permissions.IsAuthenticated, IsVendor]
 
     def get_queryset(self):
+        """Return slots belonging to the current vendor with optional filters."""
         user = self.request.user
-        return Slot.objects.filter(
-            activity__organization__members__user=user,
-            is_active=True,
-        )
+        qs = Slot.objects.filter(activity__organization__members__user=user)
+
+        params = self.request.query_params
+
+        # active filter – default to active only
+        active = params.get("active")
+        if active in ("0", "false", "False"):
+            qs = qs.filter(is_active=False)
+        else:
+            qs = qs.filter(is_active=True)
+
+        activity_id = params.get("activity")
+        if activity_id:
+            qs = qs.filter(activity_id=activity_id)
+
+        after = params.get("after")
+        if after:
+            dt = parse_datetime(after)
+            if dt:
+                qs = qs.filter(begins_at__gte=dt)
+
+        before = params.get("before")
+        if before:
+            dt = parse_datetime(before)
+            if dt:
+                qs = qs.filter(begins_at__lte=dt)
+
+        keyword = params.get("q")
+        if keyword:
+            qs = qs.filter(Q(title__icontains=keyword) | Q(location__icontains=keyword))
+
+        ordering = params.get("ordering") or "-begins_at"
+        if ordering not in ("begins_at", "-begins_at"):
+            ordering = "-begins_at"
+        return qs.order_by(ordering)
 
     def get_serializer_class(self):
         if self.action in ("create", "update", "partial_update"):

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -108,6 +108,8 @@ class MerchantSlotSerializer(serializers.ModelSerializer):
         if begins and ends:
             if begins.date() != ends.date():
                 errors["ends_at"] = ["Must not cross days"]
+            if begins >= ends:
+                errors.setdefault("ends_at", []).append("Must be after begins_at")
             if begins < now:
                 errors["begins_at"] = ["Must be in the future"]
 
@@ -117,6 +119,14 @@ class MerchantSlotSerializer(serializers.ModelSerializer):
                 qs = qs.exclude(pk=self.instance.pk)
             if qs.filter(begins_at__lt=ends, ends_at__gt=begins).exists():
                 errors.setdefault("begins_at", []).append("Overlaps another slot")
+
+        capacity = attrs.get("capacity")
+        if capacity is not None and capacity <= 0:
+            errors.setdefault("capacity", []).append("Must be > 0")
+
+        price = attrs.get("price")
+        if price is not None and price < 0:
+            errors.setdefault("price", []).append("Must be >= 0")
 
         if errors:
             raise serializers.ValidationError(errors)

--- a/backend/sports/urls.py
+++ b/backend/sports/urls.py
@@ -33,12 +33,15 @@ router.register(r"slots",     SlotViewSet,     basename="slot")
 router.register(r"bookings",  BookingViewSet,  basename="booking")
 router.register(r"favorites", FavoriteViewSet, basename="favorite")
 router.register(r"merchant/slots", MerchantSlotViewSet, basename="merchant-slots")
-urlpatterns = router.urls + [
+urlpatterns = [
+    # bulk delete must come before router patterns so it isn't captured as a pk
+    path("merchant/slots/bulk-delete/", MerchantSlotBulkDeleteView.as_view()),
+]
+urlpatterns += router.urls + [
     path("slots/bulk/", BulkSlotCreateView.as_view(), name="slot-bulk"),
     path("merchant/bookings/", MerchantBookingList.as_view()),
     path("merchant/bookings/paged/", MerchantBookingListPaged.as_view()),
     path("merchant/bookings/<int:pk>/cancel/", MerchantBookingCancelView.as_view()),
-    path("merchant/slots/bulk-delete/", MerchantSlotBulkDeleteView.as_view()),
     path("activities/<int:activity_id>/reviews/", ActivityReviewList.as_view(), name="activity-reviews"),
     path("home/continue-planning/", ContinuePlanningView.as_view()),
 ]

--- a/lib/screens/merchant_slots_page.dart
+++ b/lib/screens/merchant_slots_page.dart
@@ -25,7 +25,7 @@ class _MerchantSlotsPageState extends State<MerchantSlotsPage> {
   Future<void> _refresh() async {
     setState(() => _loading = true);
     try {
-      final page = await slotService.fetchMine(page: 1);
+      final page = await slotService.fetchMineAdvanced(page: 1);
       setState(() {
         _slots
           ..clear()
@@ -43,7 +43,7 @@ class _MerchantSlotsPageState extends State<MerchantSlotsPage> {
     setState(() => _loadingMore = true);
     try {
       final nextPage = _page + 1;
-      final page = await slotService.fetchMine(page: nextPage);
+      final page = await slotService.fetchMineAdvanced(page: nextPage);
       setState(() {
         _slots.addAll(page.results);
         _next = page.next;

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -138,12 +138,51 @@ class SlotService {
     return Paginated.fromJson(data, (j) => Slot.fromJson(j));
   }
 
+  Future<Paginated<Slot>> fetchMineAdvanced({
+    int page = 1,
+    int? activityId,
+    DateTime? after,
+    DateTime? before,
+    bool? active,
+    String? q,
+    String? ordering,
+  }) async {
+    final params = <String, dynamic>{'page': page};
+    if (activityId != null) params['activity'] = activityId;
+    if (after != null) params['after'] = _iso(after);
+    if (before != null) params['before'] = _iso(before);
+    if (active != null) params['active'] = active ? '1' : '0';
+    if (q != null && q.isNotEmpty) params['q'] = q;
+    if (ordering != null) params['ordering'] = ordering;
+
+    final res = await apiClient.get('/merchant/slots/', queryParameters: params);
+    final dynamic payload = res.data;
+    if (payload is Map<String, dynamic>) {
+      return Paginated.fromJson(payload, (j) => Slot.fromJson(j));
+    } else if (payload is List) {
+      // Backend without pagination support
+      return Paginated.fromJson(
+          {'next': null, 'previous': null, 'results': payload},
+          (j) => Slot.fromJson(j));
+    } else {
+      throw const FormatException('Unexpected response');
+    }
+  }
+
   Future<void> updateMerchantSlot(int id, Map<String, dynamic> patch) async {
     await apiClient.patch('/merchant/slots/$id/', data: patch);
   }
 
   Future<void> deleteMerchantSlot(int id) async {
     await apiClient.delete('/merchant/slots/$id/');
+  }
+
+  Future<Map<String, dynamic>> bulkDelete(List<int> ids) async {
+    final res = await apiClient.delete(
+      '/merchant/slots/bulk-delete/',
+      data: {'ids': ids},
+    );
+    return Map<String, dynamic>.from(res.data as Map);
   }
 }
 


### PR DESCRIPTION
## Summary
- support filtering, search and ordering for merchant slots
- tighten slot validation for time and numeric fields
- expose advanced merchant slot list and bulk delete helpers
- adjust merchant slots page to use advanced pagination
- ensure bulk-delete route resolves before slot detail routes

## Testing
- `pytest tests/test_merchant_slots.py -q`
- `python manage.py check`
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689a2cb3560883268d3d90e34f85a0bc