### PR TITLE
Fix facility creation and enable pysqlite3

### DIFF
--- a/backend/PlayNexus/asgi.py
+++ b/backend/PlayNexus/asgi.py
@@ -8,6 +8,14 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
 """
 
 import os
+import sys
+
+# Ensure pysqlite3 is available when using SQLite + SpatiaLite
+try:  # pragma: no cover
+    import pysqlite3 as sqlite3  # type: ignore
+    sys.modules["sqlite3"] = sqlite3
+except Exception:  # pragma: no cover
+    pass
 
 from django.core.asgi import get_asgi_application
 

--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -44,6 +44,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "django.contrib.staticfiles",
+    "django.contrib.gis",
 
     # 3rd-party
     "rest_framework",

--- a/backend/PlayNexus/wsgi.py
+++ b/backend/PlayNexus/wsgi.py
@@ -8,6 +8,14 @@ https://docs.djangoproject.com/en/5.2/howto/deployment/wsgi/
 """
 
 import os
+import sys
+
+# Ensure pysqlite3 is available when using SQLite + SpatiaLite
+try:  # pragma: no cover
+    import pysqlite3 as sqlite3  # type: ignore
+    sys.modules["sqlite3"] = sqlite3
+except Exception:  # pragma: no cover
+    pass
 
 from django.core.wsgi import get_wsgi_application
 from whitenoise import WhiteNoise

--- a/backend/manage.py
+++ b/backend/manage.py
@@ -4,6 +4,13 @@ import os
 import sys
 from dotenv import load_dotenv
 
+# Ensure pysqlite3 is used for SpatiaLite support
+try:  # pragma: no cover - fallback for environments without pysqlite3
+    import pysqlite3 as sqlite3  # type: ignore
+    sys.modules["sqlite3"] = sqlite3
+except Exception:  # pragma: no cover
+    pass
+
 # Load environment variables for local runs (project root .env)
 load_dotenv(os.path.join(os.path.dirname(__file__), "..", ".env"))
 

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -284,12 +284,15 @@ class FacilityCreateSerializer(serializers.ModelSerializer):
     def create(self, validated_data):
         lat = validated_data.pop("lat")
         lng = validated_data.pop("lng")
+        categories = validated_data.pop("categories", [])
         point = Point(lng, lat, srid=4326)
         request = self.context.get("request")
         owner = request.user if request else None
         facility = Facility.objects.create(
             location=point, owner=owner, **validated_data
         )
+        if categories:
+            facility.categories.set(categories)
         return facility
 
 


### PR DESCRIPTION
## Summary
- properly handle category assignment when creating facilities
- load pysqlite3 so SpatiaLite works in management and runtime entrypoints

## Testing
- `pip install -r ../requirements.txt`
- `pip install pysqlite3-binary`
- `pytest` *(fails: assert 400 == 200, IntegrityError, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_689a69088ef08326b5e7f454e675bbce