### PR TITLE
Handle paginated facility responses to show facilities when creating slots

### DIFF
--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -13,8 +13,14 @@ class FacilityService {
     });
 
     dynamic data = res.data;
-    if (data is Map && data['features'] is List) {
-      data = data['features'];
+    if (data is Map) {
+      if (data['features'] is List) {
+        // GeoJSON FeatureCollection format
+        data = data['features'];
+      } else if (data['results'] is List) {
+        // DRF paginated response
+        data = data['results'];
+      }
     }
 
     if (data is! List) {


### PR DESCRIPTION
## Summary
- handle paginated Facility API responses so facility dropdown loads correctly on slot creation page

## Testing
- `pip install -r requirements.txt`
- `pytest` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689b3b8bfa708326ad35daa38153c88f