### PR TITLE
Fix facility dropdown not showing in slot creation

### DIFF
--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -5,12 +5,13 @@ class FacilityService {
   Future<List<Facility>> fetchFacilities(
       List<String> categories, double radius, double lat, double lng,
       {bool mine = false}) async {
-    final res = await apiClient.get('/facilities/', queryParameters: {
-      'categories': categories.join(','),
+    final params = {
+      if (categories.isNotEmpty) 'categories': categories.join(','),
       if (radius > 0) 'radius': radius.toInt(),
       if (lat != 0 || lng != 0) 'near': '$lat,$lng',
       if (mine) 'mine': '1',
-    });
+    };
+    final res = await apiClient.get('/facilities/', queryParameters: params);
 
     dynamic data = res.data;
     if (data is Map) {

--- a/test/facility_service_test.dart
+++ b/test/facility_service_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dio/dio.dart';
+import 'package:sports_booking_app/services/api_client.dart';
+import 'package:sports_booking_app/services/facility_service.dart';
+
+class _FakeDio extends Dio {
+  Map<String, dynamic>? lastQueryParameters;
+
+  @override
+  Future<Response<T>> get<T>(
+    String path, {
+    data,
+    Map<String, dynamic>? queryParameters,
+    Options? options,
+    CancelToken? cancelToken,
+    ProgressCallback? onReceiveProgress,
+  }) async {
+    lastQueryParameters = queryParameters;
+    return Response<T>(
+      data: [] as T,
+      requestOptions: RequestOptions(path: path),
+    );
+  }
+}
+
+void main() {
+  test('fetchFacilities omits empty categories param', () async {
+    final fake = _FakeDio();
+    apiClient = fake;
+    await facilityService.fetchFacilities([], 0, 0, 0);
+    expect(fake.lastQueryParameters?.containsKey('categories'), isFalse);
+  });
+}


### PR DESCRIPTION
## Summary
- avoid sending empty categories filter when fetching facilities
- add test for facility service

## Testing
- `flutter test` *(fails: command not found)*
- `pytest` *(fails: 19 failed, 38 passed, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b3ef57d0c832691adad06f673ffdb