### PR TITLE
Handle paginated facility responses to show facilities when creating slots

### DIFF
--- a/lib/models/facility.dart
+++ b/lib/models/facility.dart
@@ -16,14 +16,27 @@ class Facility {
   final List<String> categories;
 
   factory Facility.fromJson(Map<String, dynamic> j) {
-    final geom = j['geometry']['coordinates'] as List;
+    // API may return facilities either as plain objects or as GeoJSON Features
+    // where the fields live inside a `properties` map. Normalize accordingly.
+    final props = j['properties'] is Map
+        ? Map<String, dynamic>.from(j['properties'])
+        : j;
+
+    final geomSrc = j['geometry'] ?? props['geometry'];
+    if (geomSrc == null || geomSrc['coordinates'] is! List) {
+      throw ArgumentError('Invalid facility geometry');
+    }
+    final coords = (geomSrc['coordinates'] as List).cast<num>();
+
     return Facility(
-      id: j['id'] as int,
-      name: j['name'] as String,
-      lat: geom[1] as double,
-      lng: geom[0] as double,
-      radius: (j['radius'] as num).toDouble(),
-      categories: (j['categories'] as List).cast<int>().map((e) => e.toString()).toList(),
+      id: (j['id'] ?? props['id']) as int,
+      name: (props['name'] ?? j['name']) as String,
+      lat: coords[1].toDouble(),
+      lng: coords[0].toDouble(),
+      radius: ((props['radius'] ?? j['radius']) as num).toDouble(),
+      categories: ((props['categories'] ?? j['categories']) as List? ?? [])
+          .map((e) => e.toString())
+          .toList(),
     );
   }
 }

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -5,16 +5,23 @@ class FacilityService {
   Future<List<Facility>> fetchFacilities(
       List<String> categories, double radius, double lat, double lng,
       {bool mine = false}) async {
-    final res = await apiClient.get('/facilities/', queryParameters: {
-      'categories': categories.join(','),
+    final params = {
+      if (categories.isNotEmpty) 'categories': categories.join(','),
       if (radius > 0) 'radius': radius.toInt(),
       if (lat != 0 || lng != 0) 'near': '$lat,$lng',
       if (mine) 'mine': '1',
-    });
+    };
+    final res = await apiClient.get('/facilities/', queryParameters: params);
 
     dynamic data = res.data;
-    if (data is Map && data['features'] is List) {
-      data = data['features'];
+    if (data is Map) {
+      if (data['features'] is List) {
+        // GeoJSON FeatureCollection format
+        data = data['features'];
+      } else if (data['results'] is List) {
+        // DRF paginated response
+        data = data['results'];
+      }
     }
 
     if (data is! List) {
@@ -68,8 +75,12 @@ class FacilityService {
       'page': page,
     });
     dynamic data = res.data;
-    if (data is Map && data['results'] is List) {
-      data = data['results'];
+    if (data is Map) {
+      if (data['features'] is List) {
+        data = data['features'];
+      } else if (data['results'] is List) {
+        data = data['results'];
+      }
     }
     if (data is! List) {
       throw Exception('Unexpected response format');


### PR DESCRIPTION
## Summary
- handle paginated Facility API responses so facility dropdown loads correctly on slot creation page
- normalize facility parsing to read GeoJSON `Feature` items and skip empty category filters

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=backend DJANGO_SETTINGS_MODULE=PlayNexus.settings pytest` *(fails: could not translate host name "db" to address)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689b3b8bfa708326ad35daa38153c88f