### PR TITLE
Fix merchant slot listing and prevent self-booking

### DIFF
--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -179,15 +179,16 @@ class _AddSlotPageState extends State<AddSlotPage> {
                               facilityId: _facilityId!,
                             );
                           } else {
-                            await slotService.updateMerchantSlot(widget.slot!.id, {
-                              'facility': _facilityId,
-                              'begins_at': start!.toIso8601String(),
-                              'ends_at': end!.toIso8601String(),
-                              'capacity': int.parse(capacityCtrl.text),
-                              'price': double.parse(priceCtrl.text),
-                              'title': titleCtrl.text,
-                              'location': locationCtrl.text,
-                            });
+                            await slotService.updateMerchantSlot(
+                              widget.slot!.id,
+                              facilityId: _facilityId,
+                              beginsAt: start!,
+                              endsAt: end!,
+                              capacity: int.parse(capacityCtrl.text),
+                              price: double.parse(priceCtrl.text),
+                              title: titleCtrl.text,
+                              location: locationCtrl.text,
+                            );
                           }
                           if (context.mounted) Navigator.pop(context, true);
                         } on DioException catch (e) {

--- a/lib/screens/payment_page.dart
+++ b/lib/screens/payment_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../models/slot.dart';
 import '../services/booking_service.dart';
 import '../services/payment_service.dart';
+import '../services/slot_service.dart';
 import 'package:flutter_stripe/flutter_stripe.dart';
 import '../providers.dart';
 import 'booking_confirmation_page.dart';
@@ -17,6 +18,28 @@ class PaymentPage extends ConsumerStatefulWidget {
 
 class _PaymentPageState extends ConsumerState<PaymentPage> {
   bool loading = false;
+  bool _isMySlot = false;
+  bool _checking = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _checkOwnership();
+  }
+
+  Future<void> _checkOwnership() async {
+    try {
+      final mine = await slotService.fetchMerchantSlot(widget.slot.id);
+      if (mounted) {
+        setState(() {
+          _isMySlot = mine != null;
+          _checking = false;
+        });
+      }
+    } catch (_) {
+      if (mounted) setState(() => _checking = false);
+    }
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -29,12 +52,19 @@ class _PaymentPageState extends ConsumerState<PaymentPage> {
           children: [
             Text(widget.slot.title, style: Theme.of(context).textTheme.titleMedium),
             const SizedBox(height: 20),
-            ElevatedButton(
-              onPressed: loading ? null : _pay,
-              child: loading
-                  ? const CircularProgressIndicator()
-                  : const Text('Pay & Book'),
-            ),
+            if (_checking)
+              const CircularProgressIndicator()
+            else ...[
+              if (_isMySlot)
+                const Text('You cannot book your own slot.')
+              else
+                ElevatedButton(
+                  onPressed: loading ? null : _pay,
+                  child: loading
+                      ? const CircularProgressIndicator()
+                      : const Text('Pay & Book'),
+                ),
+            ],
           ],
         ),
       ),

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -101,8 +101,9 @@ class SlotService {
       await apiClient.post('/merchant/slots/', data: {
         'activity': activityId,
         'facility': facilityId,
-        'begins_at': start.toIso8601String(),
-        'ends_at': end.toIso8601String(),
+        // Ensure timezone aware datetimes for Django
+        'begins_at': _iso(start),
+        'ends_at': _iso(end),
         'capacity': capacity,
         'price': price,
         'title': title,
@@ -132,6 +133,30 @@ class SlotService {
     }
   }
 
+  Future<void> updateMerchantSlot(
+    int id, {
+    int? activityId,
+    int? facilityId,
+    DateTime? beginsAt,
+    DateTime? endsAt,
+    int? capacity,
+    double? price,
+    String? title,
+    String? location,
+  }) async {
+    final patch = <String, dynamic>{};
+    if (activityId != null) patch['activity'] = activityId;
+    if (facilityId != null) patch['facility'] = facilityId;
+    if (beginsAt != null) patch['begins_at'] = _iso(beginsAt);
+    if (endsAt != null) patch['ends_at'] = _iso(endsAt);
+    if (capacity != null) patch['capacity'] = capacity;
+    if (price != null) patch['price'] = price;
+    if (title != null) patch['title'] = title;
+    if (location != null) patch['location'] = location;
+
+    await apiClient.patch('/merchant/slots/$id/', data: patch);
+  }
+  
   Future<Paginated<Slot>> fetchMine({int page = 1}) async {
     final res = await apiClient.get('/merchant/slots/', queryParameters: {'page': page});
     final dynamic data = res.data;
@@ -155,10 +180,6 @@ class SlotService {
       }
       rethrow;
     }
-  }
-
-  Future<void> updateMerchantSlot(int id, Map<String, dynamic> patch) async {
-    await apiClient.patch('/merchant/slots/$id/', data: patch);
   }
 
   Future<void> deleteMerchantSlot(int id) async {

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -134,8 +134,27 @@ class SlotService {
 
   Future<Paginated<Slot>> fetchMine({int page = 1}) async {
     final res = await apiClient.get('/merchant/slots/', queryParameters: {'page': page});
-    final data = res.data as Map<String, dynamic>;
-    return Paginated.fromJson(data, (j) => Slot.fromJson(j));
+    final dynamic data = res.data;
+    if (data is Map<String, dynamic>) {
+      return Paginated.fromJson(data, (j) => Slot.fromJson(j));
+    } else if (data is List) {
+      return Paginated.fromList(
+          data.cast<Map<String, dynamic>>(), (j) => Slot.fromJson(j));
+    } else {
+      throw const FormatException('Unsupported slots payload');
+    }
+  }
+
+  Future<Slot?> fetchMerchantSlot(int id) async {
+    try {
+      final res = await apiClient.get('/merchant/slots/$id/');
+      return Slot.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 404 || e.response?.statusCode == 403) {
+        return null;
+      }
+      rethrow;
+    }
   }
 
   Future<void> updateMerchantSlot(int id, Map<String, dynamic> patch) async {


### PR DESCRIPTION
## Summary
- handle list responses when fetching merchant slots
- block merchants from booking their own slots with a clear message

## Testing
- `flutter test` *(fails: command not found: flutter)*
- `cd backend && pytest` *(fails: 19 failed, 38 passed, 6 errors)*

------
https://chatgpt.com/codex/tasks/task_e_689b48ed7c108326b15ad17f5f7e3959