### PR TITLE
Fix merchant slot listing

### DIFF
--- a/backend/sports/merchant_views.py
+++ b/backend/sports/merchant_views.py
@@ -10,6 +10,7 @@ from drf_spectacular.utils import extend_schema, OpenApiExample, OpenApiResponse
 
 from .models import Slot, Booking
 from .serializers import SlotSerializer, MerchantSlotSerializer, BookingSerializer
+from .views import DefaultPagination
 from accounts.permissions import IsVendor
 from payments.services import refund
 
@@ -18,6 +19,7 @@ class MerchantSlotViewSet(viewsets.ModelViewSet):
     """CRUD operations for Slots owned by merchants."""
 
     permission_classes = [permissions.IsAuthenticated, IsVendor]
+    pagination_class = DefaultPagination
 
     def get_queryset(self):
         user = self.request.user

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -132,10 +132,22 @@ class SlotService {
     }
   }
 
+  Paginated<Slot> _parsePage(Object data) {
+    if (data is List) {
+      return Paginated.fromList(
+        data.cast<Map<String, dynamic>>(),
+        (j) => Slot.fromJson(j),
+      );
+    }
+    if (data is Map<String, dynamic>) {
+      return Paginated.fromJson(data, (j) => Slot.fromJson(j));
+    }
+    return Paginated(count: 0, next: null, previous: null, results: const []);
+  }
+
   Future<Paginated<Slot>> fetchMine({int page = 1}) async {
     final res = await apiClient.get('/merchant/slots/', queryParameters: {'page': page});
-    final data = res.data as Map<String, dynamic>;
-    return Paginated.fromJson(data, (j) => Slot.fromJson(j));
+    return _parsePage(res.data);
   }
 
   Future<void> updateMerchantSlot(int id, Map<String, dynamic> patch) async {


### PR DESCRIPTION
## Summary
- paginate merchant slots API so providers can list their own slots
- make slot service resilient to paginated and non-paginated responses

## Testing
- `pytest backend/tests/test_merchant_slots.py -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689b4b0919cc8326b768e1ecffc0a28b