### PR TITLE
Paginate merchant slot listing for Flutter app

### DIFF
--- a/backend/sports/merchant_views.py
+++ b/backend/sports/merchant_views.py
@@ -1,7 +1,7 @@
 from rest_framework import viewsets, permissions, generics, status
 from rest_framework.response import Response
 from rest_framework.views import APIView
-from rest_framework.pagination import CursorPagination
+from rest_framework.pagination import CursorPagination, PageNumberPagination
 from django.utils.dateparse import parse_datetime
 from django.utils import timezone
 from django.shortcuts import get_object_or_404
@@ -14,10 +14,17 @@ from accounts.permissions import IsVendor
 from payments.services import refund
 
 
+class MerchantSlotPagination(PageNumberPagination):
+    """Default pagination for merchant-owned slots."""
+
+    page_size = 50
+
+
 class MerchantSlotViewSet(viewsets.ModelViewSet):
     """CRUD operations for Slots owned by merchants."""
 
     permission_classes = [permissions.IsAuthenticated, IsVendor]
+    pagination_class = MerchantSlotPagination
 
     def get_queryset(self):
         user = self.request.user

--- a/backend/tests/test_merchant_slots.py
+++ b/backend/tests/test_merchant_slots.py
@@ -151,7 +151,8 @@ def test_bulk_delete_soft(auth_client, activity):
 
     resp2 = auth_client.get("/api/merchant/slots/")
     assert resp2.status_code == 200
-    assert resp2.data == []
+    assert resp2.data["count"] == 0
+    assert resp2.data["results"] == []
 
 
 def test_booking_flow_unchanged(db):


### PR DESCRIPTION
## Summary
- return paginated results for merchant slot endpoints so My Slots page can display them
- adjust merchant slot tests for new response format

## Testing
- `pytest` *(fails: Unable to load the SpatiaLite library)*

------
https://chatgpt.com/codex/tasks/task_e_689b4c6c5b8883268daee8fb3d4f6ed7