### PR TITLE
Add merchant slot management and booking safeguards

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE = PlayNexus.settings
+DJANGO_SETTINGS_MODULE = backend.PlayNexus.settings
 addopts = -q
 python_files = tests.py test_*.py *_tests.py
+pythonpath = ..

--- a/backend/sports/migrations/0002_slot_owner.py
+++ b/backend/sports/migrations/0002_slot_owner.py
@@ -1,0 +1,22 @@
+from django.db import migrations, models
+import django.db.models.deletion
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('sports', '0001_initial'),
+        ('auth', '0012_alter_user_first_name_max_length'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='slot',
+            name='owner',
+            field=models.ForeignKey(
+                null=True,
+                on_delete=django.db.models.deletion.CASCADE,
+                related_name='owned_slots',
+                to='auth.user',
+            ),
+        ),
+    ]

--- a/backend/sports/models.py
+++ b/backend/sports/models.py
@@ -27,6 +27,15 @@ class Slot(models.Model):
     """A single bookable time-window for one sport."""
 
     sport = models.ForeignKey(Sport, related_name="slots", on_delete=models.CASCADE)
+    # New: track which user created/owns this slot so merchants can manage their own
+    # slots and are prevented from booking them.  Using auth.User keeps compatibility
+    # with existing tests and avoids custom user model complexity.
+    owner = models.ForeignKey(
+        "auth.User",
+        related_name="owned_slots",
+        on_delete=models.CASCADE,
+        null=True,
+    )
     title = models.CharField(max_length=60)
     location = models.CharField(max_length=80)
     begins_at = models.DateTimeField()

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -17,9 +17,13 @@ class SlotSerializer(serializers.ModelSerializer):
         max_digits=3, decimal_places=1, coerce_to_string=False
     )
 
+    # Owner should be read-only – set automatically from request.user
+    owner = serializers.ReadOnlyField(source="owner_id")
+
     class Meta:
         model = Slot
         fields = "__all__"
+        read_only_fields = ("id", "owner")
 
 
 class BookingSerializer(serializers.ModelSerializer):

--- a/backend/sports/urls.py
+++ b/backend/sports/urls.py
@@ -1,10 +1,11 @@
 # sports/urls.py
 from rest_framework.routers import DefaultRouter
-from .views import SportViewSet, SlotViewSet, BookingViewSet
+from .views import SportViewSet, SlotViewSet, BookingViewSet, MySlotViewSet
 
 router = DefaultRouter()
 router.register(r"sports", SportViewSet, basename="sport")
 router.register(r"slots", SlotViewSet, basename="slot")
 router.register(r"bookings", BookingViewSet, basename="booking")
+router.register(r"my-slots", MySlotViewSet, basename="my-slot")
 
 urlpatterns = router.urls

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -23,6 +23,19 @@ class SlotViewSet(viewsets.ReadOnlyModelViewSet):
         return qs.filter(sport_id=sport_id) if sport_id else qs
 
 
+class MySlotViewSet(viewsets.ModelViewSet):
+    """CRUD for slots owned by the authenticated merchant."""
+
+    serializer_class = SlotSerializer
+    permission_classes = [permissions.IsAuthenticated]
+
+    def get_queryset(self):
+        return Slot.objects.filter(owner=self.request.user).select_related("sport")
+
+    def perform_create(self, serializer):
+        serializer.save(owner=self.request.user)
+
+
 class BookingViewSet(viewsets.ModelViewSet):
     serializer_class = BookingSerializer
     permission_classes = [permissions.IsAuthenticated]
@@ -39,6 +52,13 @@ class BookingViewSet(viewsets.ModelViewSet):
 
         slot: Slot = ser.validated_data["slot"]
         pax = ser.validated_data["pax"]
+
+        # Prevent merchants from booking their own slots
+        if slot.owner_id == request.user.id:
+            return Response(
+                {"detail": "Cannot book your own slot"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
         slot = Slot.objects.select_for_update().get(pk=slot.pk)
         taken = slot.bookings.aggregate(t=models.Sum("pax"))["t"] or 0

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,13 +1,19 @@
 import pytest
 from django.utils import timezone
+from django.contrib.auth.models import User
 from backend.sports.models import Sport, Slot
+
+@pytest.fixture
+def user(db):
+    return User.objects.create_user(username="merchant", password="pass")
+
 
 @pytest.fixture
 def sport(db):
     return Sport.objects.create(name="Tennis")
 
 @pytest.fixture
-def slot(db, sport):
+def slot(db, sport, user):
     return Slot.objects.create(
         sport=sport,
         title="Morning session",
@@ -15,4 +21,5 @@ def slot(db, sport):
         begins_at=timezone.now() + timezone.timedelta(hours=1),
         ends_at=timezone.now() + timezone.timedelta(hours=2),
         capacity=4,
+        owner=user,
     )

--- a/backend/tests/test_api.py
+++ b/backend/tests/test_api.py
@@ -2,20 +2,62 @@ from django.urls import reverse
 from rest_framework.test import APIClient
 from backend.sports.models import Sport, Slot, Booking
 from django.contrib.auth.models import User
+from django.utils import timezone
 import pytest
 
 
 @pytest.mark.django_db
-def test_sports_list(client, sport):
+def test_sports_list(sport):
+    client = APIClient()
     resp = client.get("/api/sports/")
     assert resp.status_code == 200
     assert resp.json()[0]["id"] == sport.id
 
 
 @pytest.mark.django_db
-def test_slots_filter(client, sport, slot):
+def test_slots_filter(sport, slot):
+    client = APIClient()
     resp = client.get("/api/slots/", {"sport": sport.id})
     assert resp.status_code == 200
     assert resp.json()[0]["id"] == slot.id
+
+
+@pytest.mark.django_db
+def test_my_slots_list(user, sport):
+    slot = Slot.objects.create(
+        sport=sport,
+        title="Evening",
+        location="Court 2",
+        begins_at=timezone.now() + timezone.timedelta(hours=3),
+        ends_at=timezone.now() + timezone.timedelta(hours=4),
+        capacity=3,
+        owner=user,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    resp = client.get("/api/my-slots/")
+    assert resp.status_code == 200
+    assert resp.json()[0]["id"] == slot.id
+
+
+@pytest.mark.django_db
+def test_merchant_cannot_book_own_slot(user, sport):
+    slot = Slot.objects.create(
+        sport=sport,
+        title="Night",
+        location="Court 3",
+        begins_at=timezone.now() + timezone.timedelta(hours=5),
+        ends_at=timezone.now() + timezone.timedelta(hours=6),
+        capacity=2,
+        owner=user,
+    )
+    client = APIClient()
+    client.force_authenticate(user=user)
+    resp = client.post(
+        "/api/bookings/",
+        {"slot_id": slot.id, "pax": 1},
+    )
+    assert resp.status_code == 400
+    assert resp.json()["detail"] == "Cannot book your own slot"
 
 

--- a/lib/models/slot.dart
+++ b/lib/models/slot.dart
@@ -11,6 +11,7 @@ class Slot {
     required this.endsAt,
     required this.capacity,
     required this.price,
+    this.ownerId,
   });
 
   final int      id;
@@ -21,6 +22,7 @@ class Slot {
   final DateTime endsAt;
   final int      capacity;
   final double   price;
+  final int?     ownerId;
 
   /// 允许后端返回 sport=ID 或 sport=Map 两种格式
   factory Slot.fromJson(Map<String, dynamic> j) {
@@ -46,6 +48,7 @@ class Slot {
       endsAt:    DateTime.parse(j['ends_at']   as String),
       capacity:  j['capacity']         as int,
       price:     double.parse(j['price'].toString()),
+      ownerId:   j['owner'] as int?,
     );
   }
 
@@ -59,5 +62,6 @@ class Slot {
     'ends_at'   : endsAt.toIso8601String(),
     'capacity'  : capacity,
     'price'     : price,
+    if (ownerId != null) 'owner': ownerId,
   };
 }

--- a/lib/providers.dart
+++ b/lib/providers.dart
@@ -16,4 +16,9 @@ final slotsProvider = FutureProvider.family<List<Slot>, int>((ref, sportId) {
   return slotService.fetchBySport(sportId);
 });
 
+// ───────── Slots owned by current user ─────────
+final mySlotsProvider = FutureProvider<List<Slot>>((ref) {
+  return slotService.fetchMine();
+});
+
 final authProvider = Provider<AuthService>((ref) => authService);

--- a/lib/screens/home_page.dart
+++ b/lib/screens/home_page.dart
@@ -13,6 +13,7 @@ import 'categories_page.dart';
 
 import '../providers.dart';                                   // ← new (sportsProvider)
 import 'login_page.dart';                                     // for login navigation
+import 'my_slots_page.dart';
 
 class HomePage extends ConsumerStatefulWidget {               // Stateful → ConsumerStateful
   const HomePage({super.key});
@@ -314,6 +315,11 @@ class _HomePageState extends ConsumerState<HomePage> {
             Navigator.push(
               context,
               MaterialPageRoute(builder: (_) => const LoginPage()),
+            );
+          } else if (i == 1) {
+            Navigator.push(
+              context,
+              MaterialPageRoute(builder: (_) => const MySlotsPage()),
             );
           } else {
             setState(() => _navIndex = i);

--- a/lib/screens/my_slots_page.dart
+++ b/lib/screens/my_slots_page.dart
@@ -1,0 +1,32 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import '../providers.dart';
+import '../widgets/slot_card.dart';
+
+/// Page showing slots created by the current merchant.
+class MySlotsPage extends ConsumerWidget {
+  const MySlotsPage({super.key});
+
+  @override
+  Widget build(BuildContext context, WidgetRef ref) {
+    final slotsAsync = ref.watch(mySlotsProvider);
+    return Scaffold(
+      appBar: AppBar(title: const Text('My Slots')),
+      body: slotsAsync.when(
+        loading: () => const Center(child: CircularProgressIndicator(strokeWidth: 2)),
+        error: (err, _) => Center(
+          child: Text(err.toString(), style: const TextStyle(color: Colors.red)),
+        ),
+        data: (slots) => ListView.separated(
+          padding: const EdgeInsets.all(16),
+          itemCount: slots.length,
+          separatorBuilder: (_, __) => const SizedBox(height: 16),
+          itemBuilder: (_, i) => SlotCard(
+            slot: slots[i],
+            onTap: () {},
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -13,12 +13,19 @@ class BookingService {
         .toList(growable: false);
   }
 
-  Future<Booking> create(int slotId) async {
-    final res = await apiClient.post(
-      '/bookings/',
-      data: {'slot': slotId},
-      options: Options(contentType: Headers.formUrlEncodedContentType),
-    );
-    return Booking.fromJson(res.data as Map<String, dynamic>);
+  Future<Booking> create(int slotId, {int pax = 1}) async {
+    try {
+      final res = await apiClient.post(
+        '/bookings/',
+        data: {'slot_id': slotId, 'pax': pax},
+        options: Options(contentType: Headers.formUrlEncodedContentType),
+      );
+      return Booking.fromJson(res.data as Map<String, dynamic>);
+    } on DioException catch (e) {
+      final msg = e.response?.data is Map
+          ? (e.response!.data['detail'] ?? 'Unknown error')
+          : e.message;
+      throw Exception(msg);
+    }
   }
 }

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -22,6 +22,23 @@ class SlotService {
         .map((e) => Slot.fromJson(e as Map<String, dynamic>))
         .toList(growable: false);
   }
+
+  /// GET /api/my-slots/ - slots created by current user
+  Future<List<Slot>> fetchMine() async {
+    final Response res = await apiClient.get('/my-slots/');
+    final dynamic payload = res.data;
+    final List data = payload is Map ? payload['results'] as List : payload as List;
+    return data
+        .cast<dynamic>()
+        .map((e) => Slot.fromJson(e as Map<String, dynamic>))
+        .toList(growable: false);
+  }
+
+  /// POST /api/my-slots/ - create a new slot
+  Future<Slot> create(Slot slot) async {
+    final Response res = await apiClient.post('/my-slots/', data: slot.toJson());
+    return Slot.fromJson(res.data as Map<String, dynamic>);
+  }
 }
 
 /// Global singleton – keep existing usage unchanged

--- a/lib/widgets/app_bottom_nav.dart
+++ b/lib/widgets/app_bottom_nav.dart
@@ -61,9 +61,9 @@ class AppBottomNav extends StatelessWidget {
           label: 'Home',
         ),
         NavigationDestination(
-          icon: _icon(Icons.favorite_outline, Icons.favorite,
-              selected: index == 1, badge: 2), // 示范红点
-          label: 'Favorites',
+          icon: _icon(Icons.event_note_outlined, Icons.event_note,
+              selected: index == 1),
+          label: 'My Slots',
         ),
         NavigationDestination(
           icon: _icon(Icons.inbox_outlined, Icons.inbox,


### PR DESCRIPTION
## Summary
- Track slot ownership and expose merchant CRUD API to manage their own slots
- Prevent merchants from booking their own slots and improve booking error handling
- Add Flutter My Slots page and navigation with provider and service support

## Testing
- `cd backend && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b4dcc69588326af5d700c8fb7d3e3