### PR TITLE
Handle payment network errors more clearly

### DIFF
--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -5,12 +5,23 @@ import 'api_client.dart';
 class PaymentService {
   Future<Map<String, dynamic>> createIntent(int slotId) async {
     try {
-      final res = await apiClient.post('/payments/checkout/', data: {'slot': slotId});
+      final res =
+          await apiClient.post('/payments/checkout/', data: {'slot': slotId});
       return res.data as Map<String, dynamic>;
     } on DioException catch (e) {
+      // if backend returned a structured error message (e.g. {"detail": "..."})
       if (e.response?.data is Map && e.response?.data['detail'] != null) {
         throw Exception(e.response?.data['detail'].toString());
       }
+
+      // When no response is available Dio sets `response` to null which resulted
+      // in the unhelpful "HTTP null: null" message seen in the app.  Provide a
+      // clearer description so users know the request never reached the
+      // server (e.g. backend down / no internet).
+      if (e.response == null) {
+        throw Exception(e.message ?? 'Connection error');
+      }
+
       throw Exception('HTTP ${e.response?.statusCode}: ${e.response?.data}');
     }
   }

--- a/test/payment_service_test.dart
+++ b/test/payment_service_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:dio/dio.dart';
+import 'package:sports_booking_app/services/payment_service.dart';
+import 'package:sports_booking_app/services/api_client.dart';
+
+/// A [HttpClientAdapter] that always throws a [DioException] without a
+/// response to simulate network errors.
+class _ErrorAdapter extends HttpClientAdapter {
+  @override
+  void close({bool force = false}) {}
+
+  @override
+  Future<ResponseBody> fetch(RequestOptions options,
+      Stream<List<int>>? requestStream, Future<dynamic>? cancelFuture) async {
+    throw DioException(requestOptions: options, message: 'No connection');
+  }
+}
+
+void main() {
+  test('createIntent propagates connection error message', () async {
+    // Override the global apiClient with a Dio instance that fails.
+    apiClient = Dio(BaseOptions(baseUrl: 'http://example.com'))
+      ..httpClientAdapter = _ErrorAdapter();
+
+    expect(() => paymentService.createIntent(1),
+        throwsA(predicate((e) => e.toString().contains('No connection'))));
+  });
+}


### PR DESCRIPTION
## Summary
- improve payment service error handling to avoid `HTTP null: null` messages
- add regression test for network error propagation

## Testing
- `flutter test` *(fails: command not found)*
- `apt-get install -y dart` *(fails: Unable to locate package dart)*
- `apt-get install -y flutter` *(fails: Unable to locate package flutter)*

------
https://chatgpt.com/codex/tasks/task_e_689b7a1c37a08326b8b44a227aed370c