### PR TITLE
Harden payment checkout and mobile networking

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
     <!-- Needed for geolocator -->
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
     <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />

--- a/backend/payments/tests/test_checkout.py
+++ b/backend/payments/tests/test_checkout.py
@@ -1,0 +1,240 @@
+import os
+import sys
+import pysqlite3
+import django
+
+sys.modules["sqlite3"] = pysqlite3
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "PlayNexus.settings")
+os.environ.setdefault("DB_HOST", "")
+os.environ.setdefault(
+    "SPATIALITE_LIBRARY_PATH", "/usr/lib/x86_64-linux-gnu/mod_spatialite.so"
+)
+
+django.setup()
+
+import pytest
+from rest_framework.test import APIClient
+from django.contrib.auth.models import User
+from django.utils import timezone
+from sports.models import Sport, Category, Activity, Slot, Booking
+import stripe
+from payments import views as pay_views
+
+
+pytestmark = pytest.mark.django_db
+
+
+@pytest.fixture
+def user():
+    return User.objects.create_user("u1", email="u1@example.com", password="pass")
+
+
+@pytest.fixture
+def auth_client(user):
+    client = APIClient()
+    client.force_authenticate(user)
+    return client
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@pytest.fixture
+def slot():
+    sport = Sport.objects.create(name="X")
+    cat = Category.objects.create(name="C")
+    from accounts.models import Organization
+    from uuid import uuid4
+
+    org = Organization.objects.create(name="O", slug=f"o-{uuid4().hex[:8]}")
+    act = Activity.objects.create(
+        sport=sport,
+        discipline=cat,
+        title="A",
+        description="",
+        difficulty=1,
+        duration=60,
+        base_price=10,
+        organization=org,
+    )
+    return Slot.objects.create(
+        sport=sport,
+        activity=act,
+        title="S",
+        location="L",
+        begins_at=timezone.now() + timezone.timedelta(hours=1),
+        ends_at=timezone.now() + timezone.timedelta(hours=2),
+        capacity=5,
+        price=10,
+    )
+
+
+def test_checkout_requires_auth(client, slot):
+    resp = client.post("/api/payments/checkout/", {"slot": slot.id})
+    assert resp.status_code == 401
+
+
+def test_checkout_invalid_slot(auth_client):
+    resp = auth_client.post("/api/payments/checkout/", {"slot": 9999})
+    assert resp.status_code == 400
+    assert resp.data["detail"] == "invalid slot"
+
+
+def test_checkout_missing_key_returns_500(auth_client, slot, monkeypatch):
+    monkeypatch.setattr(pay_views.stripe, "api_key", "")
+    resp = auth_client.post("/api/payments/checkout/", {"slot": slot.id})
+    assert resp.status_code == 500
+
+
+def test_checkout_creates_intent(auth_client, user, slot, monkeypatch):
+    class FakeIntent:
+        id = "pi_new"
+        client_secret = "sec"
+        status = "requires_payment_method"
+
+    def fake_create(**kwargs):
+        assert (
+            kwargs["idempotency_key"]
+            == f"user-{user.id}-slot-{slot.id}"
+        )
+        return FakeIntent()
+
+    monkeypatch.setattr(pay_views.stripe.PaymentIntent, "create", staticmethod(fake_create))
+    monkeypatch.setattr(pay_views.stripe, "api_key", "sk_test_123")
+    resp = auth_client.post("/api/payments/checkout/", {"slot": slot.id})
+    assert resp.status_code == 200
+    assert resp.data["payment_intent_id"] == "pi_new"
+    booking = Booking.objects.get(id=resp.data["booking_id"])
+    assert booking.payment_intent_id == "pi_new"
+
+
+def test_checkout_reuses_intent(auth_client, user, slot, monkeypatch):
+    booking = Booking.objects.create(
+        slot=slot, activity=slot.activity, user=user, payment_intent_id="pi_old"
+    )
+
+    class FakeIntent:
+        id = "pi_old"
+        client_secret = "sec"
+        status = "requires_action"
+
+    def fake_retrieve(intent_id):
+        assert intent_id == "pi_old"
+        return FakeIntent()
+
+    monkeypatch.setattr(pay_views.stripe.PaymentIntent, "retrieve", staticmethod(fake_retrieve))
+    monkeypatch.setattr(pay_views.stripe, "api_key", "sk_test_123")
+    resp = auth_client.post("/api/payments/checkout/", {"slot": slot.id})
+    assert resp.status_code == 200
+    assert resp.data["payment_intent_id"] == "pi_old"
+    booking.refresh_from_db()
+    assert booking.payment_intent_id == "pi_old"
+
+
+def test_checkout_creates_new_after_cancel(auth_client, user, slot, monkeypatch):
+    booking = Booking.objects.create(
+        slot=slot, activity=slot.activity, user=user, payment_intent_id="pi_old"
+    )
+
+    class OldIntent:
+        id = "pi_old"
+        client_secret = "old"
+        status = "canceled"
+
+    class NewIntent:
+        id = "pi_new"
+        client_secret = "new"
+        status = "requires_payment_method"
+
+    monkeypatch.setattr(
+        pay_views.stripe.PaymentIntent, "retrieve", staticmethod(lambda _id: OldIntent())
+    )
+    monkeypatch.setattr(
+        pay_views.stripe.PaymentIntent, "create", staticmethod(lambda **_: NewIntent())
+    )
+    monkeypatch.setattr(pay_views.stripe, "api_key", "sk_test_123")
+
+    resp = auth_client.post("/api/payments/checkout/", {"slot": slot.id})
+    assert resp.data["payment_intent_id"] == "pi_new"
+    booking.refresh_from_db()
+    assert booking.payment_intent_id == "pi_new"
+
+
+def test_confirm_marks_paid(auth_client, user, slot, monkeypatch):
+    booking = Booking.objects.create(
+        slot=slot,
+        activity=slot.activity,
+        user=user,
+        payment_intent_id="pi_1",
+        status="pending",
+        paid=False,
+    )
+
+    class Intent:
+        id = "pi_1"
+        status = "succeeded"
+
+    monkeypatch.setattr(
+        pay_views.stripe.PaymentIntent, "retrieve", staticmethod(lambda _id: Intent())
+    )
+    resp = auth_client.get("/api/payments/confirm/pi_1/")
+    assert resp.status_code == 200
+    booking.refresh_from_db()
+    assert booking.paid is True
+    assert booking.status == "confirmed"
+
+
+def test_webhook_signature_success(user, slot, monkeypatch):
+    booking = Booking.objects.create(
+        slot=slot, activity=slot.activity, user=user, payment_intent_id="pi_w"
+    )
+
+    event = {
+        "type": "payment_intent.succeeded",
+        "data": {
+            "object": {
+                "id": "pi_w",
+                "metadata": {"slot_id": slot.id, "user_id": user.id},
+            }
+        },
+    }
+
+    def fake_construct_event(payload, sig, secret):
+        return event
+
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec")
+    monkeypatch.setattr(
+        pay_views.stripe.Webhook, "construct_event", staticmethod(fake_construct_event)
+    )
+    client = APIClient()
+    resp = client.post(
+        "/api/payments/webhook/",
+        data="{}",
+        content_type="application/json",
+        HTTP_STRIPE_SIGNATURE="sig",
+    )
+    assert resp.status_code == 200
+    booking.refresh_from_db()
+    assert booking.paid
+
+
+def test_webhook_signature_failure(monkeypatch):
+    def fake_construct_event(payload, sig, secret):
+        raise stripe.error.SignatureVerificationError("bad", sig)
+
+    monkeypatch.setenv("STRIPE_WEBHOOK_SECRET", "whsec")
+    monkeypatch.setattr(
+        pay_views.stripe.Webhook, "construct_event", staticmethod(fake_construct_event)
+    )
+    client = APIClient()
+    resp = client.post(
+        "/api/payments/webhook/",
+        data="{}",
+        content_type="application/json",
+        HTTP_STRIPE_SIGNATURE="sig",
+    )
+    assert resp.status_code == 400
+

--- a/backend/payments/views.py
+++ b/backend/payments/views.py
@@ -1,6 +1,7 @@
 import os
 import logging
 import stripe
+from drf_spectacular.utils import extend_schema
 from rest_framework.views import APIView
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
@@ -9,25 +10,31 @@ from rest_framework import status
 from sports.models import Slot, Booking
 from sports.serializers import BookingSerializer
 
-stripe.api_key = os.getenv('STRIPE_API_KEY', '')
+stripe.api_key = os.getenv("STRIPE_API_KEY", "")
 logger = logging.getLogger(__name__)
 
 
 class StripeCheckoutView(APIView):
     permission_classes = [IsAuthenticated]
 
+    @extend_schema(responses={200: None})
     def post(self, request):
-        slot_id = request.data.get('slot')
+        slot_id = request.data.get("slot")
         if not slot_id:
-            return Response({'detail': 'slot required'}, status=400)
+            return Response({"detail": "slot required"}, status=400)
         try:
             slot = Slot.objects.get(pk=slot_id)
         except Slot.DoesNotExist:
-            return Response({'detail': 'invalid slot'}, status=400)
+            return Response({"detail": "invalid slot"}, status=400)
 
-        if not stripe.api_key or stripe.api_key.endswith('xxx'):
+        if not slot.is_active:
+            return Response({"detail": "Slot inactive"}, status=400)
+        if slot.current_participants >= slot.capacity:
+            return Response({"detail": "Not enough seats left"}, status=400)
+
+        if not stripe.api_key or stripe.api_key.endswith("xxx"):
             return Response(
-                {'detail': 'Stripe secret key is not configured'},
+                {"detail": "Stripe secret key is not configured"},
                 status=status.HTTP_500_INTERNAL_SERVER_ERROR,
             )
 
@@ -35,40 +42,67 @@ class StripeCheckoutView(APIView):
             slot=slot,
             user=request.user,
             defaults={
-                'activity': slot.activity,
-                'status': 'pending',
-                'paid': False,
+                "activity": slot.activity,
+                "status": "pending",
+                "paid": False,
             },
         )
 
+        intent = None
         if booking.payment_intent_id:
             try:
                 intent = stripe.PaymentIntent.retrieve(booking.payment_intent_id)
             except stripe.error.StripeError as e:
-                logger.exception('Failed to retrieve PaymentIntent')
-                return Response({'detail': str(e)}, status=status.HTTP_502_BAD_GATEWAY)
+                logger.exception("Failed to retrieve PaymentIntent")
+                return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
+
+            if intent.status in [
+                "requires_payment_method",
+                "requires_confirmation",
+                "requires_action",
+                "processing",
+            ]:
+                pass  # reuse existing intent
+            elif intent.status in ["canceled", "succeeded"] and not booking.paid:
+                try:
+                    intent = stripe.PaymentIntent.create(
+                        amount=int(slot.price * 100),
+                        currency="usd",
+                        automatic_payment_methods={"enabled": True},
+                        metadata={"slot_id": slot_id, "user_id": request.user.id},
+                        idempotency_key=f"user-{request.user.id}-slot-{slot_id}",
+                    )
+                    booking.payment_intent_id = intent.id
+                    booking.save(update_fields=["payment_intent_id"])
+                except stripe.error.StripeError as e:
+                    logger.exception("Failed to create PaymentIntent")
+                    return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
         else:
             try:
                 intent = stripe.PaymentIntent.create(
                     amount=int(slot.price * 100),
-                    currency='usd',
-                    automatic_payment_methods={'enabled': True},
-                    metadata={'slot_id': slot_id, 'user_id': request.user.id},
+                    currency="usd",
+                    automatic_payment_methods={"enabled": True},
+                    metadata={"slot_id": slot_id, "user_id": request.user.id},
+                    idempotency_key=f"user-{request.user.id}-slot-{slot_id}",
                 )
                 booking.payment_intent_id = intent.id
-                booking.save(update_fields=['payment_intent_id'])
+                booking.save(update_fields=["payment_intent_id"])
             except stripe.error.StripeError as e:
-                logger.exception('Failed to create PaymentIntent')
-                return Response({'detail': str(e)}, status=status.HTTP_502_BAD_GATEWAY)
-            except Exception as e:
-                logger.exception('Error creating PaymentIntent')
-                return Response({'detail': 'internal error'}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)
+                logger.exception("Failed to create PaymentIntent")
+                return Response({"detail": str(e)}, status=status.HTTP_502_BAD_GATEWAY)
+            except Exception:
+                logger.exception("Error creating PaymentIntent")
+                return Response(
+                    {"detail": "internal error"},
+                    status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                )
 
         return Response(
             {
-                'client_secret': intent.client_secret,
-                'payment_intent_id': intent.id,
-                'booking_id': booking.id,
+                "client_secret": intent.client_secret,
+                "payment_intent_id": intent.id,
+                "booking_id": booking.id,
             },
             status=status.HTTP_200_OK,
         )

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -314,6 +314,8 @@ class BookingSerializer(serializers.ModelSerializer):
     )
     status = serializers.CharField(read_only=True)
     paid = serializers.BooleanField(read_only=True)
+    user_name = serializers.SerializerMethodField()
+    user_email = serializers.SerializerMethodField()
 
     class Meta:
         model = Booking
@@ -325,8 +327,17 @@ class BookingSerializer(serializers.ModelSerializer):
             "booked_at",
             "status",
             "paid",
+            "user_name",
+            "user_email",
         )
         read_only_fields = ("id", "booked_at", "status", "paid")
+
+    def get_user_name(self, obj):
+        name = obj.user.get_full_name()
+        return name or getattr(obj.user, "username", "")
+
+    def get_user_email(self, obj):
+        return getattr(obj.user, "email", "")
 
 
 class ReviewSerializer(serializers.ModelSerializer):

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -69,6 +69,18 @@ void initAuthInterceptor() {
         handler.next(options);
       },
       onError: (err, handler) async {
+        if (err.message == null ||
+            err.message!.isEmpty ||
+            err.message == 'null' ||
+            err.type == DioExceptionType.unknown) {
+          err = DioException(
+            requestOptions: err.requestOptions,
+            response: err.response,
+            type: err.type,
+            error: 'Network error — please try again.',
+          );
+        }
+
         if (err.response?.statusCode == 401 &&
             !err.requestOptions.path.contains('token/refresh') &&
             err.requestOptions.extra['__retry'] != true) {

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -12,9 +12,11 @@ class PaymentService {
       if (data is Map && data['detail'] != null) {
         throw Exception(data['detail'].toString());
       }
-      final msg = e.message ?? e.error?.toString() ?? 'network error';
-      final code = e.response?.statusCode?.toString() ?? 'network';
-      throw Exception('HTTP $code: $msg');
+      final code = e.response?.statusCode;
+      if (code != null) {
+        throw Exception('HTTP $code');
+      }
+      throw Exception('Network error — please try again.');
     }
   }
 


### PR DESCRIPTION
## Summary
- validate slots before creating Stripe intents and reuse or recreate them with idempotency keys
- expose user name/email in booking serializer and handle Stripe confirm/webhook
- add Android Internet permission and harden Dio error handling with clearer messages

## Testing
- `pytest backend/payments/tests/test_checkout.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689bb28f45608326bdce3146df0d3552