### PR TITLE
fix: stabilize payments API calls

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,15 +19,12 @@ import 'services/api_client.dart';
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await dotenv.load(fileName: 'mobile/.env');
-  // <-- load .env variables
-
+  await initApiClient();
   Stripe.publishableKey = dotenv.env['STRIPE_PUBLIC_KEY'] ?? '';
-
-  initApiClient();
   initAuthInterceptor();
 
   runApp(
-    const ProviderScope(                        // <-- Riverpod root scope
+    const ProviderScope( // <-- Riverpod root scope
       child: SportsBookingApp(),
     ),
   );

--- a/lib/services/activity_service.dart
+++ b/lib/services/activity_service.dart
@@ -21,7 +21,7 @@ class ActivityService {
   }
 
   Future<Paginated<Activity>> fetchActivities({Map<String, dynamic>? params}) async {
-    final res = await apiClient.get('/activities/', queryParameters: params);
+    final res = await apiClient.get('activities/', queryParameters: params);
     return _parsePage(res.data);
   }
 
@@ -58,7 +58,7 @@ class ActivityService {
   }
 
   Future<Activity> fetchById(int id) async {
-    final Response res = await apiClient.get('/activities/$id/');
+    final Response res = await apiClient.get('activities/$id/');
     return Activity.fromJson(res.data as Map<String, dynamic>);
   }
 
@@ -88,7 +88,7 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.post('/activities/', data: form);
+      await apiClient.post('activities/', data: form);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
@@ -121,18 +121,18 @@ class ActivityService {
             filename: p.basename(imageFile.path)),
     });
     try {
-      await apiClient.patch('/activities/$id/', data: form);
+      await apiClient.patch('activities/$id/', data: form);
     } on DioException catch (e) {
       _rethrowFieldErrors(e);
     }
   }
 
   Future<void> deleteActivity(int id) async {
-    await apiClient.delete('/activities/$id/');
+    await apiClient.delete('activities/$id/');
   }
 
   Future<void> updateActivityStatus(int id, {required bool isActive}) async {
-    await apiClient.patch('/activities/$id/', data: {'is_active': isActive});
+    await apiClient.patch('activities/$id/', data: {'is_active': isActive});
   }
 
   void _rethrowFieldErrors(DioException e) {

--- a/lib/services/api_client.dart
+++ b/lib/services/api_client.dart
@@ -33,21 +33,25 @@ String adjustBaseUrl(String base,
 }
 
 /// Call after dotenv.load to construct the client with the base URL.
-void initApiClient() {
-  var base = dotenv.env['API_BASE_URL']!; // e.g. http://10.0.2.2:8000/api
+Future<void> initApiClient() async {
+  var base = dotenv.env['API_BASE_URL'] ?? '';
+  if (base.isEmpty) {
+    throw Exception('API_BASE_URL missing in mobile/.env');
+  }
   base = adjustBaseUrl(base);
   if (!base.endsWith('/')) base += '/';
   apiClient = Dio(
     BaseOptions(
       baseUrl: base,
-      connectTimeout: const Duration(seconds: 15),
-      receiveTimeout: const Duration(seconds: 15),
+      connectTimeout: const Duration(seconds: 10),
+      receiveTimeout: const Duration(seconds: 30),
+      headers: {'Content-Type': 'application/json'},
       responseType: ResponseType.json,
     ),
   );
   if (kDebugMode) {
-    apiClient.interceptors.add(
-        LogInterceptor(requestBody: true, responseBody: true));
+    apiClient.interceptors
+        .add(LogInterceptor(requestBody: true, responseBody: true));
   }
 }
 
@@ -78,7 +82,7 @@ void initAuthInterceptor() {
               // BUG: concurrent 401s triggered multiple refresh calls
               // FIX: queue refresh so only one request runs at a time
               _refreshing ??= apiClient
-                  .post('/auth/token/refresh/', data: {'refresh': refresh})
+                  .post('auth/token/refresh/', data: {'refresh': refresh})
                   .then((res) async {
                 final data = res.data as Map<String, dynamic>;
                 final access = data['access'] as String;

--- a/lib/services/auth_service.dart
+++ b/lib/services/auth_service.dart
@@ -10,7 +10,7 @@ class AuthService {
 
   Future<void> login(String email, String password) async {
     final Response res = await apiClient.post(
-      '/auth/login/',
+      'auth/login/',
       data: {'email': email, 'password': password},
     );
     final access = res.data['access'];
@@ -22,7 +22,7 @@ class AuthService {
 
   Future<void> register(String email, String password1, String password2) async {
     final Response res = await apiClient.post(
-      '/auth/registration/',
+      'auth/registration/',
       data: {
         'email': email,
         'password1': password1,
@@ -38,7 +38,7 @@ class AuthService {
 
   Future<void> registerProvider(String email, String p1, String p2, String name, String phone, String address) async {
     final Response res = await apiClient.post(
-      '/provider/register/',
+      'provider/register/',
       data: {
         'email': email,
         'password1': p1,
@@ -60,7 +60,7 @@ class AuthService {
     if (account == null) return;
     final auth = await account.authentication;
     final Response res = await apiClient.post(
-      '/auth/google/',
+      'auth/google/',
       data: {'id_token': auth.idToken},
     );
     final access = res.data['access'];
@@ -73,7 +73,7 @@ class AuthService {
   Future<void> logout() async {
     try {
       final refresh = await _storage.read(key: 'refresh');
-      await apiClient.post('/auth/logout/', data: {'refresh': refresh});
+      await apiClient.post('auth/logout/', data: {'refresh': refresh});
     } finally {
       await _storage.delete(key: 'access');
       await _storage.delete(key: 'refresh');
@@ -82,14 +82,14 @@ class AuthService {
   }
 
   Future<void> requestPasswordReset(String email) async {
-    await apiClient.post('/auth/password/reset/', data: {'email': email});
+    await apiClient.post('auth/password/reset/', data: {'email': email});
   }
 
   Future<void> refresh() async {
     final refresh = await _storage.read(key: 'refresh');
     if (refresh == null) return;
     final Response res = await apiClient.post(
-      '/auth/token/refresh/',
+      'auth/token/refresh/',
       data: {'refresh': refresh},
     );
     final access = res.data['access'];

--- a/lib/services/booking_service.dart
+++ b/lib/services/booking_service.dart
@@ -6,7 +6,7 @@ import 'api_client.dart';
 
 class BookingService {
   Future<List<Booking>> fetchMine() async {
-    final res = await apiClient.get('/bookings/');
+    final res = await apiClient.get('bookings/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Booking.fromJson)
@@ -15,7 +15,7 @@ class BookingService {
 
   Future<Booking> create(int slotId, {int pax = 1}) async {
     final res = await apiClient.post(
-      '/bookings/',
+      'bookings/',
       data: {'slot_id': slotId, 'pax': pax},
       options: Options(contentType: Headers.formUrlEncodedContentType),
     );
@@ -23,7 +23,7 @@ class BookingService {
   }
 
   Future<Booking> fetchById(int id) async {
-    final res = await apiClient.get('/bookings/' + id.toString() + '/');
+    final res = await apiClient.get('bookings/' + id.toString() + '/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/facility_service.dart
+++ b/lib/services/facility_service.dart
@@ -11,7 +11,7 @@ class FacilityService {
       if (lat != 0 || lng != 0) 'near': '$lat,$lng',
       if (mine) 'mine': '1',
     };
-    final res = await apiClient.get('/facilities/', queryParameters: params);
+    final res = await apiClient.get('facilities/', queryParameters: params);
 
     dynamic data = res.data;
     if (data is Map) {
@@ -40,7 +40,7 @@ class FacilityService {
     if (lat == null || lng == null) {
       throw ArgumentError('lat/lng required');
     }
-    await apiClient.post('/facilities/', data: {
+    await apiClient.post('facilities/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
@@ -56,7 +56,7 @@ class FacilityService {
   Future<void> updateFacility(
       int id, String name, double lat, double lng, List<int> categories,
       {double radius = 1000}) async {
-    await apiClient.patch('/facilities/$id/', data: {
+    await apiClient.patch('facilities/$id/', data: {
       'name': name,
       'lat': lat,
       'lng': lng,
@@ -66,11 +66,11 @@ class FacilityService {
   }
 
   Future<void> deleteFacility(int id) async {
-    await apiClient.delete('/facilities/$id/');
+    await apiClient.delete('facilities/$id/');
   }
 
   Future<List<Facility>> searchFacilities({required String query, int page = 1}) async {
-    final res = await apiClient.get('/facilities/', queryParameters: {
+    final res = await apiClient.get('facilities/', queryParameters: {
       'q': query,
       'page': page,
     });

--- a/lib/services/favorite_service.dart
+++ b/lib/services/favorite_service.dart
@@ -14,12 +14,12 @@ class FriendlyError implements Exception {
 
 class FavoriteService {
   Future<Set<int>> fetchFavoriteIds() async {
-    final Response res = await apiClient.get('/favorites/ids/');
+    final Response res = await apiClient.get('favorites/ids/');
     return (res.data as List).cast<int>().toSet();
   }
 
   Future<Paginated<Activity>> listFavorites({int page = 1, int pageSize = 20}) async {
-    final Response res = await apiClient.get('/favorites/', queryParameters: {
+    final Response res = await apiClient.get('favorites/', queryParameters: {
       'page': page,
       'page_size': pageSize,
     });
@@ -29,7 +29,7 @@ class FavoriteService {
 
   Future<bool> toggle(int activityId) async {
     try {
-      final Response res = await apiClient.post('/activities/$activityId/favorite/toggle/');
+      final Response res = await apiClient.post('activities/$activityId/favorite/toggle/');
       return res.data['favorited'] as bool? ?? true;
     } on DioException catch (e) {
       if (e.response?.statusCode == 401) throw UnauthorizedError();

--- a/lib/services/home_service.dart
+++ b/lib/services/home_service.dart
@@ -6,7 +6,7 @@ import 'api_client.dart';
 
 class HomeService {
   Future<List<FeaturedCategory>> fetchFeaturedCategories() async {
-    final res = await apiClient.get('/featured-categories/');
+    final res = await apiClient.get('featured-categories/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(FeaturedCategory.fromJson)
@@ -14,7 +14,7 @@ class HomeService {
   }
 
   Future<List<FeaturedActivity>> fetchFeaturedActivities() async {
-    final res = await apiClient.get('/featured-activities/');
+    final res = await apiClient.get('featured-activities/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(FeaturedActivity.fromJson)
@@ -35,7 +35,7 @@ class HomeService {
   }
 
   Future<Paginated<Activity>> fetchContinuePlanning() async {
-    final res = await apiClient.get('/home/continue-planning/');
+    final res = await apiClient.get('home/continue-planning/');
     final data = res.data;
     if (data is List) {
       return Paginated.fromList(

--- a/lib/services/org_service.dart
+++ b/lib/services/org_service.dart
@@ -3,7 +3,7 @@ import 'api_client.dart';
 
 class OrgService {
   Future<List<Map<String, dynamic>>> fetchMine() async {
-    final Response res = await apiClient.get('/accounts/merchant/orgs/me/');
+    final Response res = await apiClient.get('accounts/merchant/orgs/me/');
     return (res.data as List).cast<Map<String, dynamic>>();
   }
 }

--- a/lib/services/payment_service.dart
+++ b/lib/services/payment_service.dart
@@ -5,7 +5,18 @@ import 'api_client.dart';
 class PaymentService {
   Future<Map<String, dynamic>> createIntent(int slotId) async {
     try {
-      final res = await apiClient.post('/payments/checkout/', data: {'slot': slotId});
+      final res = await apiClient.post(
+        'payments/checkout/',
+        data: {'slot': slotId},
+        options: Options(
+          headers: {
+            'Accept-Encoding': 'identity',
+            'Connection': 'close',
+          },
+          sendTimeout: const Duration(seconds: 10),
+          receiveTimeout: const Duration(seconds: 30),
+        ),
+      );
       return res.data as Map<String, dynamic>;
     } on DioException catch (e) {
       final data = e.response?.data;
@@ -19,12 +30,12 @@ class PaymentService {
   }
 
   Future<Booking> confirmIntent(String intentId) async {
-    final res = await apiClient.get('/payments/confirm/$intentId/');
+    final res = await apiClient.get('payments/confirm/$intentId/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 
   Future<Booking> fetchBooking(int bookingId) async {
-    final res = await apiClient.get('/bookings/' + bookingId.toString() + '/');
+    final res = await apiClient.get('bookings/' + bookingId.toString() + '/');
     return Booking.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/profile_service.dart
+++ b/lib/services/profile_service.dart
@@ -5,12 +5,12 @@ import 'api_client.dart';
 
 class ProfileService {
   Future<Profile> fetch() async {
-    final Response res = await apiClient.get('/profile/');
+    final Response res = await apiClient.get('profile/');
     return Profile.fromJson(res.data as Map<String, dynamic>);
   }
 
   Future<Profile> update(Map<String, dynamic> data) async {
-    final Response res = await apiClient.put('/provider/profile/', data: data);
+    final Response res = await apiClient.put('provider/profile/', data: data);
     return Profile.fromJson(res.data as Map<String, dynamic>);
   }
 }

--- a/lib/services/review_service.dart
+++ b/lib/services/review_service.dart
@@ -5,7 +5,7 @@ import 'api_client.dart';
 class ReviewService {
   Future<List<Review>> fetchReviews(int activityId, {int? limit}) async {
     final Response res = await apiClient.get(
-      '/activities/$activityId/reviews/',
+      'activities/$activityId/reviews/',
       queryParameters: limit != null ? {'limit': limit} : null,
     );
     return (res.data as List)
@@ -17,7 +17,7 @@ class ReviewService {
   Future<Review> createReview(
       int activityId, int rating, String comment) async {
     final Response res = await apiClient.post(
-      '/activities/$activityId/reviews/',
+      'activities/$activityId/reviews/',
       data: {'rating': rating, 'comment': comment},
     );
     return Review.fromJson(res.data as Map<String, dynamic>);

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -15,7 +15,7 @@ class SlotService {
   /// GET /api/slots/?sport=<sportId>
   Future<List<Slot>> fetchBySport(int sportId) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {'sport': sportId},
     );
 
@@ -33,7 +33,7 @@ class SlotService {
   /// only return slots from now onwards.
   Future<List<Slot>> fetchByActivity(int activityId) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'activity': activityId,
         'after': _iso(DateTime.now()),
@@ -51,7 +51,7 @@ class SlotService {
 
   Future<List<Slot>> fetchBySportDate(int sportId, DateTime after) async {
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'sport': sportId,
         'after': _iso(after),
@@ -71,7 +71,7 @@ class SlotService {
     final start = DateTime.utc(date.year, date.month, date.day);
     final end = start.add(const Duration(days: 1));
     final Response res = await apiClient.get(
-      '/slots/',
+      'slots/',
       queryParameters: {
         'activity': activityId,
         'after': _iso(start),
@@ -98,7 +98,7 @@ class SlotService {
       String location,
       {required int facilityId}) async {
     try {
-      await apiClient.post('/merchant/slots/', data: {
+      await apiClient.post('merchant/slots/', data: {
         'activity': activityId,
         'facility': facilityId,
         // Ensure timezone aware datetimes for Django
@@ -154,11 +154,11 @@ class SlotService {
     if (title != null) patch['title'] = title;
     if (location != null) patch['location'] = location;
 
-    await apiClient.patch('/merchant/slots/$id/', data: patch);
+    await apiClient.patch('merchant/slots/$id/', data: patch);
   }
   
   Future<Paginated<Slot>> fetchMine({int page = 1}) async {
-    final res = await apiClient.get('/merchant/slots/', queryParameters: {'page': page});
+    final res = await apiClient.get('merchant/slots/', queryParameters: {'page': page});
     final dynamic data = res.data;
     if (data is Map<String, dynamic>) {
       return Paginated.fromJson(data, (j) => Slot.fromJson(j));
@@ -172,7 +172,7 @@ class SlotService {
 
   Future<Slot?> fetchMerchantSlot(int id) async {
     try {
-      final res = await apiClient.get('/merchant/slots/$id/');
+      final res = await apiClient.get('merchant/slots/$id/');
       return Slot.fromJson(res.data as Map<String, dynamic>);
     } on DioException catch (e) {
       if (e.response?.statusCode == 404 || e.response?.statusCode == 403) {
@@ -183,7 +183,7 @@ class SlotService {
   }
 
   Future<void> deleteMerchantSlot(int id) async {
-    await apiClient.delete('/merchant/slots/$id/');
+    await apiClient.delete('merchant/slots/$id/');
   }
 }
 

--- a/lib/services/sport_category_service.dart
+++ b/lib/services/sport_category_service.dart
@@ -3,7 +3,7 @@ import 'api_client.dart';
 
 class SportCategoryService {
   Future<List<SportCategory>> fetchCategories() async {
-    final res = await apiClient.get('/sport-categories/');
+    final res = await apiClient.get('sport-categories/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(SportCategory.fromJson)
@@ -12,21 +12,21 @@ class SportCategoryService {
   }
 
   Future<void> createCategory(String name, int? parent) async {
-    await apiClient.post('/sport-categories/', data: {
+    await apiClient.post('sport-categories/', data: {
       'name': name,
       'parent': parent,
     });
   }
 
   Future<void> updateCategory(int id, String name, int? parent) async {
-    await apiClient.patch('/sport-categories/' + id.toString() + '/', data: {
+    await apiClient.patch('sport-categories/' + id.toString() + '/', data: {
       'name': name,
       'parent': parent,
     });
   }
 
   Future<void> deleteCategory(int id) async {
-    await apiClient.delete('/sport-categories/' + id.toString() + '/');
+    await apiClient.delete('sport-categories/' + id.toString() + '/');
   }
 }
 

--- a/lib/services/sports_service.dart
+++ b/lib/services/sports_service.dart
@@ -15,7 +15,7 @@ import 'api_client.dart';
 class SportsService {
   /// GET /api/sports/
   Future<List<Sport>> fetchSports() async {
-    final res = await apiClient.get('/sports/');
+    final res = await apiClient.get('sports/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Sport.fromJson)
@@ -28,7 +28,7 @@ class SportsService {
   /// The backend returns ALL upcoming slots (future dates only).
   /// You can add query-string filters on the API later as needed.
   Future<List<Slot>> fetchSlots() async {
-    final res = await apiClient.get('/slots/');
+    final res = await apiClient.get('slots/');
     final list = (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Slot.fromJson)
@@ -37,7 +37,7 @@ class SportsService {
   }
 
   Future<List<Category>> fetchCategories() async {
-    final res = await apiClient.get('/categories/');
+    final res = await apiClient.get('categories/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Category.fromJson)
@@ -45,7 +45,7 @@ class SportsService {
   }
 
   Future<List<Variant>> fetchVariants() async {
-    final res = await apiClient.get('/variants/');
+    final res = await apiClient.get('variants/');
     return (res.data as List)
         .cast<Map<String, dynamic>>()
         .map(Variant.fromJson)
@@ -53,7 +53,7 @@ class SportsService {
   }
 
   Future<void> createSport({required String name, String? description}) async {
-    await apiClient.post('/sports/', data: {
+    await apiClient.post('sports/', data: {
       'name': name,
       if (description != null) 'description': description,
     });


### PR DESCRIPTION
## Summary
- remove leading slashes from all apiClient requests
- harden api client initialization and timeouts
- add payment checkout request headers to disable compression and reuse

## Testing
- `dart format lib/services/payment_service.dart` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689ca99a71a08326b2a753948751ef5e