### PR TITLE
feat: make bookings clickable with detail cards

### DIFF
--- a/lib/screens/booking_detail_page.dart
+++ b/lib/screens/booking_detail_page.dart
@@ -1,8 +1,8 @@
 import 'package:flutter/material.dart';
 import 'package:qr_flutter/qr_flutter.dart';
 
-import '../models/booking.dart';
 import '../models/activity.dart';
+import '../models/booking.dart';
 
 class BookingDetailPage extends StatelessWidget {
   const BookingDetailPage({super.key, required this.booking, required this.activity});
@@ -15,6 +15,9 @@ class BookingDetailPage extends StatelessWidget {
     final slot = booking.slot;
     final image = activity.imageUrl ?? activity.image;
     final begins = slot.beginsAt.toLocal();
+    final dateStr =
+        '${begins.toString().split(' ')[0]} • ${begins.hour.toString().padLeft(2, '0')}:${begins.minute.toString().padLeft(2, '0')}';
+    final theme = Theme.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('Booking Details')),
       body: SingleChildScrollView(
@@ -54,33 +57,87 @@ class BookingDetailPage extends StatelessWidget {
             const SizedBox(height: 16),
             Text(
               activity.title,
-              style: Theme.of(context).textTheme.headlineSmall,
+              style: theme.textTheme.headlineSmall,
             ),
-            const SizedBox(height: 8),
-            Text(
-              slot.location,
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              '${begins.toString().split(' ')[0]} • ${begins.hour.toString().padLeft(2, '0')}:${begins.minute.toString().padLeft(2, '0')}',
-              style: Theme.of(context).textTheme.bodyMedium,
-            ),
-            const SizedBox(height: 8),
-            Text(
-              'Pax: ${booking.pax}',
-              style: Theme.of(context).textTheme.bodyMedium,
+            if (activity.description.isNotEmpty) ...[
+              const SizedBox(height: 8),
+              Text(
+                activity.description,
+                style: theme.textTheme.bodyMedium
+                    ?.copyWith(color: Colors.grey.shade700),
+              ),
+            ],
+            const SizedBox(height: 16),
+            Card(
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(12),
+              ),
+              elevation: 2,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Column(
+                  children: [
+                    _DetailRow(
+                      icon: Icons.place_outlined,
+                      text: slot.location,
+                    ),
+                    const SizedBox(height: 8),
+                    _DetailRow(
+                      icon: Icons.schedule,
+                      text: dateStr,
+                    ),
+                    const SizedBox(height: 8),
+                    _DetailRow(
+                      icon: Icons.group_outlined,
+                      text: 'Pax: ${booking.pax}',
+                    ),
+                  ],
+                ),
+              ),
             ),
             const SizedBox(height: 24),
             Center(
-              child: QrImageView(
-                data: booking.id.toString(),
-                size: 200,
+              child: Column(
+                children: [
+                  Text(
+                    'Entry Pass',
+                    style: theme.textTheme.titleMedium,
+                  ),
+                  const SizedBox(height: 12),
+                  QrImageView(
+                    data: booking.id.toString(),
+                    size: 200,
+                  ),
+                ],
               ),
             ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class _DetailRow extends StatelessWidget {
+  const _DetailRow({required this.icon, required this.text});
+
+  final IconData icon;
+  final String text;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    return Row(
+      children: [
+        Icon(icon, color: theme.colorScheme.primary),
+        const SizedBox(width: 8),
+        Expanded(
+          child: Text(
+            text,
+            style: theme.textTheme.bodyMedium,
+          ),
+        ),
+      ],
     );
   }
 }

--- a/lib/screens/booking_detail_page.dart
+++ b/lib/screens/booking_detail_page.dart
@@ -1,0 +1,87 @@
+import 'package:flutter/material.dart';
+import 'package:qr_flutter/qr_flutter.dart';
+
+import '../models/booking.dart';
+import '../models/activity.dart';
+
+class BookingDetailPage extends StatelessWidget {
+  const BookingDetailPage({super.key, required this.booking, required this.activity});
+
+  final Booking booking;
+  final Activity activity;
+
+  @override
+  Widget build(BuildContext context) {
+    final slot = booking.slot;
+    final image = activity.imageUrl ?? activity.image;
+    final begins = slot.beginsAt.toLocal();
+    return Scaffold(
+      appBar: AppBar(title: const Text('Booking Details')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: image.isNotEmpty
+                  ? (image.startsWith('http')
+                      ? Image.network(
+                          image,
+                          height: 200,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                          errorBuilder: (_, __, ___) => Image.asset(
+                            'assets/images/default.jpg',
+                            height: 200,
+                            width: double.infinity,
+                            fit: BoxFit.cover,
+                          ),
+                        )
+                      : Image.asset(
+                          image,
+                          height: 200,
+                          width: double.infinity,
+                          fit: BoxFit.cover,
+                        ))
+                  : Image.asset(
+                      slot.sport.banner,
+                      height: 200,
+                      width: double.infinity,
+                      fit: BoxFit.cover,
+                    ),
+            ),
+            const SizedBox(height: 16),
+            Text(
+              activity.title,
+              style: Theme.of(context).textTheme.headlineSmall,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              slot.location,
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              '${begins.toString().split(' ')[0]} • ${begins.hour.toString().padLeft(2, '0')}:${begins.minute.toString().padLeft(2, '0')}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 8),
+            Text(
+              'Pax: ${booking.pax}',
+              style: Theme.of(context).textTheme.bodyMedium,
+            ),
+            const SizedBox(height: 24),
+            Center(
+              child: QrImageView(
+                data: booking.id.toString(),
+                size: 200,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+

--- a/lib/screens/bookings_page.dart
+++ b/lib/screens/bookings_page.dart
@@ -5,7 +5,7 @@ import '../models/booking.dart';
 import '../models/activity.dart';
 import '../services/activity_service.dart';
 import '../widgets/booking_card.dart';
-import 'activity_detail_page.dart';
+import 'booking_detail_page.dart';
 
 class BookingsPage extends ConsumerWidget {
   const BookingsPage({super.key});
@@ -38,7 +38,8 @@ class BookingsPage extends ConsumerWidget {
                       Navigator.push(
                         context,
                         MaterialPageRoute(
-                          builder: (_) => ActivityDetailPage(activity: activity),
+                          builder: (_) =>
+                              BookingDetailPage(booking: b, activity: activity),
                         ),
                       );
                     }

--- a/lib/screens/bookings_page.dart
+++ b/lib/screens/bookings_page.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../providers.dart';
 import '../models/booking.dart';
+import '../models/activity.dart';
+import '../services/activity_service.dart';
+import '../widgets/booking_card.dart';
+import 'activity_detail_page.dart';
 
 class BookingsPage extends ConsumerWidget {
   const BookingsPage({super.key});
@@ -18,20 +22,27 @@ class BookingsPage extends ConsumerWidget {
           if (bookings.isEmpty) {
             return const Center(child: Text('No bookings yet'));
           }
-          return ListView.separated(
+          return ListView.builder(
             padding: const EdgeInsets.all(16),
             itemCount: bookings.length,
-            separatorBuilder: (_, __) => const Divider(),
             itemBuilder: (_, i) {
               final b = bookings[i];
-              return ListTile(
-                title: Text(b.slot.title),
-                subtitle: Text(
-                  '${b.slot.beginsAt.toLocal()} • pax ${b.pax}',
-                ),
-                trailing: Text(
-                  '${b.bookedAt.toLocal()}'.split(' ')[0],
-                  style: const TextStyle(fontSize: 12),
+              return Padding(
+                padding: const EdgeInsets.only(bottom: 12),
+                child: BookingCard(
+                  booking: b,
+                  onTap: () async {
+                    final Activity activity =
+                        await activityService.fetchById(b.slot.activityId);
+                    if (context.mounted) {
+                      Navigator.push(
+                        context,
+                        MaterialPageRoute(
+                          builder: (_) => ActivityDetailPage(activity: activity),
+                        ),
+                      );
+                    }
+                  },
                 ),
               );
             },

--- a/lib/widgets/booking_card.dart
+++ b/lib/widgets/booking_card.dart
@@ -1,0 +1,80 @@
+import 'package:flutter/material.dart';
+
+import '../models/booking.dart';
+
+class BookingCard extends StatelessWidget {
+  final Booking booking;
+  final VoidCallback onTap;
+
+  const BookingCard({super.key, required this.booking, required this.onTap});
+
+  @override
+  Widget build(BuildContext context) {
+    final slot = booking.slot;
+    final image = slot.sport.banner;
+    final begins = slot.beginsAt.toLocal();
+    return InkWell(
+      onTap: onTap,
+      child: Card(
+        clipBehavior: Clip.hardEdge,
+        child: Row(
+          children: [
+            image.startsWith('http')
+                ? Image.network(
+                    image,
+                    width: 120,
+                    height: 100,
+                    fit: BoxFit.cover,
+                    errorBuilder: (_, __, ___) => Image.asset(
+                      'assets/images/default.jpg',
+                      width: 120,
+                      height: 100,
+                      fit: BoxFit.cover,
+                    ),
+                  )
+                : Image.asset(
+                    image,
+                    width: 120,
+                    height: 100,
+                    fit: BoxFit.cover,
+                  ),
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(12),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      slot.title,
+                      style: Theme.of(context).textTheme.titleMedium,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      slot.location,
+                      style: Theme.of(context).textTheme.bodySmall,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 8),
+                    Text(
+                      '${begins.toString().split(' ')[0]} • ${begins.hour.toString().padLeft(2, '0')}:${begins.minute.toString().padLeft(2, '0')}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      'Pax: ${booking.pax}',
+                      style: Theme.of(context).textTheme.bodySmall,
+                    ),
+                  ],
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+


### PR DESCRIPTION
## Summary
- show bookings as image cards
- tap booking to fetch activity and open detail page

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cdfa27eb08326894b0708cb34746b