### PR TITLE
Allow merchants to create slots without facilities

### DIFF
--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -202,6 +202,7 @@ class _AddSlotPageState extends State<AddSlotPage> {
                             Navigator.pop(context, true);
                           }
                         } on DioException catch (e) {
+                          String message = 'Failed to save slot';
                           if (e.error is Map<String, List<String>>) {
                             final map = e.error as Map<String, List<String>>;
                             final general = map['non_field_errors'];
@@ -210,19 +211,36 @@ class _AddSlotPageState extends State<AddSlotPage> {
                                   map.map((k, v) => MapEntry(k, v.join(', ')));
                               _errors.remove('non_field_errors');
                             });
+                            final fieldMessages = map.entries
+                                .where((entry) =>
+                                    entry.key != 'non_field_errors')
+                                .expand((entry) => entry.value)
+                                .toList();
                             if (general != null && general.isNotEmpty) {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                  SnackBar(content: Text(general.join(', '))));
-                            } else {
-                              ScaffoldMessenger.of(context).showSnackBar(
-                                  const SnackBar(
-                                      content: Text('Failed to save slot')));
+                              message = general.join(', ');
+                            } else if (fieldMessages.isNotEmpty) {
+                              message = fieldMessages.first;
                             }
-                          } else {
-                            ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(
-                                    content: Text('Failed to save slot')));
+                          } else if (e.type == DioExceptionType.connectionError) {
+                            message =
+                                'Unable to connect. Please check your internet connection.';
+                          } else if (e.type == DioExceptionType.connectionTimeout ||
+                              e.type == DioExceptionType.receiveTimeout ||
+                              e.type == DioExceptionType.sendTimeout) {
+                            message = 'Connection timed out. Please try again.';
+                          } else if (e.response?.data is Map &&
+                              (e.response!.data as Map)['detail'] != null) {
+                            message =
+                                (e.response!.data as Map)['detail'].toString();
+                          } else if (e.response?.statusCode != null &&
+                              e.response!.statusCode! >= 500) {
+                            message =
+                                'Server error (${e.response!.statusCode}). Please try again later.';
+                          } else if (e.message != null) {
+                            message = e.message!;
                           }
+                          ScaffoldMessenger.of(context)
+                              .showSnackBar(SnackBar(content: Text(message)));
                         } finally {
                           if (mounted) setState(() => _submitting = false);
                         }

--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -194,17 +194,34 @@ class _AddSlotPageState extends State<AddSlotPage> {
                               location: locationCtrl.text,
                             );
                           }
-                          if (context.mounted) Navigator.pop(context, true);
+                          if (context.mounted) {
+                            ScaffoldMessenger.of(context).showSnackBar(SnackBar(
+                                content: Text(widget.slot == null
+                                    ? 'Slot created successfully'
+                                    : 'Slot updated successfully')));
+                            Navigator.pop(context, true);
+                          }
                         } on DioException catch (e) {
                           if (e.error is Map<String, List<String>>) {
                             final map = e.error as Map<String, List<String>>;
+                            final general = map['non_field_errors'];
                             setState(() {
                               _errors =
                                   map.map((k, v) => MapEntry(k, v.join(', ')));
+                              _errors.remove('non_field_errors');
                             });
+                            if (general != null && general.isNotEmpty) {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  SnackBar(content: Text(general.join(', '))));
+                            } else {
+                              ScaffoldMessenger.of(context).showSnackBar(
+                                  const SnackBar(
+                                      content: Text('Failed to save slot')));
+                            }
                           } else {
                             ScaffoldMessenger.of(context).showSnackBar(
-                                const SnackBar(content: Text('Failed to save slot')));
+                                const SnackBar(
+                                    content: Text('Failed to save slot')));
                           }
                         } finally {
                           if (mounted) setState(() => _submitting = false);

--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -84,7 +84,6 @@ class _AddSlotPageState extends State<AddSlotPage> {
                     .map((f) => DropdownMenuItem(value: f.id, child: Text(f.name)))
                     .toList(),
                 onChanged: (v) => setState(() => _facilityId = v),
-                validator: (v) => v == null ? 'Required' : null,
               ),
               TextFormField(
                 controller: capacityCtrl,
@@ -159,7 +158,12 @@ class _AddSlotPageState extends State<AddSlotPage> {
                     : () async {
                         setState(() => _errors.clear());
                         if (!_formKey.currentState!.validate()) return;
-                        if (start == null || end == null) return;
+                        if (start == null || end == null) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(
+                                  content: Text('Start and end times required')));
+                          return;
+                        }
                         if (!end!.isAfter(start!)) {
                           ScaffoldMessenger.of(context).showSnackBar(
                               const SnackBar(content: Text('End must be after start')));
@@ -176,7 +180,7 @@ class _AddSlotPageState extends State<AddSlotPage> {
                               double.parse(priceCtrl.text),
                               titleCtrl.text,
                               locationCtrl.text,
-                              facilityId: _facilityId!,
+                              facilityId: _facilityId,
                             );
                           } else {
                             await slotService.updateMerchantSlot(

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -89,18 +89,19 @@ class SlotService {
   }
 
   Future<void> createSlot(
-      int activityId,
-      DateTime start,
-      DateTime end,
-      int capacity,
-      double price,
-      String title,
-      String location,
-      {required int facilityId}) async {
+    int activityId,
+    DateTime start,
+    DateTime end,
+    int capacity,
+    double price,
+    String title,
+    String location, {
+    int? facilityId,
+  }) async {
     try {
       await apiClient.post('/merchant/slots/', data: {
         'activity': activityId,
-        'facility': facilityId,
+        if (facilityId != null) 'facility': facilityId,
         // Ensure timezone aware datetimes for Django
         'begins_at': _iso(start),
         'ends_at': _iso(end),

--- a/lib/services/slot_service.dart
+++ b/lib/services/slot_service.dart
@@ -154,8 +154,30 @@ class SlotService {
     if (price != null) patch['price'] = price;
     if (title != null) patch['title'] = title;
     if (location != null) patch['location'] = location;
-
-    await apiClient.patch('/merchant/slots/$id/', data: patch);
+    try {
+      await apiClient.patch('/merchant/slots/$id/', data: patch);
+    } on DioException catch (e) {
+      if (e.response?.statusCode == 400 || e.response?.statusCode == 422) {
+        final data = e.response?.data;
+        if (data is Map<String, dynamic>) {
+          final map = <String, List<String>>{};
+          data.forEach((key, value) {
+            if (value is List) {
+              map[key] = value.map((v) => v.toString()).toList();
+            } else {
+              map[key] = [value.toString()];
+            }
+          });
+          throw DioException(
+            requestOptions: e.requestOptions,
+            response: e.response,
+            type: e.type,
+            error: map,
+          );
+        }
+      }
+      throw e;
+    }
   }
   
   Future<Paginated<Slot>> fetchMine({int page = 1}) async {


### PR DESCRIPTION
## Summary
- Allow slot creation without selecting a facility
- Show message when start/end times are missing during slot creation

## Testing
- `dart format lib/screens/add_slot_page.dart lib/services/slot_service.dart` *(fails: command not found)*
- `pytest backend/tests/test_merchant_slots.py::test_create_update_overlap_400 backend/tests/test_merchant_slots.py::test_booking_flow_unchanged -q` *(fails: Could not find the GDAL library)*

------
https://chatgpt.com/codex/tasks/task_e_689d08c545508326a56166b012d745a8