### PR TITLE
Separate user and merchant account profiles

### DIFF
--- a/backend/accounts/serializers.py
+++ b/backend/accounts/serializers.py
@@ -1,6 +1,6 @@
 from django.contrib.auth.models import User
 from rest_framework import serializers
-from .models import VendorProfile
+from .models import VendorProfile, CustomerProfile
 
 
 class ProfileSerializer(serializers.Serializer):
@@ -44,17 +44,23 @@ class ProfileSerializer(serializers.Serializer):
         }
 
     def update(self, instance: User, validated_data):
-        vendor_data = validated_data.get("vendorprofile", {})
-        vendor, _ = VendorProfile.objects.get_or_create(user=instance)
-        customer, _ = CustomerProfile.objects.get_or_create(user=instance)
-        vendor.company_name = vendor_data.get(
-            "company_name", vendor.company_name
-        )
-        customer.phone = vendor_data.get("phone", customer.phone)
-        vendor.address = vendor_data.get("address", vendor.address)
-        vendor.logo = vendor_data.get("logo", vendor.logo)
-        vendor.save()
-        customer.save()
+        vendor_data = validated_data.get("vendorprofile")
+        customer_data = validated_data.get("customerprofile")
+
+        if vendor_data:
+            vendor, _ = VendorProfile.objects.get_or_create(user=instance)
+            vendor.company_name = vendor_data.get(
+                "company_name", vendor.company_name
+            )
+            vendor.address = vendor_data.get("address", vendor.address)
+            vendor.logo = vendor_data.get("logo", vendor.logo)
+            vendor.save()
+
+        if customer_data:
+            customer, _ = CustomerProfile.objects.get_or_create(user=instance)
+            customer.phone = customer_data.get("phone", customer.phone)
+            customer.save()
+
         return instance
 
 

--- a/backend/accounts/signals.py
+++ b/backend/accounts/signals.py
@@ -2,7 +2,7 @@ from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.contrib.auth.models import User
 
-from .models import CustomerProfile, VendorProfile
+from .models import CustomerProfile
 
 
 @receiver(post_save, sender=User)
@@ -11,4 +11,3 @@ def create_user_profile(sender, instance, created, **kwargs):
         return
     # normal users get a CustomerProfile by default
     CustomerProfile.objects.get_or_create(user=instance)
-    VendorProfile.objects.get_or_create(user=instance)

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -10,7 +10,7 @@ django.setup()
 pytestmark = pytest.mark.django_db
 
 
-def test_registration_creates_profiles():
+def test_registration_creates_customer_profile_only():
     client = APIClient()
     client.defaults["HTTP_HOST"] = "localhost"
     resp = client.post(
@@ -24,7 +24,7 @@ def test_registration_creates_profiles():
     )
     assert resp.status_code == 201
     user = User.objects.get(email="demo_auth@example.com")
-    assert VendorProfile.objects.filter(user=user).exists()
+    assert not VendorProfile.objects.filter(user=user).exists()
     assert CustomerProfile.objects.filter(user=user).exists()
     assert "access" in resp.data and "refresh" in resp.data
 
@@ -36,8 +36,7 @@ def test_profile_endpoint(client):
         password="Pass12345",
     )
     # profiles automatically created via signal
-    user.vendorprofile.company_name = "ACME"
-    user.vendorprofile.save()
+    VendorProfile.objects.create(user=user, company_name="ACME")
     user.customerprofile.phone = "123456"
     user.customerprofile.save()
     client.force_authenticate(user)
@@ -93,8 +92,7 @@ def test_vendor_permission(client):
         email="v1@e.com",
         password="Pass12345",
     )
-    user.vendorprofile.company_name = "ACME"
-    user.vendorprofile.save()
+    VendorProfile.objects.create(user=user, company_name="ACME")
     client.force_authenticate(user)
     resp = client.get("/api/vendor-area/")
     assert resp.status_code == 200
@@ -105,8 +103,6 @@ def test_vendor_permission(client):
         email="c1@e.com",
         password="Pass12345",
     )
-    user2.vendorprofile.delete()
-    user2 = User.objects.get(pk=user2.pk)
     client.force_authenticate(user2)
     resp2 = client.get("/api/vendor-area/")
     assert resp2.status_code == 403


### PR DESCRIPTION
## Summary
- stop creating VendorProfile for every new user
- avoid auto-creating vendor profile when updating profile
- adjust auth tests for new separation

## Testing
- `pytest` *(fails: django.db.utils.OperationalError: near "EXISTS": syntax error)*

------
https://chatgpt.com/codex/tasks/task_e_689d07dda7c083269fe77c3052a2cacb