### PR TITLE
feat: add geo distance search

### DIFF
--- a/backend/PlayNexus/settings.py
+++ b/backend/PlayNexus/settings.py
@@ -172,6 +172,9 @@ STATICFILES_STORAGE = "whitenoise.storage.CompressedManifestStaticFilesStorage"
 MEDIA_URL = "/media/"
 MEDIA_ROOT = BASE_DIR / "media"
 
+# Default radius for location-based queries (meters)
+NEARBY_DEFAULT_RADIUS_M = 5000
+
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 
 # ──────────────────────────────

--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -156,6 +156,7 @@ class VariantSerializer(serializers.ModelSerializer):
 class ActivitySerializer(serializers.ModelSerializer):
     image_url = serializers.SerializerMethodField()
     organization = serializers.PrimaryKeyRelatedField(read_only=True)
+    distance_m = serializers.IntegerField(read_only=True, required=False)
 
     class Meta:
         model = Activity
@@ -173,6 +174,7 @@ class ActivitySerializer(serializers.ModelSerializer):
             "duration",
             "base_price",
             "is_nearby",
+            "distance_m",
         )
         read_only_fields = ("id", "organization")
 
@@ -200,6 +202,12 @@ class ActivitySerializer(serializers.ModelSerializer):
         if len(desc) > 500:
             raise serializers.ValidationError({"description": "Max 500 characters"})
         return attrs
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        if data.get("distance_m") in (None, ""):
+            data.pop("distance_m", None)
+        return data
 
     def create(self, validated_data):
         request = self.context.get("request")
@@ -243,6 +251,7 @@ class FeaturedActivitySerializer(serializers.ModelSerializer):
 
 class FacilitySerializer(GeoFeatureModelSerializer):
     owner = serializers.SerializerMethodField()
+    distance_m = serializers.IntegerField(read_only=True, required=False)
 
     class Meta:
         model = Facility
@@ -254,10 +263,18 @@ class FacilitySerializer(GeoFeatureModelSerializer):
             "location",
             "categories",
             "owner",
+            "distance_m",
         )
 
     def get_owner(self, obj):
         return getattr(obj.owner, "email", "")
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        props = data.get("properties", data)
+        if props.get("distance_m") in (None, ""):
+            props.pop("distance_m", None)
+        return data
 
 
 class FacilityCreateSerializer(serializers.ModelSerializer):

--- a/backend/sports/views.py
+++ b/backend/sports/views.py
@@ -1,8 +1,11 @@
 # sports/views.py
 from django.db import transaction
 from django.contrib.gis.geos import Point
-from django.contrib.gis.db.models.functions import Distance
-from django.db.models import Q
+from django.contrib.gis.db.models.functions import Distance, Transform
+from django.contrib.gis.measure import D
+from django.db.models import Q, F, Value, Min, IntegerField
+from django.db.models.functions import Cast
+from django.conf import settings
 from rest_framework import viewsets, permissions, status, serializers, mixins
 from rest_framework.decorators import action
 from accounts.permissions import IsVendor
@@ -11,7 +14,13 @@ from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework.pagination import PageNumberPagination
 from django.utils import timezone
-from drf_spectacular.utils import extend_schema, OpenApiResponse, OpenApiExample
+from drf_spectacular.utils import (
+    extend_schema,
+    OpenApiResponse,
+    OpenApiExample,
+    OpenApiParameter,
+    OpenApiTypes,
+)
 
 from .models import (
     Sport,
@@ -45,6 +54,48 @@ from .serializers import (
     SlotCreateSerializer,
     FavoriteSerializer,
 )
+
+
+# ---------------------------------------------------------------------------
+# Helpers for optional location-based filtering
+# ---------------------------------------------------------------------------
+def _parse_radius(value, default=settings.NEARBY_DEFAULT_RADIUS_M, lo=100, hi=30000):
+    """Return a sanitized radius in meters."""
+    try:
+        v = int(value) if value is not None else default
+        return max(lo, min(hi, v))
+    except Exception:
+        return default
+
+
+def _apply_near_filter(qs, field_name, latlng, radius_m, aggregate=False):
+    """Filter and annotate queryset by distance to a point.
+
+    Returns (queryset, used) where used indicates whether the filter was
+    applied. Any errors (invalid input or missing GIS stack) fall back to the
+    unmodified queryset.
+    """
+
+    if not latlng:
+        return qs, False
+    try:
+        lat, lng = [float(x) for x in latlng.split(",")]
+        p4326 = Point(lng, lat, srid=4326)
+        filter_kwargs = {f"{field_name}__distance_lte": (p4326, D(m=radius_m))}
+        distance = Distance(
+            Transform(F(field_name), 3857),
+            Transform(Value(p4326), 3857),
+        )
+        if aggregate:
+            distance = Min(distance)
+        qs = (
+            qs.filter(**filter_kwargs)
+            .annotate(distance_m=Cast(distance, IntegerField()))
+            .order_by("distance_m")
+        )
+        return qs, True
+    except Exception:
+        return qs, False
 
 
 class DefaultPagination(PageNumberPagination):
@@ -150,6 +201,14 @@ class ActivityViewSet(viewsets.ModelViewSet):
         nearby = self.request.query_params.get("nearby")
         if nearby == "1":
             qs = qs.filter(is_nearby=True)
+        else:
+            near = self.request.query_params.get("near")
+            radius = _parse_radius(self.request.query_params.get("radius"))
+            qs, used = _apply_near_filter(
+                qs, "slots__facility__location", near, radius, aggregate=True
+            )
+            if used:
+                qs = qs.distinct()
         category = self.request.query_params.get("category")
         if category:
             try:
@@ -171,6 +230,23 @@ class ActivityViewSet(viewsets.ModelViewSet):
 
         return qs
 
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="near",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description="Distance search using facility location. Ignored if nearby=1.",
+                examples=[OpenApiExample("Example", value="51.5072,-0.1276")],
+            ),
+            OpenApiParameter(
+                name="radius",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Search radius in meters (default 5000, min 100, max 30000)",
+            ),
+        ]
+    )
     def list(self, request, *args, **kwargs):
         if request.query_params.get("no_page") == "1":
             self.pagination_class = None
@@ -222,24 +298,33 @@ class FacilityViewSet(viewsets.ModelViewSet):
             qs = qs.filter(
                 Q(name__icontains=query) | Q(categories__name__icontains=query)
             ).distinct()
-
         near = self.request.query_params.get("near")
-        if near:
-            try:
-                lat, lng = map(float, near.split(","))
-                radius = float(self.request.query_params.get("radius", 5000))
-                point = Point(lng, lat, srid=4326)
-                qs = (
-                    qs.filter(location__distance_lte=(point, radius))
-                    .annotate(distance=Distance("location", point))
-                    .order_by("distance")
-                )
-            except ValueError:
-                pass
+        radius = _parse_radius(self.request.query_params.get("radius"))
+        qs, _ = _apply_near_filter(qs, "location", near, radius)
         return qs
 
     def perform_create(self, serializer):
         serializer.save(owner=self.request.user)
+
+    @extend_schema(
+        parameters=[
+            OpenApiParameter(
+                name="near",
+                type=OpenApiTypes.STR,
+                location=OpenApiParameter.QUERY,
+                description='Filter by distance to "lat,lng"',
+                examples=[OpenApiExample("Example", value="51.5072,-0.1276")],
+            ),
+            OpenApiParameter(
+                name="radius",
+                type=OpenApiTypes.INT,
+                location=OpenApiParameter.QUERY,
+                description="Search radius in meters (default 5000, min 100, max 30000)",
+            ),
+        ]
+    )
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)
 
 
 class SlotViewSet(viewsets.ReadOnlyModelViewSet):

--- a/backend/tests/test_geo_api.py
+++ b/backend/tests/test_geo_api.py
@@ -15,7 +15,7 @@ django.setup()  # noqa: E402
 from django.contrib.gis.geos import Point  # noqa: E402
 from django.utils import timezone  # noqa: E402
 from rest_framework.test import APIClient  # noqa: E402
-from sports.models import Category, Facility, Slot  # noqa: E402
+from sports.models import Category, Facility, Slot, Activity, Sport  # noqa: E402
 
 pytestmark = [pytest.mark.django_db]
 
@@ -100,3 +100,81 @@ def test_create_facility(django_user_model):
     from sports.models import Facility
     facility = Facility.objects.get(name="New")
     assert facility.owner == user
+
+
+# ---------------------------------------------------------------------------
+# New tests for location-based search
+# ---------------------------------------------------------------------------
+
+
+def _seed_facilities():
+    f1 = Facility.objects.create(name="A", location=Point(0, 0))
+    f2 = Facility.objects.create(name="B", location=Point(0.02, 0))
+    f3 = Facility.objects.create(name="C", location=Point(1, 1))
+    return f1, f2, f3
+
+
+def test_facilities_near_filter_ordering():
+    f1, f2, f3 = _seed_facilities()
+    resp = APIClient().get("/api/facilities/", {"near": "0,0", "radius": 3000})
+    ids = [row["id"] for row in resp.data]
+    assert ids == [f1.id, f2.id]
+    dists = [row["properties"]["distance_m"] for row in resp.data]
+    assert dists == sorted(dists)
+    assert all(isinstance(d, int) for d in dists)
+
+
+def test_facilities_distance_field_absent_without_near():
+    _seed_facilities()
+    resp = APIClient().get("/api/facilities/")
+    assert "distance_m" not in resp.data[0]["properties"]
+
+
+def test_facilities_invalid_near_graceful():
+    _seed_facilities()
+    resp = APIClient().get("/api/facilities/", {"near": "abc"})
+    assert len(resp.data) == 3
+    assert "distance_m" not in resp.data[0]["properties"]
+
+
+def test_activities_near_and_nearby_priority():
+    sport = Sport.objects.create(name="Tennis")
+    cat = Category.objects.create(name="Court")
+    f1, f2, f3 = _seed_facilities()
+    act_near = Activity.objects.create(sport=sport, discipline=cat, title="Near")
+    act_far = Activity.objects.create(
+        sport=sport, discipline=cat, title="Far", is_nearby=True
+    )
+    Slot.objects.create(
+        facility=f1,
+        activity=act_near,
+        title="S1",
+        location="loc",
+        begins_at=timezone.now(),
+        ends_at=timezone.now() + timezone.timedelta(hours=1),
+        capacity=5,
+        price=1,
+    )
+    Slot.objects.create(
+        facility=f3,
+        activity=act_far,
+        title="S2",
+        location="loc",
+        begins_at=timezone.now(),
+        ends_at=timezone.now() + timezone.timedelta(hours=1),
+        capacity=5,
+        price=1,
+    )
+
+    client = APIClient()
+    resp = client.get("/api/activities/", {"near": "0,0", "radius": 3000})
+    ids = [row["id"] for row in resp.data]
+    assert ids == [act_near.id]
+    assert isinstance(resp.data[0]["distance_m"], int)
+
+    resp = client.get(
+        "/api/activities/", {"near": "0,0", "nearby": 1}
+    )
+    ids = [row["id"] for row in resp.data]
+    assert ids == [act_far.id]
+    assert "distance_m" not in resp.data[0]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,3 +2,4 @@
 
 ## Unreleased
 - 新增分页版商家订单列表 `/merchant/bookings/paged/`；旧端点 `/merchant/bookings/` 保持兼容。
+- Facilities: support `near` (lat,lng) + optional `radius` (m) for distance search; results include `distance_m` when used. Activities optionally accept the same parameters while `nearby=1` takes precedence.


### PR DESCRIPTION
## Summary
- add server-side `near`/`radius` filtering for facilities and activities
- expose optional `distance_m` field on FacilitySerializer and ActivitySerializer
- document geo search parameters and default radius

## Testing
- `pytest backend -q` *(fails: OperationalError: near "EXISTS": syntax error - SpatiaLite extension missing)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7fed3e8c83268efdd8a1a885de83