### PR TITLE
feat: enforce slot duration and ordering

### DIFF
--- a/backend/sports/serializers.py
+++ b/backend/sports/serializers.py
@@ -110,6 +110,10 @@ class MerchantSlotSerializer(serializers.ModelSerializer):
                 errors["ends_at"] = ["Must not cross days"]
             if begins < now:
                 errors["begins_at"] = ["Must be in the future"]
+            if ends <= begins:
+                errors.setdefault("ends_at", []).append("Must be after start")
+            elif (ends - begins).total_seconds() < 30 * 60:
+                errors.setdefault("ends_at", []).append("Must be at least 30 minutes")
 
         if activity and begins and ends:
             qs = Slot.objects.filter(activity=activity, is_active=True)

--- a/backend/tests/test_merchant_slots.py
+++ b/backend/tests/test_merchant_slots.py
@@ -120,6 +120,44 @@ def test_create_past_or_cross_day_400(auth_client, activity):
     assert resp2.status_code == 400
 
 
+def test_end_before_start_400(auth_client, activity):
+    begins = timezone.now() + timezone.timedelta(hours=1)
+    ends = begins - timezone.timedelta(minutes=10)
+    resp = auth_client.post(
+        "/api/merchant/slots/",
+        {
+            "activity": activity.id,
+            "begins_at": begins.isoformat(),
+            "ends_at": ends.isoformat(),
+            "capacity": 5,
+            "price": "0",
+            "title": "Inv",
+            "location": "Loc",
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
+def test_duration_too_short_400(auth_client, activity):
+    begins = timezone.now() + timezone.timedelta(hours=1)
+    ends = begins + timezone.timedelta(minutes=20)
+    resp = auth_client.post(
+        "/api/merchant/slots/",
+        {
+            "activity": activity.id,
+            "begins_at": begins.isoformat(),
+            "ends_at": ends.isoformat(),
+            "capacity": 5,
+            "price": "0",
+            "title": "Short",
+            "location": "Loc",
+        },
+        format="json",
+    )
+    assert resp.status_code == 400
+
+
 def test_bulk_delete_soft(auth_client, activity):
     begins = timezone.now() + timezone.timedelta(hours=1)
     ends = begins + timezone.timedelta(hours=1)

--- a/lib/screens/add_slot_page.dart
+++ b/lib/screens/add_slot_page.dart
@@ -169,6 +169,18 @@ class _AddSlotPageState extends State<AddSlotPage> {
                               const SnackBar(content: Text('End must be after start')));
                           return;
                         }
+                        if (start!.year != end!.year ||
+                            start!.month != end!.month ||
+                            start!.day != end!.day) {
+                          ScaffoldMessenger.of(context).showSnackBar(
+                              const SnackBar(content: Text('Slot must not cross days')));
+                          return;
+                        }
+                        if (end!.difference(start!).inMinutes < 30) {
+                          ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
+                              content: Text('Duration must be at least 30 minutes')));
+                          return;
+                        }
                         setState(() => _submitting = true);
                         try {
                           if (widget.slot == null) {


### PR DESCRIPTION
## Summary
- enforce slot start/end ordering and minimum length on backend serializer
- add matching client-side slot form validation
- cover edge cases with new unit tests for start/end rules

## Testing
- `pytest backend/tests/test_merchant_slots.py::test_end_before_start_400 -q` *(fails: Could not find the GDAL library)*


------
https://chatgpt.com/codex/tasks/task_e_68ab56447a688326a526eaeb0a0003ce